### PR TITLE
Clean up repeated and unused styling

### DIFF
--- a/auth-web/src/App.vue
+++ b/auth-web/src/App.vue
@@ -53,4 +53,23 @@ export default Vue.extend({
   @import "./assets/styl/base.styl";
   @import "./assets/styl/layout.styl";
   @import "./assets/styl/overrides.styl";
+
+  .app-container
+    display flex
+    flex-flow column nowrap
+    min-height 100vh
+
+  .header-group
+    position fixed
+    width 100%
+    z-index 2
+
+  .app-body
+    flex 1 1 auto
+
+  @media (min-width 1264px)
+    .app-body
+      > .container:first-child
+        padding-top 3rem
+        padding-bottom 3rem
 </style>

--- a/auth-web/src/assets/styl/layout.styl
+++ b/auth-web/src/assets/styl/layout.styl
@@ -1,31 +1,54 @@
-// Layout Variables
-$app-header-height = 70px // 70px
-
-.app-container
-  display flex
-  flex-flow column nowrap
-  min-height 100vh
-
-.header-group
-  position fixed
-  width 100%
-  z-index 2
-
-.app-header
-  z-index 2
-
-.app-body
-  flex 1 1 auto
-
-@media (min-width 1264px)
-  .app-body
-    > .container:first-child
-      padding-top 3rem
-      padding-bottom 3rem
-
-.app-footer
-  flex 0 0 auto
-
+// Layout style rules shared across the app
 .container
   max-width 1200px
   padding 1.5rem
+
+h1, h2
+  margin-bottom 1.5rem
+
+article
+  flex 1 1 auto
+
+aside
+  flex 0 0 auto
+  margin-top 2rem
+
+.intro-text
+  margin-bottom 2rem
+  letter-spacing -0.01rem
+  font-size 1rem
+  font-weight 300
+
+  em
+    font-style normal
+    font-weight 400
+
+.view-container
+  display flex
+  flex-flow column nowrap
+
+// Layout styling for different device sizes
+@media (max-width 480px)
+  h1 span
+    display block
+
+@media (min-width 768px)
+  h1
+    margin-bottom 2rem
+
+  .intro-text
+    margin-bottom 3rem
+    font-size 1.125rem
+
+@media (min-width: 960px)
+  article
+    padding-top 0.8rem
+    padding-bottom 0.8rem
+
+  aside
+    margin-top 0
+    margin-left 2rem
+    width 20rem
+
+  .view-container
+    flex-flow row nowrap

--- a/auth-web/src/views/BusinessProfile.vue
+++ b/auth-web/src/views/BusinessProfile.vue
@@ -40,57 +40,8 @@ export default class BusinessProfile extends Vue {
 </script>
 
 <style lang="stylus" scoped>
-  @import '../assets/styl/theme.styl';
-
-  h1, h2
-    margin-bottom: 1.5rem;
-
-  article
-    flex: 1 1 auto;
-
-  aside
-    flex 0 0 auto
-    margin-top 2rem
-
-  .intro-text
-    margin-bottom 2rem
-    letter-spacing -0.01rem
-    font-size 1rem
-    font-weight 300
-
-    em
-      font-style: normal
-      font-weight: 400
-
-  .view-container
-    display flex
-    flex-flow column nowrap
 
   .profile-card .container
       padding 1.5rem
 
-  @media (max-width 480px)
-    h1 span
-      display block
-
-  @media (min-width 768px)
-    h1
-      margin-bottom 2rem
-
-    .intro-text
-      margin-bottom 3rem
-      font-size 1.125rem
-
-  @media (min-width: 960px)
-    article
-      padding-top 0.8rem
-      padding-bottom 0.8rem
-
-    aside
-      margin-top 0
-      margin-left 2rem
-      width 20rem
-
-    .view-container
-        flex-flow row nowrap
 </style>

--- a/auth-web/src/views/Home.vue
+++ b/auth-web/src/views/Home.vue
@@ -33,61 +33,12 @@ export default ({
 </script>
 
 <style lang="stylus" scoped>
-  @import "../assets/styl/theme.styl"
-
-  h1, h2
-    margin-bottom 1.5rem
-
-  article
-    flex 1 1 auto
-
-  aside
-    flex 0 0 auto
-    margin-top 2rem
-
-  .intro-text
-    margin-bottom 2rem
-    letter-spacing -0.01rem
-    font-size 1rem
-    font-weight 300
-
-    em
-      font-style normal
-      font-weight 400
-
-  .view-container
-    display flex
-    flex-flow column nowrap
 
   .sign-in-card .container
     padding 1.5rem
 
-  @media (max-width 480px)
-    h1 span
-      display block
-
-  @media (min-width 768px)
-    h1
-      margin-bottom 2rem
-
-    .intro-text
-      margin-bottom 3rem
-      font-size 1.125rem
-
   @media (min-width: 960px)
-    article
-      padding-top 0.8rem
-      padding-bottom 0.8rem
-
-    aside
-      margin-top 0
-      margin-left 2rem
-      width 20rem
-
     .sign-in-card .container
       padding 2rem
-
-    .view-container
-      flex-flow row nowrap
 
 </style>


### PR DESCRIPTION
*Issue #:* No corresponding ticket. 

*Description of changes:*
The following changes were made in order to ensure that shared style rules are not repeated in multiple places in the app:
- Moved style rules that were being repeated in BusinessProfile.vue and Home.vue to layout.styl
- Moved style rules that were only being used in App.vue out of layout.styl and directly into App.vue
- Removed a couple of style rules from layout.styl that were not being used anywhere in the app

*API Code Review Checklist:*
 - #### Common
    - [ ] Proper naming conventions followed on variables, classes, definitions etc.
    - [ ] Proper logging levels are used in the code 
 - #### REST 
    - [ ] Endpoints follows agreed pattern and organized around resources
    - [ ] Conform to http semantics
    - [ ] Proper filtering and pagination is provided for large amounts of data
 - #### Code structure
    - [ ] Resources is used for request payload processing, validations, response codes, messages etc.
    - [ ] Service is used for business logic, 3rd party communication management. Maintains proper folder structure.
    - [ ] Model is used for database models.
    - [ ] Schemas is used for json schema
    - [ ] Util contains commonly used utility functions, constants
 - #### Test Cases
    - [ ] Unit test cases with happy and sad path for service, model (?) layers
    - [ ] Endpoints test cases with happy and sad path for resources
    - [ ] Mocking of services (mainly 3rd party dependencies) provided if applicable
    - [ ] Postman collection tests provided for endpoints with happy path
 - #### Code Quality
    - [ ] Proper code coverage for all the layers (percentage 80, 90 ?)
    - [ ] Linting
- #### DB Migrations
    - [ ] Alembic is used to manage database migration. [Reference](https://github.com/bcgov/namex/blob/master/docs/database.md)


*UI Code Review Checklist:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
