### PR TITLE
AUTH-API: Change invitation endpoints to use request origin

### DIFF
--- a/auth-api/config.py
+++ b/auth-api/config.py
@@ -113,7 +113,7 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     MAIL_FROM_ID = os.getenv('MAIL_FROM_ID')
 
     # mail token  configuration
-    AUTH_WEB_TOKEN_CONFIRM_URL = os.getenv('AUTH_WEB_TOKEN_CONFIRM_URL')
+    AUTH_WEB_TOKEN_CONFIRM_PATH = os.getenv('AUTH_WEB_TOKEN_CONFIRM_PATH')
     EMAIL_SECURITY_PASSWORD_SALT = os.getenv('EMAIL_SECURITY_PASSWORD_SALT')
     EMAIL_TOKEN_SECRET_KEY = os.getenv('EMAIL_TOKEN_SECRET_KEY')
     TOKEN_EXPIRY_PERIOD = os.getenv('TOKEN_EXPIRY_PERIOD')

--- a/auth-api/src/auth_api/resources/invitation.py
+++ b/auth-api/src/auth_api/resources/invitation.py
@@ -43,6 +43,7 @@ class Invitations(Resource):
     def post():
         """Send a new invitation using the details in request and saves the invitation."""
         token = g.jwt_oidc_token_info
+        origin = request.environ.get('HTTP_ORIGIN', 'localhost')
         request_json = request.get_json()
         valid_format, errors = schema_utils.validate(request_json, 'invitation')
         if not valid_format:
@@ -53,7 +54,7 @@ class Invitations(Resource):
                 response, status = {'message': 'Not authorized to perform this action'}, \
                     http_status.HTTP_401_UNAUTHORIZED
             else:
-                response, status = InvitationService.create_invitation(request_json, user, token).as_dict(), \
+                response, status = InvitationService.create_invitation(request_json, user, token, origin).as_dict(), \
                     http_status.HTTP_201_CREATED
         except BusinessException as exception:
             response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
@@ -87,6 +88,7 @@ class Invitation(Resource):
     def patch(invitation_id):
         """Update the invitation specified by the provided id as retried."""
         token = g.jwt_oidc_token_info
+        origin = request.environ.get('HTTP_ORIGIN', 'localhost')
         try:
             user = UserService.find_by_jwt_token(token)
             if user is None:
@@ -98,7 +100,7 @@ class Invitation(Resource):
                     response, status = {'message': 'The requested invitation could not be found.'}, \
                                http_status.HTTP_404_NOT_FOUND
                 else:
-                    response, status = invitation.update_invitation(user, token).as_dict(), http_status.HTTP_200_OK
+                    response, status = invitation.update_invitation(user, token, origin).as_dict(), http_status.HTTP_200_OK
         except BusinessException as exception:
             response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
         return response, status

--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -295,13 +295,13 @@ class OrgContacts(Resource):
         @_JWT.requires_auth
         @TRACER.trace()
         @cors.crossdomain(origin='*')
-        def delete(org_id, member_id):
+        def delete(org_id, membership_id):  # pylint:disable=unused-argument
             """Delete a membership record for the given org and user."""
             try:
                 org = OrgService.find_by_org_id(org_id, g.jwt_oidc_token_info,
                                                 allowed_roles=(*CLIENT_ADMIN_ROLES, STAFF))
                 if org:
-                    response, status = org.remove_member(member_id).as_dict(), \
+                    response, status = org.remove_member(membership_id).as_dict(), \
                         http_status.HTTP_200_OK
                 else:
                     response, status = {'message': 'The requested organization could not be found.'}, \


### PR DESCRIPTION
*Issue#* 1586

https://github.com/bcgov/entity/issues/1586

*Description of changes:*

Change invitation endpoints to use request origin for email link.  Renamed config item.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
