### PR TITLE
read urls from the browser instead of config maps

### DIFF
--- a/auth-web/.env
+++ b/auth-web/.env
@@ -1,1 +1,2 @@
 VUE_APP_PATH = cooperatives/auth
+VUE_APP_PATH_COOPS = cooperatives

--- a/auth-web/.env.production
+++ b/auth-web/.env.production
@@ -1,1 +1,2 @@
 VUE_APP_PATH = cooperatives/auth
+VUE_APP_PATH_COOPS = cooperatives

--- a/auth-web/src/components/auth/AddBusinessForm.vue
+++ b/auth-web/src/components/auth/AddBusinessForm.vue
@@ -64,7 +64,6 @@ export default class AddBusinessForm extends Vue {
   }
   showPasscode = false
   validationError = ''
-  VUE_APP_COPS_REDIRECT_URL = configHelper.getValue('VUE_APP_COPS_REDIRECT_URL')
   entityNumRules = [
     v => !!v || 'Incorporation Number is required'
   ]

--- a/auth-web/src/components/auth/AffiliatedEntityList.vue
+++ b/auth-web/src/components/auth/AffiliatedEntityList.vue
@@ -59,7 +59,6 @@ import { SessionStorageKeys } from '@/util/constants'
   }
 })
 export default class AffiliatedEntityList extends Vue {
-  private VUE_APP_COPS_REDIRECT_URL = configHelper.getValue('VUE_APP_COPS_REDIRECT_URL')
   private userStore = getModule(UserModule, this.$store)
   readonly organizations!: Organization[]
   readonly getOrganizations!: () => Organization[]
@@ -92,11 +91,9 @@ export default class AffiliatedEntityList extends Vue {
   }
 
   redirectToNext (incorporationNumber: string) {
-    if (this.VUE_APP_COPS_REDIRECT_URL) {
-      configHelper.addToSession(SessionStorageKeys.BusinessIdentifierKey, incorporationNumber)
-      const redirectURL = this.VUE_APP_COPS_REDIRECT_URL + 'dashboard'
-      window.location.href = decodeURIComponent(redirectURL)
-    }
+    configHelper.addToSession(SessionStorageKeys.BusinessIdentifierKey, incorporationNumber)
+    const redirectURL = configHelper.getCoopsURL() + 'dashboard'
+    window.location.href = decodeURIComponent(redirectURL)
   }
 }
 </script>

--- a/auth-web/src/components/auth/BusinessContactForm.vue
+++ b/auth-web/src/components/auth/BusinessContactForm.vue
@@ -87,7 +87,6 @@ import { SessionStorageKeys } from '../../util/constants'
   }
 })
 export default class BusinessContactForm extends Vue {
-  private VUE_APP_COPS_REDIRECT_URL = configHelper.getValue('VUE_APP_COPS_REDIRECT_URL')
   private businessStore = getModule(BusinessModule, this.$store)
   private emailAddress = ''
   private confirmedEmailAddress = ''
@@ -154,15 +153,13 @@ export default class BusinessContactForm extends Vue {
 
       result.then(response => {
         // TODO: Change this to transition to entity dashboard once complete
-        setTimeout(() => {
-          window.location.href = this.VUE_APP_COPS_REDIRECT_URL
-        }, 500)
+        window.location.href = configHelper.getCoopsURL()
       })
     }
   }
 
   cancel () {
-    window.location.href = this.VUE_APP_COPS_REDIRECT_URL
+    window.location.href = configHelper.getCoopsURL()
   }
 
   skip () {
@@ -170,9 +167,7 @@ export default class BusinessContactForm extends Vue {
     this.businessStore.setSkippedContactEntry(true)
 
     // Go directly to co-op UI without saving
-    setTimeout(() => {
-      window.location.href = this.VUE_APP_COPS_REDIRECT_URL
-    }, 500)
+    window.location.href = configHelper.getCoopsURL()
   }
 }
 </script>

--- a/auth-web/src/components/auth/PasscodeForm.vue
+++ b/auth-web/src/components/auth/PasscodeForm.vue
@@ -74,7 +74,6 @@ import { Component, Prop } from 'vue-property-decorator'
 import { getModule } from 'vuex-module-decorators'
 import BusinessModule from '../../store/modules/business'
 import configHelper from '../../util/config-helper'
-import iframeServices from '../../services/iframe.services'
 import { SessionStorageKeys } from '@/util/constants'
 
 @Component
@@ -84,7 +83,6 @@ export default class PasscodeForm extends Vue {
   noPasscodeDialog = false
   loginError = ''
   valid = false
-  VUE_APP_COPS_REDIRECT_URL = configHelper.getValue('VUE_APP_COPS_REDIRECT_URL')
   entityNumRules = [
     v => !!v || 'Incorporation Number is required'
   ]
@@ -109,14 +107,10 @@ export default class PasscodeForm extends Vue {
     if ((this.businessStore.currentBusiness.contacts &&
          this.businessStore.currentBusiness.contacts.length > 0) || this.businessStore.skippedContactEntry) {
       // transition to co-ops UI as we already have a contact set (or user has opted to skip already in this session)
-      setTimeout(() => {
-        window.location.href = this.VUE_APP_COPS_REDIRECT_URL
-      }, 500)
+      window.location.href = configHelper.getCoopsURL()
     } else {
       // transition to business contact UI
-      setTimeout(() => {
-        this.$router.push('/businessprofile')
-      }, 500)
+      this.$router.push('/businessprofile')
     }
   }
 

--- a/auth-web/src/components/auth/SearchBusinessForm.vue
+++ b/auth-web/src/components/auth/SearchBusinessForm.vue
@@ -69,7 +69,6 @@ import { mapActions } from 'vuex'
 })
 export default class SearchBusinessForm extends Vue {
   private businessStore = getModule(BusinessModule, this.$store)
-  private VUE_APP_COPS_REDIRECT_URL = configHelper.getValue('VUE_APP_COPS_REDIRECT_URL')
   private entityNumRules = [v => !!v || 'Incorporation Number is required']
   private businessNumber = ''
   private errorMessage = ''
@@ -92,7 +91,7 @@ export default class SearchBusinessForm extends Vue {
         this.errorMessage = ''
 
         // Redirect to the coops UI
-        window.location.href = this.VUE_APP_COPS_REDIRECT_URL
+        window.location.href = configHelper.getCoopsURL()
       } catch (exception) {
         this.errorMessage = this.$t('noResultMsg').toString()
       }

--- a/auth-web/src/services/iframe.services.ts
+++ b/auth-web/src/services/iframe.services.ts
@@ -4,6 +4,6 @@ const AUTHENTICATION_RESOURCE_NAME = '/authenticate'
 
 export default {
   emit (framewindow :Window, msg:string) {
-    framewindow.postMessage(msg, ConfigHelper.getValue('VUE_APP_COPS_REDIRECT_URL'))
+    framewindow.postMessage(msg, ConfigHelper.getCoopsURL())
   }
 }

--- a/auth-web/src/services/payment.services.ts
+++ b/auth-web/src/services/payment.services.ts
@@ -5,8 +5,9 @@ import { PaySystemStatus } from '@/models/PaySystemStatus'
 export default {
 
   createTransaction (paymentId:String, redirectUrl:String) {
-    var url = `${ConfigHelper.getValue('VUE_APP_PAY_ROOT_API')}/payment-requests/${paymentId}/transactions?redirect_uri=${redirectUrl}`
-    return Axios.post(url, {})
+    var url = `${ConfigHelper.getValue('VUE_APP_PAY_ROOT_API')}/payment-requests/${paymentId}/transactions`
+    return Axios.post(url, { clientSystemUrl: redirectUrl,
+      payReturnUrl: ConfigHelper.getSelfURL() + '/returnpayment' })
   },
 
   updateTransaction (paymentId:String, transactionId:String, receiptNum?:String) {

--- a/auth-web/src/util/config-helper.ts
+++ b/auth-web/src/util/config-helper.ts
@@ -31,6 +31,16 @@ export default {
     }
   },
 
+  getCoopsURL () {
+    // this needs trailing slash
+    return `${window.location.origin}/${process.env.VUE_APP_PATH_COOPS}/`
+  },
+
+  getSelfURL () {
+    // this is without a trailing slash
+    return `${window.location.origin}/${process.env.VUE_APP_PATH}`
+  },
+
   getValue (key: String) {
     // @ts-ignore
     return JSON.parse(sessionStorage.getItem(SessionStorageKeys.ApiConfigKey))[key]

--- a/auth-web/src/views/TokenValidator.vue
+++ b/auth-web/src/views/TokenValidator.vue
@@ -25,7 +25,6 @@ import { EmptyResponse } from '@/models/global'
   }
 })
 export default class TokenValidator extends Vue {
-  private VUE_APP_AUTH_WEB_REDIRECT_URL = configHelper.getValue('VUE_APP_AUTH_WEB_ROOT_URL')
   private orgStore = getModule(OrgModule, this.$store);
   private readonly validateInvitationToken!: (token: string) => EmptyResponse
 
@@ -45,7 +44,7 @@ export default class TokenValidator extends Vue {
       if (configHelper.getFromSession('KEYCLOAK_TOKEN')) {
         this.$router.push('/confirmtoken/' + (this.token))
       } else {
-        let redirectUrl = this.VUE_APP_AUTH_WEB_REDIRECT_URL + '/confirmtoken/' + this.token
+        let redirectUrl = configHelper.getSelfURL() + '/confirmtoken/' + this.token
         this.$router.push('/signin/bcsc/' + encodeURIComponent(redirectUrl))
       }
     } catch (exception) {


### PR DESCRIPTION
1. introduced two methods in confighelper class to read browser origin
2. removed the timeouts and some redundant if's


Havent fixed Tests yet

*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*

1. introduced two methods in confighelper class to read browser origin
2. removed the timeouts and some redundant if's
*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
