### PR TITLE
AUTH-API: Fix logic error on create business affiliation

### DIFF
--- a/auth-api/src/auth_api/schemas/entity.py
+++ b/auth-api/src/auth_api/schemas/entity.py
@@ -17,10 +17,10 @@ from marshmallow import fields
 
 from auth_api.models import Entity as EntityModel
 
-from .base_schema import BaseSchema
+from .camel_case_schema import CamelCaseSchema
 
 
-class EntitySchema(BaseSchema):  # pylint: disable=too-many-ancestors, too-few-public-methods
+class EntitySchema(CamelCaseSchema):  # pylint: disable=too-many-ancestors, too-few-public-methods
     """Used to manage the default mapping between JSON and the Entity model."""
 
     class Meta:  # pylint: disable=too-few-public-methods

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -103,7 +103,7 @@ class Affiliation:
             authorized = False
 
         # If a passcode was provided...
-        if pass_code:
+        elif pass_code:
             # ... and the entity has a passcode on it, check that they match
             authorized = validate_passcode(pass_code, entity.pass_code)
         # If a passcode was not provided...


### PR DESCRIPTION
*Issue #:* 1595
https://github.com/bcgov/entity/issues/1595

*Description of changes:*

Fix a logic error when creating an affiliation that allows the same user to affiliate with the same business multiple times.  Also switch to use proper CamelCaseSchema.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
