### PR TITLE
Force ordered load of bundled styles

### DIFF
--- a/auth-web/src/App.vue
+++ b/auth-web/src/App.vue
@@ -29,9 +29,6 @@ export default Vue.extend({
 </script>
 
 <style lang="scss">
-  @import "./assets/scss/base.scss";
-  @import "./assets/scss/layout.scss";
-  @import "./assets/scss/overrides.scss";
 
   .app-container {
     display: flex;

--- a/auth-web/src/assets/scss/base.scss
+++ b/auth-web/src/assets/scss/base.scss
@@ -4,27 +4,27 @@
   font-family: 'BCSans';
   font-style: normal;
   font-weight: 400;
-  src: url('assets/fonts/BCSans/BCSans-Regular.woff2') format('woff2'), /* Optimized for very modern browsers */
-       url('assets/fonts/BCSans/BCSans-Regular.woff') format('woff'), /* Modern Browsers */
+  src: url('../fonts/BCSans/BCSans-Regular.woff2') format('woff2'), /* Optimized for very modern browsers */
+       url('../fonts/BCSans/BCSans-Regular.woff') format('woff'), /* Modern Browsers */
 }
 @font-face{
   font-family: 'BCSans';
   font-style: italic;
-  src: url('assets/fonts/BCSans/BCSans-Italic.woff2') format('woff2'), /* Optimized for very modern browsers */
-       url('assets/fonts/BCSans/BCSans-Italic.woff') format('woff'); /* Modern Browsers */
+  src: url('../fonts/BCSans/BCSans-Italic.woff2') format('woff2'), /* Optimized for very modern browsers */
+       url('../fonts/BCSans/BCSans-Italic.woff') format('woff'); /* Modern Browsers */
 }
 @font-face{
   font-family: 'BCSans';
   font-weight: 700; 
-  src: url('assets/fonts/BCSans/BCSans-Bold.woff2') format('woff2'), /* Optimized for very modern browsers */
-       url('assets/fonts/BCSans/BCSans-Bold.woff') format('woff'); /* Modern Browsers */
+  src: url('../fonts/BCSans/BCSans-Bold.woff2') format('woff2'), /* Optimized for very modern browsers */
+       url('../fonts/BCSans/BCSans-Bold.woff') format('woff'); /* Modern Browsers */
 }
 @font-face{
   font-family: 'BCSans';
   font-style: italic;
   font-weight: 700; 
-  src: url('assets/fonts/BCSans/BCSans-BoldItalic.woff2') format('woff2'), /* Optimized for very modern browsers */
-       url('assets/fonts/BCSans/BCSans-BoldItalic.woff') format('woff'); /* Modern Browsers */
+  src: url('../fonts/BCSans/BCSans-BoldItalic.woff2') format('woff2'), /* Optimized for very modern browsers */
+       url('../fonts/BCSans/BCSans-BoldItalic.woff') format('woff'); /* Modern Browsers */
 }
 
 html,

--- a/auth-web/src/assets/scss/overrides.scss
+++ b/auth-web/src/assets/scss/overrides.scss
@@ -1,4 +1,5 @@
 // Vuetify Overrides
+@import "theme.scss";
 
 // Buttons
 .v-btn {

--- a/auth-web/src/plugins/vuetify.ts
+++ b/auth-web/src/plugins/vuetify.ts
@@ -1,5 +1,9 @@
 import 'material-icons/iconfont/material-icons.css' // Ensure you are using css-loader
 import 'vuetify/dist/vuetify.min.css'
+import '$assets/scss/base.scss'
+import '$assets/scss/layout.scss'
+import '$assets/scss/overrides.scss'
+
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 

--- a/auth-web/vue.config.js
+++ b/auth-web/vue.config.js
@@ -4,7 +4,8 @@ module.exports = {
     devtool: 'source-map',
     resolve: {
       alias: {
-        'vue': path.resolve('./node_modules/vue')
+        'vue': path.resolve('./node_modules/vue'),
+        '$assets': path.resolve('./src/assets/')
       }
     }
   },


### PR DESCRIPTION
*Issue #:* 1646
https://github.com/bcgov/entity/issues/1646
*Description of changes:*

This change will force Vue/Webpack to load the SCSS stylesheets in a specific order regardless of whether it's running in dev or prod mode.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
