### PR TITLE
removed org from the user schema 

### DIFF
--- a/auth-api/src/auth_api/schemas/user.py
+++ b/auth-api/src/auth_api/schemas/user.py
@@ -30,4 +30,3 @@ class UserSchema(BaseSchema):  # pylint: disable=too-many-ancestors, too-few-pub
         exclude = ('id', 'orgs')
 
     contacts = fields.Pluck('ContactLinkSchema', 'contact', many=True)
-    # orgs = fields.Pluck('MembershipSchema', 'org', many=True)

--- a/auth-api/src/auth_api/schemas/user.py
+++ b/auth-api/src/auth_api/schemas/user.py
@@ -27,7 +27,7 @@ class UserSchema(BaseSchema):  # pylint: disable=too-many-ancestors, too-few-pub
         """Maps all of the User fields to a default schema."""
 
         model = UserModel
-        exclude = ('id',)
+        exclude = ('id', 'orgs')
 
     contacts = fields.Pluck('ContactLinkSchema', 'contact', many=True)
-    orgs = fields.Pluck('MembershipSchema', 'org', many=True)
+    # orgs = fields.Pluck('MembershipSchema', 'org', many=True)

--- a/auth-api/src/auth_api/services/user.py
+++ b/auth-api/src/auth_api/services/user.py
@@ -186,7 +186,3 @@ class User:  # pylint: disable=too-many-instance-attributes
         org_id = membership.org_id
 
         return UserModel.find_users_by_org_id_by_status_by_roles(org_id, CLIENT_ADMIN_ROLES, status)
-
-    def get_orgs(self):
-        """Return the orgs associated with this user."""
-        return {'orgs': self.as_dict()['orgs']}

--- a/auth-api/tests/unit/services/test_user.py
+++ b/auth-api/tests/unit/services/test_user.py
@@ -231,19 +231,6 @@ def test_user_find_by_username_missing_username(session):  # pylint: disable=unu
     assert user is None
 
 
-def test_get_orgs(session):  # pylint:disable=unused-argument
-    """Assert that orgs for a user can be retrieved."""
-    user_model = factory_user_model(user_info=TestUserInfo.user_test)
-    user = UserService(user_model)
-
-    OrgService.create_org(TestOrgInfo.org1, user_id=user.identifier)
-
-    response = user.get_orgs()
-    assert response['orgs']
-    assert len(response['orgs']) == 1
-    assert response['orgs'][0]['name'] == TestOrgInfo.org1['name']
-
-
 def test_delete_contact_user_link(session, auth_mock):  # pylint:disable=unused-argument
     """Assert that a contact can not be deleted if contact link exists."""
     user_model = factory_user_model(user_info=TestUserInfo.user_test)


### PR DESCRIPTION
removed org from the user schema

*Issue #:*
https://github.com/bcgov/entity/issues/1932

*Description of changes:*

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
