### PR TITLE
Hide invite button for users with MEMBER role

### DIFF
--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -259,7 +259,7 @@ class OrgMembers(Resource):
             roles = request.args.get('roles')
 
             # Require ADMIN or higher for anything other than Active Members list
-            if status == Status.ACTIVE:
+            if status == Status.ACTIVE.name:
                 allowed_roles = CLIENT_AUTH_ROLES
             else:
                 allowed_roles = CLIENT_ADMIN_ROLES

--- a/auth-web/src/components/auth/AffiliatedEntityList.vue
+++ b/auth-web/src/components/auth/AffiliatedEntityList.vue
@@ -46,7 +46,7 @@
 <script lang="ts">
 import { Component, Emit, Vue } from 'vue-property-decorator'
 import { Organization, RemoveBusinessPayload } from '@/models/Organization'
-import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
+import { mapActions, mapGetters, mapMutations } from 'vuex'
 import { Business } from '@/models/business'
 import ConfigHelper from '@/util/config-helper'
 import OrgModule from '@/store/modules/org'
@@ -57,7 +57,7 @@ import { getModule } from 'vuex-module-decorators'
 
 @Component({
   computed: {
-    ...mapState('org', ['organizations'])
+    ...mapGetters('org', ['myOrg'])
   },
   methods: {
     ...mapMutations('business', ['setCurrentBusiness']),
@@ -68,7 +68,7 @@ export default class AffiliatedEntityList extends Vue {
   private VUE_APP_COPS_REDIRECT_URL = ConfigHelper.getValue('VUE_APP_COPS_REDIRECT_URL')
   private orgStore = getModule(OrgModule, this.$store)
   private isLoading = true
-  private readonly organizations!: Organization[]
+  private readonly myOrg!: Organization
   private readonly setCurrentBusiness!: (business: Business) => void
   private readonly syncOrganizations!: () => Organization[]
 
@@ -88,13 +88,6 @@ export default class AffiliatedEntityList extends Vue {
         width: '270'
       }
     ]
-  }
-
-  private get myOrg (): Organization {
-    if (this.organizations && this.organizations.length > 0) {
-      return this.organizations[0]
-    }
-    return undefined
   }
 
   private get myBusinesses () {

--- a/auth-web/src/components/auth/InvitationsDataTable.vue
+++ b/auth-web/src/components/auth/InvitationsDataTable.vue
@@ -23,22 +23,19 @@
 
 <script lang="ts">
 import { Component, Emit, Vue } from 'vue-property-decorator'
-import { mapActions, mapGetters, mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 import { Invitation } from '@/models/Invitation'
-import { Organization } from '@/models/Organization'
 import moment from 'moment'
 
 @Component({
   computed: {
-    ...mapState('org', ['pendingOrgInvitations']),
-    ...mapGetters('org', ['myOrg'])
+    ...mapState('org', ['pendingOrgInvitations'])
   },
   methods: {
     ...mapActions('org', ['syncPendingOrgInvitations'])
   }
 })
 export default class InvitationsDataTable extends Vue {
-  private readonly myOrg!: Organization
   private readonly pendingOrgInvitations!: Invitation[]
   private readonly syncPendingOrgInvitations!: () => Invitation[]
   private readonly headerInvitations = [

--- a/auth-web/src/components/auth/MemberDataTable.vue
+++ b/auth-web/src/components/auth/MemberDataTable.vue
@@ -62,7 +62,7 @@
 
 <script lang="ts">
 import { Component, Emit, Vue } from 'vue-property-decorator'
-import { mapActions, mapGetters, mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 import { Member } from '@/models/Organization'
 import moment from 'moment'
 
@@ -73,8 +73,7 @@ export interface ChangeRolePayload {
 
 @Component({
   computed: {
-    ...mapState('org', ['activeOrgMembers']),
-    ...mapGetters('org', ['myOrg'])
+    ...mapState('org', ['activeOrgMembers'])
   },
   methods: {
     ...mapActions('org', ['syncActiveOrgMembers'])

--- a/auth-web/src/components/auth/PendingMemberDataTable.vue
+++ b/auth-web/src/components/auth/PendingMemberDataTable.vue
@@ -25,14 +25,13 @@
 
 <script lang="ts">
 import { Component, Emit, Vue } from 'vue-property-decorator'
-import { mapActions, mapGetters, mapState } from 'vuex'
+import { mapActions, mapState } from 'vuex'
 import { Member } from '@/models/Organization'
 import moment from 'moment'
 
 @Component({
   computed: {
-    ...mapState('org', ['pendingOrgMembers']),
-    ...mapGetters('org', ['myOrg'])
+    ...mapState('org', ['pendingOrgMembers'])
   },
   methods: {
     ...mapActions('org', ['syncPendingOrgMembers'])

--- a/auth-web/src/components/auth/Signin.vue
+++ b/auth-web/src/components/auth/Signin.vue
@@ -5,11 +5,11 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import { KeycloakError, KeycloakPromise } from 'keycloak-js'
+import { MembershipStatus, Organization } from '@/models/Organization'
 import { mapActions, mapState } from 'vuex'
 import CommonUtils from '@/util/common-util'
 import ConfigHelper from '@/util/config-helper'
 import OrgModule from '@/store/modules/org'
-import { Organization } from '@/models/Organization'
 import { User } from '@/models/user'
 import { UserInfo } from '@/models/userInfo'
 import UserModule from '@/store/modules/user'
@@ -80,7 +80,7 @@ export default class Signin extends Vue {
             this.$router.push('/userprofile')
           } else if (this.organizations.length === 0) {
             this.$router.push('/createteam')
-          } else if (this.organizations.some(org => org.members[0].membershipStatus === 'PENDING_APPROVAL')) {
+          } else if (this.organizations.some(org => org.members[0].membershipStatus === MembershipStatus.Pending)) {
             this.$router.push('/pendingapproval/' + this.organizations[0].name)
           } else {
             this.$router.push('/main')

--- a/auth-web/src/models/Organization.ts
+++ b/auth-web/src/models/Organization.ts
@@ -34,8 +34,8 @@ export interface RemoveBusinessPayload {
 
 export interface Member {
   id: number
-  membershipTypeCode: string
-  membershipStatus: string
+  membershipTypeCode: MembershipType
+  membershipStatus: MembershipStatus
   user: User
 }
 
@@ -56,4 +56,17 @@ export interface PendingUserRecord {
   invitationSent: string
   invitationExpires?: string
   invitation: Invitation
+}
+
+export enum MembershipStatus {
+  'Active' = 'ACTIVE',
+  'Inactive' = 'INACTIVE',
+  'Rejected' = 'REJECTED',
+  'Pending' = 'PENDING_APPROVAL'
+}
+
+export enum MembershipType {
+  'Owner' = 'OWNER',
+  'Admin' = 'ADMIN',
+  'Member' = 'MEMBER'
 }

--- a/auth-web/src/store/modules/business.ts
+++ b/auth-web/src/store/modules/business.ts
@@ -38,10 +38,6 @@ export default class BusinessModule extends VuexModule {
       passCode: payload.passCode
     }
 
-    // Create an implicit org for the current user and the requested business
-    // const createBusinessResponse = await BusinessService.createOrg({
-    //   name: payload.businessIdentifier
-    // })
     const myOrg: Organization = this.context.rootGetters['org/myOrg']
 
     // Create an affiliation between implicit org and requested business

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -1,10 +1,10 @@
 import { Action, Module, Mutation, VuexModule } from 'vuex-module-decorators'
 import { CreateRequestBody as CreateInvitationRequestBody, Invitation } from '@/models/Invitation'
 import { CreateRequestBody as CreateOrgRequestBody, Member, Organization, UpdateMemberPayload } from '@/models/Organization'
-import { Business } from '@/models/business'
 import { EmptyResponse } from '@/models/global'
 import InvitationService from '@/services/invitation.services'
 import OrgService from '@/services/org.services'
+import { UserInfo } from '@/models/userInfo'
 import UserService from '@/services/user.services'
 import _ from 'lodash'
 
@@ -33,6 +33,14 @@ export default class OrgModule extends VuexModule {
   get myOrg (): Organization {
     if (this.organizations && this.organizations.length > 0) {
       return this.organizations[0]
+    }
+    return undefined
+  }
+
+  get myOrgMembership (): Member {
+    const currentUser: UserInfo = this.context.rootState.user.currentUser
+    if (this.myOrg && currentUser) {
+      return this.myOrg.members.find(member => member.user.username === currentUser.userName)
     }
     return undefined
   }


### PR DESCRIPTION
*Issue #:* 1931
https://github.com/bcgov/entity/issues/1931

*Description of changes:*

Only show 'Invite Users' button on Manage Teams view if current user has the ADMIN or OWNER role.  This change also included adding a store getter for the current users's membership and proper enum use for types/statuses on the front-end.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
