### PR TITLE
Redirect unapproved or non-members away from Dashboard

### DIFF
--- a/auth-web/src/components/auth/InviteUsersForm.vue
+++ b/auth-web/src/components/auth/InviteUsersForm.vue
@@ -131,7 +131,7 @@ export default class InviteUsersForm extends Vue {
 
   private created () {
     for (let i = 0; i < 3; i++) {
-      this.invitations.push({ emailAddress: '', role: this.roles[2] })
+      this.invitations.push({ emailAddress: '', role: this.roles[0] })
     }
   }
 
@@ -144,7 +144,7 @@ export default class InviteUsersForm extends Vue {
   }
 
   private addEmail () {
-    this.invitations.push({ emailAddress: '', role: this.roles[2] })
+    this.invitations.push({ emailAddress: '', role: this.roles[0] })
   }
 
   private async sendInvites () {

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -1,6 +1,6 @@
 import { Action, Module, Mutation, VuexModule } from 'vuex-module-decorators'
 import { CreateRequestBody as CreateInvitationRequestBody, Invitation } from '@/models/Invitation'
-import { CreateRequestBody as CreateOrgRequestBody, Member, Organization, UpdateMemberPayload } from '@/models/Organization'
+import { CreateRequestBody as CreateOrgRequestBody, Member, MembershipStatus, Organization, UpdateMemberPayload } from '@/models/Organization'
 import { EmptyResponse } from '@/models/global'
 import InvitationService from '@/services/invitation.services'
 import OrgService from '@/services/org.services'
@@ -40,7 +40,8 @@ export default class OrgModule extends VuexModule {
   get myOrgMembership (): Member {
     const currentUser: UserInfo = this.context.rootState.user.currentUser
     if (this.myOrg && currentUser) {
-      return this.myOrg.members.find(member => member.user.username === currentUser.userName)
+      return this.myOrg.members.find(member => member.user.username === currentUser.userName &&
+        (member.membershipStatus === MembershipStatus.Active || member.membershipStatus === MembershipStatus.Pending))
     }
     return undefined
   }


### PR DESCRIPTION
*Issue #:* 1970
https://github.com/bcgov/entity/issues/1970

*Description of changes:*

Added a redirect away from the Dashboard/Manage Businesses view if the current user is not an active member of a team.  If they are pending, they are redirected to the page informing them that their membership is pending approval.  Otherwise, they are directed towards the create team view.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
