### PR TITLE
#2026 - Prevent team members from accepting invites to other teams

### DIFF
--- a/auth-web/src/router.ts
+++ b/auth-web/src/router.ts
@@ -6,6 +6,7 @@ import BusinessProfile from '@/views/BusinessProfile.vue'
 import CreateAccount from '@/views/CreateAccount.vue'
 import CreateTeamView from '@/views/CreateTeamView.vue'
 import Dashboard from '@/views/management/Dashboard.vue'
+import DuplicateTeamWarning from '@/views/DuplicateTeamWarning.vue'
 import KeyCloakService from '@/services/keycloak.services'
 import PageNotFound from '@/views/PageNotFound.vue'
 import PaymentForm from '@/components/pay/PaymentForm.vue'
@@ -41,6 +42,7 @@ export function getRoutes (appFlavor: String) {
     { path: '/userprofile', component: UserProfile, props: true, meta: { requiresAuth: true } },
     { path: '/createteam', component: CreateTeamView, meta: { requiresAuth: true } },
     { path: '/createaccount', component: CreateAccount, meta: { requiresAuth: false } },
+    { path: '/duplicateteam', component: DuplicateTeamWarning, meta: { requiresAuth: true } },
     { path: '/validatetoken/:token', component: AcceptInviteLanding, props: true, meta: { requiresAuth: false, disabledRoles: [Role.Staff] } },
     { path: '/confirmtoken/:token', component: AcceptInvite, props: true, meta: { requiresAuth: true, disabledRoles: [Role.Staff] } }
   ]

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -17,6 +17,7 @@ export enum Role {
 export enum Pages {
     USER_PROFILE = 'userprofile',
     CREATE_TEAM = 'createteam',
+    DUPLICATE_TEAM_MESAGE = 'duplicateteam',
     PENDING_APPROVAL = 'pendingapproval',
     MAIN = 'main'
 }

--- a/auth-web/src/views/AcceptInvite.vue
+++ b/auth-web/src/views/AcceptInvite.vue
@@ -49,7 +49,12 @@ export default class AcceptInvite extends Mixins(NextPageMixin) {
   private async mounted () {
     await this.getUserProfile('@me')
     await this.syncOrganizations()
-    this.accept()
+    // Check to make sure this user is not already a member of a team
+    if (this.organizations.length > 0) {
+      this.$router.push('/duplicateteam')
+    } else {
+      this.accept()
+    }
   }
 
   private async accept () {

--- a/auth-web/src/views/DuplicateTeamWarning.vue
+++ b/auth-web/src/views/DuplicateTeamWarning.vue
@@ -1,0 +1,56 @@
+<template>
+  <v-container>
+    <div class="view-container">
+      <article>
+        <h1 class="mb-5">Already On a Team</h1>
+        <p class="intro-text">You cannot accept this invitation, because you already have membership on a team</p>
+        <v-card class="profile-card">
+          <v-container>
+            <v-card-text>
+              <TeamForm />
+            </v-card-text>
+          </v-container>
+        </v-card>
+      </article>
+    </div>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import { mapActions, mapState } from 'vuex'
+import { Organization } from '@/models/Organization'
+import TeamForm from '@/components/auth/TeamForm.vue'
+import { getModule } from 'vuex-module-decorators'
+
+@Component({
+  components: {
+    TeamForm
+  }
+})
+export default class DuplicateTeamWarning extends Vue {
+  async mounted () {}
+}
+</script>
+
+<style lang="scss" scoped>
+  article {
+    flex: 1 1 auto;
+    margin: 0 auto;
+    max-width: 50rem;
+  }
+
+  .v-card__title {
+    font-weight: 700;
+    letter-spacing: -0.01rem;
+  }
+
+  .intro-text {
+    margin-bottom: 3rem;
+  }
+
+  // Profile Card
+  .profile-card .container {
+    padding: 1rem;
+  }
+</style>


### PR DESCRIPTION
*Issue #:* 2026
https://github.com/bcgov/entity/issues/2026

*Description of changes:*

Intercept acceptance of an invitation by users who already a team member and route to a new view informing them that they can't accept the invite.

In addition, allow an Owner to dissolve their team if they are the only member and they have no affiliated businesses. 

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
