### PR TITLE
#2016 - Prevent duplicate invites from being generated

### DIFF
--- a/auth-web/src/components/auth/InviteUsersForm.vue
+++ b/auth-web/src/components/auth/InviteUsersForm.vue
@@ -139,16 +139,8 @@ export default class InviteUsersForm extends Vue {
   }
 
   private hasDuplicates (): boolean {
-    for (let i = 0; i < this.invitations.length; i++) {
-      for (let j = 0; j < this.invitations.length; j++) {
-        if (i !== j &&
-            this.invitations[j].emailAddress &&
-            this.invitations[i].emailAddress.toLowerCase() === this.invitations[j].emailAddress.toLowerCase()) {
-          return true
-        }
-      }
-    }
-    return false
+    const invitations = this.invitations.filter(invitation => invitation.emailAddress)
+    return new Set(invitations.map(invitation => invitation.emailAddress.toLowerCase())).size !== invitations.length
   }
 
   private isFormValid (): boolean {

--- a/auth-web/src/components/auth/NextPageMixin.vue
+++ b/auth-web/src/components/auth/NextPageMixin.vue
@@ -1,26 +1,35 @@
 // You can declare a mixin as the same style as components.
 <script lang="ts">
+import { Member, MembershipStatus, Organization } from '@/models/Organization'
+import { mapGetters, mapState } from 'vuex'
 import Component from 'vue-class-component'
-import { Organization } from '@/models/Organization'
 import { Pages } from '@/util/constants'
 import { User } from '@/models/user'
-
 import Vue from 'vue'
 
-@Component({})
+@Component({
+  computed: {
+    ...mapState('user', ['userProfile']),
+    ...mapGetters('org', ['myOrg', 'myOrgMembership'])
+  }
+})
 export default class NextPageMixin extends Vue {
-  getNextPageUrl (userProfile:User, organizations:Organization[]):string {
+  protected readonly userProfile!: User
+  protected readonly myOrg!: Organization
+  protected readonly myOrgMembership!: Member
+
+  protected getNextPageUrl (): string {
     let nextStep:string = '/'
     // Redirect to user profile if no contact info
     // Redirect to create team if no orgs
     // Redirect to dashboard otherwise
-    if (userProfile) {
-      if (!userProfile.contacts || userProfile.contacts.length === 0) {
+    if (this.userProfile) {
+      if (!this.userProfile.contacts || this.userProfile.contacts.length === 0) {
         nextStep = Pages.USER_PROFILE
-      } else if (organizations.length === 0) {
+      } else if (!this.myOrg) {
         nextStep = Pages.CREATE_TEAM
-      } else if (organizations.some(org => org.members[0].membershipStatus === 'PENDING_APPROVAL')) {
-        nextStep = Pages.PENDING_APPROVAL + '/' + organizations[0].name
+      } else if (this.myOrgMembership.membershipStatus === MembershipStatus.Pending) {
+        nextStep = Pages.PENDING_APPROVAL + '/' + this.myOrg.name
       } else {
         nextStep = Pages.MAIN
       }

--- a/auth-web/src/components/auth/Signin.vue
+++ b/auth-web/src/components/auth/Signin.vue
@@ -17,7 +17,6 @@ import { getModule } from 'vuex-module-decorators'
 
 @Component({
   computed: {
-    ...mapState('user', ['userProfile']),
     ...mapState('org', ['organizations'])
   },
   methods: {
@@ -34,7 +33,6 @@ import { getModule } from 'vuex-module-decorators'
 export default class Signin extends Mixins(NextPageMixin) {
   private userStore = getModule(UserModule, this.$store)
   private orgStore = getModule(OrgModule, this.$store)
-  private readonly userProfile!: User
   private readonly initKeycloak!: (idpHint: string) => Promise<KeycloakPromise<boolean, KeycloakError>>
   private readonly initializeSession!: () => UserInfo
   private readonly syncUserProfile!: () => User
@@ -72,7 +70,7 @@ export default class Signin extends Mixins(NextPageMixin) {
       if (this.idpHint === 'idir') {
         this.$router.push('/searchbusiness')
       } else {
-        this.$router.push(this.getNextPageUrl(this.userProfile, this.organizations))
+        this.$router.push(this.getNextPageUrl())
       }
     }
   }

--- a/auth-web/src/components/auth/UserProfileForm.vue
+++ b/auth-web/src/components/auth/UserProfileForm.vue
@@ -122,7 +122,6 @@ import { mask } from 'vue-the-mask'
     mask
   },
   computed: {
-    ...mapState('user', ['userProfile']),
     ...mapState('org', ['organizations'])
   },
   methods: {
@@ -140,7 +139,6 @@ import { mask } from 'vue-the-mask'
 export default class UserProfileForm extends Mixins(NextPageMixin) {
     private userStore = getModule(UserModule, this.$store)
     private orgStore = getModule(OrgModule, this.$store)
-    private readonly userProfile!: User
     private readonly organizations!: Organization[]
     private readonly createUserContact!: (contact: Contact) => Contact
     private readonly updateUserContact!: (contact: Contact) => Contact
@@ -234,7 +232,7 @@ export default class UserProfileForm extends Mixins(NextPageMixin) {
     }
 
     private redirectToNext () {
-      this.$router.push(this.getNextPageUrl(this.userProfile, this.organizations))
+      this.$router.push(this.getNextPageUrl())
     }
 
     cancel () {

--- a/auth-web/src/views/AcceptInvite.vue
+++ b/auth-web/src/views/AcceptInvite.vue
@@ -26,7 +26,6 @@ import { getModule } from 'vuex-module-decorators'
 
 @Component({
   computed: {
-    ...mapState('user', ['userProfile']),
     ...mapState('org', ['organizations'])
   },
   methods: {
@@ -37,7 +36,6 @@ import { getModule } from 'vuex-module-decorators'
 export default class AcceptInvite extends Mixins(NextPageMixin) {
   private orgStore = getModule(OrgModule, this.$store)
   private userStore = getModule(UserModule, this.$store)
-  private readonly userProfile!: User
   private readonly acceptInvitation!: (token: string) => Invitation
   private readonly syncOrganizations!: () => Organization[]
   private readonly getUserProfile!: (identifier: string) => User
@@ -57,7 +55,7 @@ export default class AcceptInvite extends Mixins(NextPageMixin) {
       await this.acceptInvitation(this.token)
       // the accept invitation creates a new org
       await this.syncOrganizations()
-      this.$router.push(this.getNextPageUrl(this.userProfile, this.organizations))
+      this.$router.push(this.getNextPageUrl())
     } catch (exception) {
       this.inviteError = true
     }


### PR DESCRIPTION
*Issue #:* 2016
https://github.com/bcgov/entity/issues/2016

*Description of changes:*

Fix a bug where multiple invites could be generated for the same email address.  This was fixed through the following changes on the front-end:

a) Validation was added to the invite users form to prevent duplicate emails being specified simultaneously
b) The invite users form is reset whenever it is closed
c) Prior to creating an invitation, pending invitations are checked for the same email.  If found, the existing is just resent instead of creating a new one.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
