### PR TITLE
Keycloak refresh done using tokenservices

### DIFF
--- a/auth-web/src/App.vue
+++ b/auth-web/src/App.vue
@@ -23,6 +23,18 @@ export default Vue.extend({
     SbcHeader,
     SbcFooter,
     PaySystemAlert
+  },
+  mounted (): void {
+    // eslint-disable-next-line no-console
+    console.log('APP.vue mounted')
+    if (sessionStorage.getItem('KEYCLOAK_TOKEN')) {
+      // eslint-disable-next-line no-console
+      console.info('[APP.vue] Token exists.So start the refreshtimer')
+      var self = this
+      this.$tokenService.initUsingUrl(`/${process.env.VUE_APP_PATH}/config/kc/keycloak.json`).then(function (success) {
+        self.$tokenService.scheduleRefreshTimer()
+      })
+    }
   }
 })
 

--- a/auth-web/src/components/auth/Signin.vue
+++ b/auth-web/src/components/auth/Signin.vue
@@ -52,6 +52,12 @@ export default class Signin extends Mixins(NextPageMixin) {
         if (this.idpHint === 'bcsc') {
           await this.syncUserProfile()
           await this.syncOrganizations()
+          // eslint-disable-next-line no-console
+          console.info('[SignIn.vue]Logged in User.Starting refreshTimer')
+          var self = this
+          this.$tokenService.initUsingUrl(`/${process.env.VUE_APP_PATH}/config/kc/keycloak.json`).then(function (success) {
+            self.$tokenService.scheduleRefreshTimer()
+          })
         }
         this.redirectToNext()
       }

--- a/auth-web/src/main.ts
+++ b/auth-web/src/main.ts
@@ -4,6 +4,7 @@ import 'regenerator-runtime/runtime' // to use transpiled generator functions
 import router, { getRoutes } from './router'
 import App from './App.vue'
 import ConfigHelper from '@/util/config-helper'
+import TokenService from 'sbc-common-components/src/services/token.services'
 import Vue from 'vue'
 import i18n from './plugins/i18n'
 import interceptorsSetup from '@/util/interceptors'
@@ -11,6 +12,7 @@ import store from './store'
 import vuetify from './plugins/vuetify'
 
 Vue.config.productionTip = false
+Vue.prototype.$tokenService = new TokenService()
 interceptorsSetup()
 
 /**

--- a/auth-web/src/services/keycloak.services.ts
+++ b/auth-web/src/services/keycloak.services.ts
@@ -42,6 +42,7 @@ class KeyCloakService {
 
   initSession () {
     configHelper.addToSession(SessionStorageKeys.KeyCloakToken, this.kc.token)
+    configHelper.addToSession(SessionStorageKeys.Idtoken, this.kc.idToken)
     configHelper.addToSession(SessionStorageKeys.KeyCloakRefreshToken, this.kc.refreshToken)
     configHelper.addToSession(SessionStorageKeys.UserFullName, this.getUserInfo().fullName)
     this.parsedToken = this.kc.tokenParsed as UserToken
@@ -76,6 +77,10 @@ class KeyCloakService {
         }
       })
     }
+  }
+
+  getKCInstance () :KeycloakInstance {
+    return this.kc
   }
 
   cleanupSession () {

--- a/auth-web/src/services/keycloak.services.ts
+++ b/auth-web/src/services/keycloak.services.ts
@@ -42,7 +42,7 @@ class KeyCloakService {
 
   initSession () {
     configHelper.addToSession(SessionStorageKeys.KeyCloakToken, this.kc.token)
-    configHelper.addToSession(SessionStorageKeys.Idtoken, this.kc.idToken)
+    configHelper.addToSession(SessionStorageKeys.KeyCloakIdToken, this.kc.idToken)
     configHelper.addToSession(SessionStorageKeys.KeyCloakRefreshToken, this.kc.refreshToken)
     configHelper.addToSession(SessionStorageKeys.UserFullName, this.getUserInfo().fullName)
     this.parsedToken = this.kc.tokenParsed as UserToken
@@ -86,6 +86,7 @@ class KeyCloakService {
   cleanupSession () {
     configHelper.removeFromSession(SessionStorageKeys.KeyCloakToken)
     configHelper.removeFromSession(SessionStorageKeys.KeyCloakRefreshToken)
+    configHelper.removeFromSession(SessionStorageKeys.KeyCloakIdToken)
   }
 
   async refreshToken () {

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -2,6 +2,7 @@
 export enum SessionStorageKeys {
     KeyCloakToken = 'KEYCLOAK_TOKEN',
     KeyCloakRefreshToken = 'KEYCLOAK_REFRESH_TOKEN',
+    Idtoken = 'KEYCLOAK_ID_TOKEN',
     ApiConfigKey = 'AUTH_API_CONFIG',
     BusinessIdentifierKey = 'BUSINESS_IDENTIFIER',
     UserFullName = 'USER_FULL_NAME'

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -2,7 +2,7 @@
 export enum SessionStorageKeys {
     KeyCloakToken = 'KEYCLOAK_TOKEN',
     KeyCloakRefreshToken = 'KEYCLOAK_REFRESH_TOKEN',
-    Idtoken = 'KEYCLOAK_ID_TOKEN',
+    KeyCloakIdToken = 'KEYCLOAK_ID_TOKEN',
     ApiConfigKey = 'AUTH_API_CONFIG',
     BusinessIdentifierKey = 'BUSINESS_IDENTIFIER',
     UserFullName = 'USER_FULL_NAME'

--- a/auth-web/src/util/interceptors.ts
+++ b/auth-web/src/util/interceptors.ts
@@ -32,10 +32,10 @@ function createAxiosResponseInterceptor () {
         })
       }
       axios.interceptors.response.eject(interceptor)
-      if (error.response.status === 401 && !originalRequest._retry) {
+      if (error.response.status === 401) {
         originalRequest._retry = true
-        let mm :TokenService = new TokenService()
-        mm.initUsingUrl(`/${process.env.VUE_APP_PATH}/config/kc/keycloak.json`).then(function (token) {
+        let tokenservice = new TokenService()
+        tokenservice.initUsingUrl(`/${process.env.VUE_APP_PATH}/config/kc/keycloak.json`).then(function (token) {
           originalRequest.headers['Authorization'] = `Bearer ${token}`
           return axios(originalRequest)
         }).catch(error => {


### PR DESCRIPTION
Token service timer is initiated on app load and sign in

*Issue #:*
https://app.zenhub.com/workspaces/entity-5bf2f2164b5806bc2bf60531/issues/bcgov/entity/1773

*Description of changes:*
The token service is invoked on app load and sign in as well.  Interceptor code also checked in ;but not used right now because of  https://github.com/bcgov/entity/issues/2076
Need more testing in DEV .
*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
