### PR TITLE
Fixes to terms of service acceptance flow

### DIFF
--- a/auth-api/src/auth_api/models/invite_status.py
+++ b/auth-api/src/auth_api/models/invite_status.py
@@ -19,7 +19,7 @@ It defines the different statuses of an Invitation.
 from .base_model import BaseCodeModel
 
 
-class InvitationStatus(BaseCodeModel):  # pylint: disable=too-few-public-methods # Temporarily disable until methods defined
+class InvitationStatus(BaseCodeModel):  # pylint: disable=too-few-public-methods
     """This is the Invitation Status model for the Auth service."""
 
     __tablename__ = 'invitation_status'

--- a/auth-api/src/auth_api/models/membership.py
+++ b/auth-api/src/auth_api/models/membership.py
@@ -83,7 +83,7 @@ class Membership(BaseModel):  # pylint: disable=too-few-public-methods # Tempora
     @classmethod
     def find_orgs_for_user(cls, user_id):
         """Find the org for a user."""
-        return db.session.query(OrgModel).filter(and_(OrgModel.status_code == 'ACTIVE', \
-            OrgModel.members.any(and_(cls.user_id == user_id,
-                                      or_(cls.status.in_(
-                                          VALID_STATUSES)))))).all()  # noqa:E501
+        return db.session.query(OrgModel).filter(and_(OrgModel.status_code == 'ACTIVE',
+                                                      OrgModel.members.any(and_(cls.user_id == user_id,
+                                                                                or_(cls.status.in_(
+                                                                                    VALID_STATUSES)))))).all()  # noqa:E501

--- a/auth-api/src/auth_api/schemas/user.py
+++ b/auth-api/src/auth_api/schemas/user.py
@@ -17,16 +17,23 @@ from marshmallow import fields
 
 from auth_api.models import User as UserModel
 
-from .base_schema import BaseSchema
+from .camel_case_schema import CamelCaseSchema
 
 
-class UserSchema(BaseSchema):  # pylint: disable=too-many-ancestors, too-few-public-methods
+class UserSchema(CamelCaseSchema):  # pylint: disable=too-many-ancestors, too-few-public-methods
     """This is the schema for the User model."""
 
     class Meta:  # pylint: disable=too-few-public-methods
         """Maps all of the User fields to a default schema."""
 
         model = UserModel
-        exclude = ('id', 'orgs')
+        exclude = ('id', 'orgs', 'is_terms_of_use_accepted', 'terms_of_use_accepted_version', 'terms_of_use_version')
 
     contacts = fields.Pluck('ContactLinkSchema', 'contact', many=True)
+    user_terms = fields.Method('get_user_terms_object')
+
+    def get_user_terms_object(self, obj):  # pylint: disable=no-self-use
+        return {
+            'isTermsOfUseAccepted': obj.is_terms_of_use_accepted,
+            'termsOfUseAcceptedVersion': obj.terms_of_use_accepted_version
+        }

--- a/auth-api/src/auth_api/schemas/user.py
+++ b/auth-api/src/auth_api/schemas/user.py
@@ -33,6 +33,7 @@ class UserSchema(CamelCaseSchema):  # pylint: disable=too-many-ancestors, too-fe
     user_terms = fields.Method('get_user_terms_object')
 
     def get_user_terms_object(self, obj):  # pylint: disable=no-self-use
+        """Map terms properties into nested object."""
         return {
             'isTermsOfUseAccepted': obj.is_terms_of_use_accepted,
             'termsOfUseAcceptedVersion': obj.terms_of_use_accepted_version

--- a/auth-api/src/auth_api/services/codes.py
+++ b/auth-api/src/auth_api/services/codes.py
@@ -63,5 +63,6 @@ class Codes:
                         code_schema = schema()
                         data.append(code_schema.dump(entry, many=False))
                 return data
+            return None
         except Exception as exception:
             raise BusinessException(Error.UNDEFINED_ERROR, exception)

--- a/auth-api/src/auth_api/services/membership.py
+++ b/auth-api/src/auth_api/services/membership.py
@@ -144,7 +144,6 @@ class Membership:  # pylint: disable=too-many-instance-attributes,too-few-public
            OrgService(self._model.org).get_owner_count() == 1:
             raise BusinessException(Error.CHANGE_ROLE_FAILED_ONLY_OWNER, None)
 
-
         for key, value in updated_fields.items():
             if value is not None:
                 setattr(self._model, key, value)

--- a/auth-api/src/auth_api/services/user.py
+++ b/auth-api/src/auth_api/services/user.py
@@ -208,7 +208,7 @@ class User:  # pylint: disable=too-many-instance-attributes
         2) Find all org membership for the user
         3) Check if the current user is the only owner for any org - If yes, deny the action
         4) Mark the membership as inactive on all orgs for the user
-        5) Delete the contact information for the user
+        5) Delete the contact information for the user and the accepted terms of service
         6) Mark the user record as inactive
         """
         current_app.logger.debug('<delete_user')
@@ -234,6 +234,12 @@ class User:  # pylint: disable=too-many-instance-attributes
 
         # Set the user status as inactive
         user.status = UserStatus.INACTIVE.value
+
+        # Remove accepted terms
+        user.terms_of_use_accepted_version = None
+        user.terms_of_use_version = None
+        user.is_terms_of_use_accepted = False
+
         user.save()
         current_app.logger.debug('<delete_user')
 

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -86,7 +86,7 @@ def test_update_user_terms_of_use(client, jwt, session):  # pylint:disable=unuse
                       data=input_data, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
     user = json.loads(rv.data)
-    assert user['terms_of_use_version'] == 1
+    assert user['userTerms']['termsOfUseAcceptedVersion'] == 1
 
 
 def test_update_user_terms_of_use_invalid_input(client, jwt, session):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/models/test_invitation.py
+++ b/auth-api/tests/unit/models/test_invitation.py
@@ -16,6 +16,7 @@
 Test suite to ensure that the  model routines are working as expected.
 """
 from _datetime import datetime, timedelta
+
 from auth_api.models import Invitation as InvitationModel
 from auth_api.models import InvitationMembership as InvitationMembershipModel
 from auth_api.models import Org as OrgModel

--- a/auth-api/tests/unit/services/test_user.py
+++ b/auth-api/tests/unit/services/test_user.py
@@ -49,7 +49,7 @@ def test_user_save_by_token(session):  # pylint: disable=unused-argument
     assert user is not None
     dictionary = user.as_dict()
     assert dictionary['username'] == TestJwtClaims.user_test['preferred_username']
-    assert dictionary['keycloak_guid'] == TestJwtClaims.user_test['sub']
+    assert dictionary['keycloakGuid'] == TestJwtClaims.user_test['sub']
 
 
 def test_user_save_by_token_no_token(session):  # pylint: disable=unused-argument
@@ -122,7 +122,7 @@ def test_update_terms_of_use_for_user(session):  # pylint: disable=unused-argume
 
     updated_user = UserService.update_terms_of_use(TestJwtClaims.user_test, True, 1)
     dictionary = updated_user.as_dict()
-    assert dictionary['is_terms_of_use_accepted'] is True
+    assert dictionary['userTerms']['isTermsOfUseAccepted'] is True
 
 
 def test_update_contact_for_user_no_user(session):  # pylint: disable=unused-argument
@@ -197,7 +197,7 @@ def test_user_find_by_token(session):  # pylint: disable=unused-argument
     assert found_user is not None
     dictionary = found_user.as_dict()
     assert dictionary['username'] == TestJwtClaims.user_test['preferred_username']
-    assert dictionary['keycloak_guid'] == TestJwtClaims.user_test['sub']
+    assert dictionary['keycloakGuid'] == TestJwtClaims.user_test['sub']
 
 
 def test_user_find_by_username(session):  # pylint: disable=unused-argument

--- a/auth-web/.eslintrc.js
+++ b/auth-web/.eslintrc.js
@@ -11,7 +11,8 @@ module.exports = {
   rules: {
     'no-console': 'error',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'sort-imports': 'error'
+    'sort-imports': 'error',
+    'space-before-function-parentheses': true
   },
   parserOptions: {
     parser: '@typescript-eslint/parser'

--- a/auth-web/.prettierrc.json
+++ b/auth-web/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/auth-web/src/components/auth/TermsOfUseDialog.vue
+++ b/auth-web/src/components/auth/TermsOfUseDialog.vue
@@ -1,196 +1,215 @@
 <template>
-    <v-row>
-        <v-col sm="12">
-            <v-tooltip bottom>
-                <template v-slot:activator="{ on }">
-                    <v-checkbox v-on:change="emitStatus()" class="terms-checkbox" color="default" v-on="on"
-                                v-model="termsAccepted" required on :disabled="!canCheckTerms">
-                        <template v-slot:label>
-                            <div class="terms-checkbox-label">
-                                <span>I have read and agreed to the</span>
-                                <v-btn text color="primary" class="pr-1 pl-1" @click.stop="openDialog()" data-test="terms-of-use-checkbox">
-                                    Terms of Use
-                                </v-btn>
-                            </div>
-                        </template>
-                    </v-checkbox>
-                </template>
-                <span>{{tooltipTxt}}</span>
-            </v-tooltip>
-            <v-dialog scrollable width="1024" v-model="termsDialog" :persistent="true">
-                <v-card>
-                    <v-card-title>Terms of Use</v-card-title>
-                    <v-card-text id="scroll-target" data-test="scroll-area">
-                        <div v-scroll:#scroll-target="onScroll" style="height: 2000px;">
-                            <p v-html="content" class="terms-container"></p>
-                        </div>
-                    </v-card-text>
-                    <v-card-actions>
-                        <v-btn large depressed color="primary" class="agree-btn" :disabled="this.offsetTop < 3000"
-                               @click="termsDialog = false ;termsAccepted = true ;emitStatus()" data-test="accept-button">
-                            <span>Agree to Terms</span>
-                        </v-btn>
-                        <v-btn large depressed color="primary" class="agree-btn" :disabled="this.offsetTop < 3000"
-                               @click="termsDialog = false ;emitStatus()" data-test="close-button">
-                            <span>Close</span>
-                        </v-btn>
-                    </v-card-actions>
-                </v-card>
-            </v-dialog>
-        </v-col>
-    </v-row>
-
+  <v-row>
+    <v-col sm="12">
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on }">
+          <v-checkbox
+            v-on:change="emitStatus()"
+            class="terms-checkbox"
+            color="default"
+            v-model="termsAccepted"
+            required
+            :disabled="termsAccepted || !canCheckTerms"
+          >
+            <template v-slot:label>
+              <div class="terms-checkbox-label">
+                <span>I have read and agreed to the</span>
+                <v-btn
+                  text
+                  color="primary"
+                  class="pr-1 pl-1"
+                  @click.stop="openDialog()"
+                  data-test="terms-of-use-checkbox"
+                >Terms of Use</v-btn>
+              </div>
+            </template>
+          </v-checkbox>
+        </template>
+        <span>{{tooltipTxt}}</span>
+      </v-tooltip>
+      <v-dialog scrollable width="1024" v-model="termsDialog" :persistent="true">
+        <v-card>
+          <v-card-title>Terms of Use</v-card-title>
+          <v-card-text id="scroll-target" data-test="scroll-area">
+            <div v-scroll:#scroll-target="onScroll" style="height: 2000px;">
+              <p v-html="content" class="terms-container"></p>
+            </div>
+          </v-card-text>
+          <v-card-actions>
+            <v-btn
+              large
+              depressed
+              color="primary"
+              class="agree-btn"
+              :disabled="this.offsetTop < 3000"
+              @click="termsDialog = false; termsAccepted = true; emitStatus()"
+              data-test="accept-button"
+            >
+              <span>Agree to Terms</span>
+            </v-btn>
+            <v-btn
+              large
+              depressed
+              color="primary"
+              class="agree-btn"
+              :disabled="this.offsetTop < 3000"
+              @click="termsDialog = false; emitStatus()"
+              data-test="close-button"
+            >
+              <span>Close</span>
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </v-col>
+  </v-row>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
+import { Component, Emit, Prop, Vue, Watch } from 'vue-property-decorator'
+import { User } from '@/models/user'
 import documentService from '@/services/document.service.ts'
 import { getModule } from 'vuex-module-decorators'
+import { mapState } from 'vuex'
 
-  @Component({
-    directives: {}
-  })
+@Component({
+  computed: {
+    ...mapState('user', ['userProfile'])
+  }
+})
 export default class TermsOfServiceDialog extends Vue {
-    @Prop({ default: '' })
-    lastAcceptedVersion: string
-    private termsDialog = false
-    private offsetTop = '0'
-    private termsAccepted = false
-    private content: string = ''
-    private version: string = ''
-    private canCheckTerms: boolean = false // shud be checkable only when terms dialos is opened atleast once
-    mounted () {
-      // TODO may be , cache the file somewhere in session storage or so.repeated service calls are not necessary
-      documentService.getTermsOfService('termsofuse').then(response => {
-        this.content = response.data.content
-        this.version = response.data.version_id
-      })
-    }
+  private readonly userProfile!: User
+  private termsDialog = false
+  private offsetTop = '0'
+  private termsAccepted = false
+  private content: string = ''
+  private version: string = ''
+  private canCheckTerms: boolean = false
 
-    get tooltipTxt () {
-      // return !this.canCheckTerms ? 'please read and agree to the terms of use' : 'please select terms of use'
-      return 'Please read and agree to the Terms Of Use'
-    }
+  async mounted () {
+    const response = await documentService.getTermsOfService('termsofuse')
+    this.content = response.data.content
+    this.version = response.data.version_id
+  }
 
-    @Watch('version')
-    onDocVersionChanged (val: string, oldVal: string) {
-      if (val === this.lastAcceptedVersion) {
-        this.termsAccepted = true
-        this.canCheckTerms = true
-        this.emitStatus()
-      }
-    }
+  get tooltipTxt () {
+    return 'Please read and agree to the Terms Of Use'
+  }
 
-    @Watch('lastAcceptedVersion')
-    onVersionChanged (val: string, oldVal: string) {
-      if (val === this.version) {
-        this.termsAccepted = true
-        this.canCheckTerms = true
-        this.emitStatus()
-      }
-    }
-
-    openDialog () {
-      this.termsDialog = true
+  @Watch('version')
+  onDocVersionChanged (val: string, oldVal: string) {
+    if (val === this.userProfile.userTerms.termsOfUseAcceptedVersion) {
+      this.termsAccepted = true
       this.canCheckTerms = true
+      this.emitStatus()
     }
+  }
 
-    onScroll (e) {
-      this.offsetTop = e.target.scrollTop
-    }
+  private openDialog () {
+    this.termsDialog = true
+    this.canCheckTerms = true
+  }
 
-    emitStatus () {
-      this.$emit('termsupdated', { 'termsversion': this.version, 'istermsaccepted': this.termsAccepted })
+  private onScroll (e) {
+    this.offsetTop = e.target.scrollTop
+  }
+
+  @Emit('terms-updated')
+  private emitStatus () {
+    return {
+      termsVersion: this.version,
+      isTermsAccepted: this.termsAccepted
     }
+  }
 }
 </script>
 
 <style lang="scss" scoped>
-    @import '../../assets/scss/theme.scss';
+@import '$assets/scss/theme.scss';
 
-    // Tighten up some of the spacing between rows
-    [class^="col"] {
-        padding-top: 0;
-        padding-bottom: 0;
-    }
+// Tighten up some of the spacing between rows
+[class^='col'] {
+  padding-top: 0;
+  padding-bottom: 0;
+}
 
-    .terms-checkbox {
-        pointer-events: auto !important;
-    }
+.terms-checkbox {
+  pointer-events: auto !important;
+}
 
-    .form__btns {
-        display: flex;
-        justify-content: flex-end;
-    }
+.form__btns {
+  display: flex;
+  justify-content: flex-end;
+}
 
-    .terms-checkbox-label {
-        display: flex;
-        align-items: center;
+.terms-checkbox-label {
+  display: flex;
+  align-items: center;
 
-        .v-btn {
-            height: auto;
-            margin-left: 0.1rem;
-            padding: 0.2rem;
-            text-decoration: underline;
-            font-size: 1rem;
-        }
-    }
+  .v-btn {
+    height: auto;
+    margin-left: 0.1rem;
+    padding: 0.2rem;
+    text-decoration: underline;
+    font-size: 1rem;
+  }
+}
 
-    .v-card__actions {
-        justify-content: center;
+.v-card__actions {
+  justify-content: center;
 
-        .v-btn {
-            width: 10rem;
-        }
-    }
+  .v-btn {
+    width: 10rem;
+  }
+}
 
-    // Terms and Conditions Container
-    $indent-width: 3rem;
+// Terms and Conditions Container
+$indent-width: 3rem;
 
-    .terms-container ::v-deep {
-        article {
-            padding: 2rem;
-            background: $gray1;
-        }
+.terms-container ::v-deep {
+  article {
+    padding: 2rem;
+    background: $gray1;
+  }
 
-        section {
-            margin-top: 2rem;
-        }
+  section {
+    margin-top: 2rem;
+  }
 
-        section header {
-            margin-bottom: 1rem;
-            color: $gray9;
-            text-transform: uppercase;
-            letter-spacing: -0.02rem;
-            font-size: 1.125rem;
-            font-weight: 700;
-        }
+  section header {
+    margin-bottom: 1rem;
+    color: $gray9;
+    text-transform: uppercase;
+    letter-spacing: -0.02rem;
+    font-size: 1.125rem;
+    font-weight: 700;
+  }
 
-        section header > span {
-            display: inline-block;
-            width: $indent-width;
-        }
+  section header > span {
+    display: inline-block;
+    width: $indent-width;
+  }
 
-        section div > p {
-            padding-left: $indent-width;
-        }
+  section div > p {
+    padding-left: $indent-width;
+  }
 
-        section p:last-child {
-            margin-bottom: 0;
-        }
+  section p:last-child {
+    margin-bottom: 0;
+  }
 
-        p {
-            position: relative;
-        }
+  p {
+    position: relative;
+  }
 
-        p + div {
-            margin-left: $indent-width;
-        }
+  p + div {
+    margin-left: $indent-width;
+  }
 
-        p > span {
-            position: absolute;
-            top: 0;
-            left: 0;
-        }
-    }
+  p > span {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+}
 </style>

--- a/auth-web/src/models/user.ts
+++ b/auth-web/src/models/user.ts
@@ -6,8 +6,10 @@ export interface User {
     username: string;
     contacts?: Contact[];
     modified?: Date
-    // eslint-disable-next-line camelcase
-    terms_of_use_version?: string,
-    // eslint-disable-next-line camelcase
-    is_terms_of_use_accepted?: boolean
+    userTerms?: UserTerms
+}
+
+export interface UserTerms {
+    isTermsOfUseAccepted: boolean
+    termsOfUseAcceptedVersion: string
 }

--- a/auth-web/src/services/user.services.ts
+++ b/auth-web/src/services/user.services.ts
@@ -25,10 +25,10 @@ export default class UserService {
     return Axios.get(`${ConfigHelper.getValue('VUE_APP_AUTH_ROOT_API')}/users/orgs`)
   }
 
-  static async updateUserTerms (identifier: string, termsversion: string,
-    istermsaccepted: boolean): Promise<AxiosResponse<User>> {
-    return Axios.patch(`${ConfigHelper.getValue('VUE_APP_AUTH_ROOT_API')}/users/${identifier}`, { termsversion: termsversion,
-      istermsaccepted: istermsaccepted })
+  static async updateUserTerms (identifier: string, termsVersion: string,
+    isTermsAccepted: boolean): Promise<AxiosResponse<User>> {
+    return Axios.patch(`${ConfigHelper.getValue('VUE_APP_AUTH_ROOT_API')}/users/${identifier}`, { termsversion: termsVersion,
+      istermsaccepted: isTermsAccepted })
   }
 
   static async deactivateUser (): Promise<AxiosResponse<User>> {


### PR DESCRIPTION
*Issue #:* 2086
https://github.com/bcgov/entity/issues/2086

*Description of changes:*

* Fix bug where closing Terms of Service dialog inadvertently accepted the terms
* Refactor/simplify the User Profile state with Terms of Service and usage of the store
* Camelcase conversion on API and improvements to schema export
* Change user deactivation to unaccept terms of service
* Add in a basic prettier config for formatting in vscode

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
