### PR TITLE
notify option showing wrongly in the confirm dialog

### DIFF
--- a/auth-web/src/views/management/UserManagement.vue
+++ b/auth-web/src/views/management/UserManagement.vue
@@ -66,20 +66,15 @@
 
     <!-- Confirm Action Dialog -->
     <ModalDialog
-      ref="confirmActionDialog"
-      :title="confirmActionTitle"
-      :text="confirmActionText"
-      dialog-class="notify-dialog"
-      max-width="640"
+            ref="confirmActionDialog"
+            :title="confirmActionTitle"
+            :text="confirmActionText"
+            dialog-class="notify-dialog"
+            max-width="640"
     >
       <template v-slot:icon>
         <v-icon large color="error">mdi-alert-circle-outline</v-icon>
       </template>
-      <template v-slot:text>
-        <div class="mb-8">{{ confirmActionText }}</div>
-        <v-checkbox sm hide-details color="primary" class="notify-checkbox" v-model="notifyUser" :label="$t('notifyChangeUserRoleMsg')"></v-checkbox>
-      </template>
-
       <template v-slot:actions>
         <v-btn large color="primary" @click="confirmHandler()">{{ primaryActionText }}</v-btn>
         <v-btn large color="default" @click="cancel()">{{ secondaryActionText }}</v-btn>

--- a/auth-web/src/views/management/UserManagement.vue
+++ b/auth-web/src/views/management/UserManagement.vue
@@ -66,11 +66,11 @@
 
     <!-- Confirm Action Dialog -->
     <ModalDialog
-            ref="confirmActionDialog"
-            :title="confirmActionTitle"
-            :text="confirmActionText"
-            dialog-class="notify-dialog"
-            max-width="640"
+      ref="confirmActionDialog"
+      :title="confirmActionTitle"
+      :text="confirmActionText"
+      dialog-class="notify-dialog"
+      max-width="640"
     >
       <template v-slot:icon>
         <v-icon large color="error">mdi-alert-circle-outline</v-icon>


### PR DESCRIPTION
*Issue #:*
@mengdong19 reported an issue with confirmation to send mail is being asked in the approve button.

*Description of changes:*
the modal is replaced with old code

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
