### PR TITLE
2103 : Redirecting the user to leaveteam success page

### DIFF
--- a/auth-web/src/components/auth/InterimLanding.vue
+++ b/auth-web/src/components/auth/InterimLanding.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-container>
+    <v-row justify="center">
+      <v-col cols="12" lg="8" class="text-center">
+        <v-icon size="48" :color="iconColor" class="mb-6">{{ icon }}</v-icon>
+        <h1 class="mb-5">{{ summary }}</h1>
+        <p class="mb-9"><slot name="description">{{ description }}</slot></p>
+        <slot name="actions">
+          <v-btn large link color="primary" href="./" v-if="showHomePageBtn">{{ $t('homeBtnLabel') }}</v-btn>
+        </slot>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+
+@Component({})
+export default class InterimLanding extends Vue {
+  @Prop({ default: '' }) private summary: string
+  @Prop({ default: '' }) private description: string
+  @Prop({ default: 'mdi-information-outline' }) private icon: string
+  @Prop({ default: 'primary' }) private iconColor: string
+  @Prop({ default: true }) private showHomePageBtn: boolean
+}
+</script>
+
+<style lang="scss" scoped>
+  @import "$assets/scss/theme.scss";
+
+  .container {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+  }
+</style>

--- a/auth-web/src/locales/en.json
+++ b/auth-web/src/locales/en.json
@@ -31,6 +31,7 @@
   "noPendingInvitationTitle": "No Pending Invitations",
   "noPendingInvitationMsg": "You don't have any pending invitations to BC Registries and Online Services.",
   "notifyChangeUserRoleMsg": "Notify user about this change",
+  "pendingInvitationTitle": "Thanks for joining the team {team} at BC Registries & Online Services.",
   "pendingInvitationMsg": "The administrator for this team needs to verify your invitation before you can access this application.",
   "noActiveUsersLabel": "No Active Users",
   "pageNotFoundTitle": "Page not found",
@@ -46,5 +47,9 @@
   "deactivateConfirmText": "Deactivating your Cooperatives Online profile will remove your contact information, and your access to associated teams and/or affiliated businesses.",
   "deactivateConfirmTextEmphasis": "This action cannot be undone.",
   "deactivateFailureTitle": "Deactivation Failed",
-  "deactivateFailureText": "Unable to deactivate your profile. If you are a team owner, please dissolve your team or transfer ownership first."
+  "deactivateFailureText": "Unable to deactivate your profile. If you are a team owner, please dissolve your team or transfer ownership first.",
+  "profileDeactivatedTitle": "Your profile has been deactivated.",
+  "profileDeactivatedMsg": "Your contact information, team associations and business affiliations have been removed.",
+  "leaveTeamTitle": "You have been removed from this team.",
+  "leaveTeamMsg": "If you want to regain access to this team, you will need a new invitation from the team owner."
 }

--- a/auth-web/src/router.ts
+++ b/auth-web/src/router.ts
@@ -8,6 +8,7 @@ import CreateTeamView from '@/views/CreateTeamView.vue'
 import Dashboard from '@/views/management/Dashboard.vue'
 import DuplicateTeamWarning from '@/views/DuplicateTeamWarning.vue'
 import KeyCloakService from '@/services/keycloak.services'
+import LeaveTeamLanding from '@/views/LeaveTeamLanding.vue'
 import PageNotFound from '@/views/PageNotFound.vue'
 import PaymentForm from '@/components/pay/PaymentForm.vue'
 import PaymentReturnForm from '@/components/pay/PaymentReturnForm.vue'
@@ -60,6 +61,7 @@ export function getRoutes (appFlavor: String) {
     { path: '/searchbusiness', component: SearchBusinessForm, props: true, meta: { requiresAuth: true, allowedRoles: [Role.Staff] } },
     { path: '/unauthorized', component: Unauthorized, props: true, meta: { requiresAuth: false } },
     { path: '/pendingapproval/:team_name?', component: PendingApproval, props: true, meta: { requiresAuth: false } },
+    { path: '/leaveteam', component: LeaveTeamLanding, props: true, meta: { requiresAuth: true } },
     { path: '*', component: PageNotFound }
   ]
 

--- a/auth-web/src/views/AcceptInvite.vue
+++ b/auth-web/src/views/AcceptInvite.vue
@@ -1,21 +1,14 @@
 <template>
-  <v-container>
-    <v-row justify="center">
-      <v-col cols="12" lg="8" class="text-center">
-        <div v-if="inviteError">
-          <v-icon size="48" color="error" class="mb-6">mdi-alert-circle-outline</v-icon>
-          <h1 class="mb-7">{{ $t('errorOccurredTitle')}}</h1>
-          <p class="mb-9">{{ $t('invitationProcessingErrorMsg')}}</p>
-          <v-btn large link color="primary" href="../">{{ $t('homeBtnLabel')}}</v-btn>
-        </div>
-      </v-col>
-    </v-row>
-  </v-container>
+  <div v-if="inviteError">
+    <interim-landing :summary="$t('errorOccurredTitle')" :description="$t('invitationProcessingErrorMsg')" iconColor="error" icon="mdi-alert-circle-outline">
+    </interim-landing>
+  </div>
 </template>
 
 <script lang="ts">
 import { Component, Mixins, Prop, Vue } from 'vue-property-decorator'
 import { mapActions, mapState } from 'vuex'
+import InterimLanding from '@/components/auth/InterimLanding.vue'
 import { Invitation } from '@/models/Invitation'
 import NextPageMixin from '@/components/auth/NextPageMixin.vue'
 import OrgModule from '@/store/modules/org'
@@ -31,7 +24,8 @@ import { getModule } from 'vuex-module-decorators'
   methods: {
     ...mapActions('org', ['acceptInvitation', 'syncOrganizations']),
     ...mapActions('user', ['getUserProfile'])
-  }
+  },
+  components: { InterimLanding }
 })
 export default class AcceptInvite extends Mixins(NextPageMixin) {
   private orgStore = getModule(OrgModule, this.$store)

--- a/auth-web/src/views/AcceptInviteLanding.vue
+++ b/auth-web/src/views/AcceptInviteLanding.vue
@@ -1,35 +1,29 @@
 <template>
-  <v-container>
-    <v-row justify="center">
-      <v-col cols="12" lg="8" class="text-center">
-        <div v-if="!tokenExpiry && !tokenError">
-          <v-icon size="48" color="primary" class="mb-6">mdi-login-variant</v-icon>
-          <h1 class="mb-7">{{ $t('acceptInviteLandingTitle') }}</h1>
-          <p class="mb-9">{{ $t('acceptInviteLandingMessage') }}</p>
+  <div>
+    <div v-if="!tokenExpired && !tokenError">
+      <interim-landing :summary="$t('acceptInviteLandingTitle')" :description="$t('acceptInviteLandingMessage')" icon="mdi-login-variant" showHomePageBtn="false">
+        <template v-slot:actions>
           <v-btn v-if="!isUserSignedIn()" large link color="primary" @click="redirectToSignin()">{{ $t('loginBtnLabel') }}</v-btn>
           <v-btn v-if="isUserSignedIn()" large link color="primary" @click="redirectToConfirm()">{{ $t('acceptButtonLabel') }}</v-btn>
-        </div>
-        <div v-if="tokenExpiry">
-          <v-icon size="48" color="error" class="mb-6">mdi-alert-circle-outline</v-icon>
-          <h1 class="mb-7">{{ $t('expiredInvitationTitle')}}</h1>
-          <p class="mb-9">{{ $t('expiredInvitationMessage')}}</p>
-          <v-btn large link color="primary" href="../">{{ $t('homeBtnLabel')}}</v-btn>
-        </div>
-        <div v-if="tokenError">
-          <v-icon size="48" color="error" class="mb-6">mdi-alert-circle-outline</v-icon>
-          <h1 class="mb-7">{{ $t('errorOccurredTitle')}}</h1>
-          <p class="mb-9">{{ $t('invitationProcessingErrorMsg')}}</p>
-          <v-btn large link color="primary" href="../">{{ $t('homeBtnLabel')}}</v-btn>
-        </div>
-      </v-col>
-    </v-row>
-  </v-container>
+        </template>
+      </interim-landing>
+    </div>
+    <div v-if="tokenExpired">
+      <interim-landing :summary="$t('expiredInvitationTitle')" :description="$t('expiredInvitationMessage')" icon="mdi-alert-circle-outline" iconColor="error">
+      </interim-landing>
+    </div>
+    <div v-if="tokenError">
+      <interim-landing :summary="$t('errorOccurredTitle')" :description="$t('invitationProcessingErrorMsg')" icon="mdi-alert-circle-outline" iconColor="error">
+      </interim-landing>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import ConfigHelper from '@/util/config-helper'
 import { EmptyResponse } from '@/models/global'
+import InterimLanding from '@/components/auth/InterimLanding.vue'
 import OrgModule from '@/store/modules/org'
 import { getModule } from 'vuex-module-decorators'
 import { mapActions } from 'vuex'
@@ -37,7 +31,8 @@ import { mapActions } from 'vuex'
 @Component({
   methods: {
     ...mapActions('org', ['validateInvitationToken'])
-  }
+  },
+  components: { InterimLanding }
 })
 export default class AcceptInviteLanding extends Vue {
   private orgStore = getModule(OrgModule, this.$store);
@@ -78,16 +73,3 @@ export default class AcceptInviteLanding extends Vue {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-  @import "$assets/scss/theme.scss";
-
-  .container {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
-  }
-
-  .v-icon {
-    font-size: 4rem;
-  }
-</style>

--- a/auth-web/src/views/LeaveTeamLanding.vue
+++ b/auth-web/src/views/LeaveTeamLanding.vue
@@ -1,15 +1,18 @@
 <template>
-  <interim-landing :summary="$t('pageNotFoundTitle')" :description="$t('pageNotFoundMsg')" icon="mdi-alert-circle-outline" iconColor="error">
+  <interim-landing :summary="$t('leaveTeamTitle')" :description="$t('leaveTeamMsg')">
   </interim-landing>
 </template>
 
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
 import InterimLanding from '@/components/auth/InterimLanding.vue'
+
 import Vue from 'vue'
+
 @Component({
   components: { InterimLanding }
 })
-export default class PageNotFound extends Vue {
+export default class LeaveTeamLanding extends Vue {
+
 }
 </script>

--- a/auth-web/src/views/PendingApproval.vue
+++ b/auth-web/src/views/PendingApproval.vue
@@ -1,41 +1,29 @@
 <template>
-  <v-container>
-    <v-row justify="center">
-      <v-col cols="12" lg="8" class="text-center">
-        <v-icon size="48" color="primary" class="mb-6">mdi-information-outline</v-icon>
-        <div v-if="$route.params.team_name">
-          <h1 class="mb-5">Thanks for joining the team {{ $route.params.team_name }} at BC Registries & Online Services.</h1>
-          <p class="mb-9">{{ $t('pendingInvitationMsg')}}</p>
-        </div>
-        <div v-if="!$route.params.team_name">
-          <h1 class="mb-7">{{ $t('noPendingInvitationTitle')}}</h1>
-          <p class="mb-9">{{ $t('noPendingInvitationMsg')}}</p>
-        </div>
-        <v-btn large link color="primary" href="../">{{ $t('homeBtnLabel')}}</v-btn>
-      </v-col>
-    </v-row>
-  </v-container>
+  <div>
+    <div v-if="$route.params.team_name">
+      <interim-landing :summary="$t('pendingInvitationTitle', { team: $route.params.team_name })" :description="$t('pendingInvitationMsg')" icon="mdi-information-outline">
+      </interim-landing>
+    </div>
+    <div v-if="!$route.params.team_name">
+      <interim-landing :summary="$t('noPendingInvitationTitle')" :description="$t('noPendingInvitationMsg')" icon="mdi-information-outline">
+      </interim-landing>
+    </div>
+  </div>
 </template>
 
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
+import InterimLanding from '@/components/auth/InterimLanding.vue'
 import { Role } from '@/util/constants'
 import { UserInfo } from '@/models/userInfo'
 import Vue from 'vue'
 import { mapState } from 'vuex'
 
-  @Component({})
-export default class Unauthorized extends Vue {
+@Component({
+  components: { InterimLanding }
+})
+export default class PendingApproval extends Vue {
   mounted () {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-  @import "$assets/scss/theme.scss";
-
-  .container {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
-  }
-</style>

--- a/auth-web/src/views/ProfileDeactivated.vue
+++ b/auth-web/src/views/ProfileDeactivated.vue
@@ -1,35 +1,16 @@
 <template>
-  <v-container>
-    <v-row justify="center">
-      <v-col cols="12" lg="8" class="text-center">
-        <v-icon size="48" color="primary" class="mb-6">mdi-information-outline</v-icon>
-        <div>
-          <h1 class="mb-5">Your profile has been deactivated.</h1>
-          <p class="mb-9">Your contact information, team associations and business affiliations have been removed.</p>
-        </div>
-        <v-btn large link color="primary" @click="goHome()">{{ $t('homeBtnLabel')}}</v-btn>
-      </v-col>
-    </v-row>
-  </v-container>
+  <interim-landing :summary="$t('profileDeactivatedTitle')" :description="$t('profileDeactivatedMsg')" icon="mdi-information-outline">
+  </interim-landing>
 </template>
 
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
+import InterimLanding from '@/components/auth/InterimLanding.vue'
 import Vue from 'vue'
 
-@Component({})
+@Component({
+  components: { InterimLanding }
+})
 export default class ProfileDeactivated extends Vue {
-  private goHome () {
-    this.$router.push('/')
-  }
 }
 </script>
-
-<style lang="scss" scoped>
-  @import "$assets/scss/theme.scss";
-
-  .container {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
-  }
-</style>

--- a/auth-web/src/views/management/UserManagement.vue
+++ b/auth-web/src/views/management/UserManagement.vue
@@ -354,7 +354,7 @@ export default class UserManagement extends Vue {
   private async leave () {
     await this.leaveTeam(this.myOrgMembership.id)
     this.$refs.confirmActionDialog.close()
-    this.$router.push('/')
+    this.$router.push('/leaveteam')
   }
 
   private close () {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2103

*Description of changes:*
- Created new UI for leaveteam success 
- Created a new component which can be used for these kind of UIs
- Changed all the existing duplicate code to use the new component

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
