### PR TITLE
[entity2030] Fix Role Menu Display in Invite Users Interface (IE11 issue)

### DIFF
--- a/auth-web/src/components/auth/InviteUsersForm.vue
+++ b/auth-web/src/components/auth/InviteUsersForm.vue
@@ -12,14 +12,17 @@
               :rules="emailRules"
               :data-test="getIndexedTag('email-address', index)"
             ></v-text-field>
+
             <v-overflow-btn
-              filled v-model="invitations[index].selectedRole.name"
-              class="ml-3"
-              :items="availableRoles"
+              filled
+              class="select-role-btn ml-2"
+              v-model="invitations[index].selectedRole.name"
               item-text="name"
               item-value="name"
+              :items="availableRoles"
               :value="availableRoles[0]"
               :data-test="getIndexedTag('role-selector', index)"
+              menu-props="dense"
             >
               <template v-slot:selection="{ item }">
                 {{ item.name }}
@@ -36,6 +39,7 @@
                   </v-list-item-content>
                 </div>
               </template>
+
             </v-overflow-btn>
 
             <v-btn icon class="mt-3 ml-1"
@@ -233,7 +237,7 @@ export default class InviteUsersForm extends Vue {
 
   .role-container {
     display: flex;
-    max-width: 20rem;
+    width: 20rem;
 
     .v-list-item__title {
       letter-spacing: -0.02rem;
@@ -251,5 +255,11 @@ export default class InviteUsersForm extends Vue {
 
   .v-list-item.active {
     background: $BCgovBlue0;
+  }
+
+  .select-role-btn {
+    ::v-deep .v-input__slot {
+      padding-right: 0 !important
+    }
   }
 </style>


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/entity2030

Fixed an issue with the role menu display in the Invite Users interface (IE11)

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
