### PR TITLE
Multiple email has to be separated by comma instead of spaces

### DIFF
--- a/auth-api/src/auth_api/services/invitation.py
+++ b/auth-api/src/auth_api/services/invitation.py
@@ -213,11 +213,7 @@ class Invitation:
         admin_list = UserService.get_admins_for_membership(membership_id)
         invitation: InvitationModel = InvitationModel.find_invitation_by_id(invitation_id)
         context_path = CONFIG.AUTH_WEB_TOKEN_CONFIRM_PATH
-        admin_emails = ''
-        for contact in admin_list:
-            if contact.contacts:
-                admin_emails = contact.contacts[0].contact.email + ' ' + admin_emails
-
+        admin_emails = ",".join([str(x.contacts[0].contact.email) for x in admin_list if x.contacts])
         Invitation.send_admin_notification(user.as_dict(),
                                            '{}/{}'.format(invitation_origin, context_path),
                                            admin_emails, invitation.membership[0].org.name)


### PR DESCRIPTION
Multiple email has to be separated by comma instead of spaces

*Issue #:*
https://github.com/bcgov/entity/issues/2260

*Description of changes:*

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
