### PR TITLE
serviceaccount accessing orgs without affiliation

### DIFF
--- a/auth-api/src/auth_api/models/views/authorization.py
+++ b/auth-api/src/auth_api/models/views/authorization.py
@@ -18,8 +18,7 @@ Authorization view wraps details on the entities and membership through orgs and
 
 import uuid
 
-from sqlalchemy import Column, Integer, String
-from sqlalchemy import Column, Integer, String, Integer, and_, or_
+from sqlalchemy import Column, String, Integer, and_, or_
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import expression
 
@@ -55,7 +54,7 @@ class Authorization(db.Model):
         return cls.query.filter_by(corp_type_code=corp_type, business_identifier=business_identifier) \
             .order_by(expression.case(((Authorization.org_membership == OWNER, 1),
                                        (Authorization.org_membership == ADMIN, 2),
-                                       (Authorization.org_membership == MEMBER, 3))))\
+                                       (Authorization.org_membership == MEMBER, 3)))) \
             .first()
 
     @classmethod

--- a/auth-api/src/auth_api/models/views/authorization.py
+++ b/auth-api/src/auth_api/models/views/authorization.py
@@ -19,6 +19,7 @@ Authorization view wraps details on the entities and membership through orgs and
 import uuid
 
 from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, Integer, and_, or_
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import expression
 
@@ -65,7 +66,9 @@ class Authorization(db.Model):
     @classmethod
     def find_user_authorization_by_org_id_and_corp_type(cls, org_id: int, corp_type: str):
         """Return authorization view object."""
-        return cls.query.filter_by(corp_type_code=corp_type, org_id=org_id).order_by(
+        return db.session.query(Authorization).filter(
+            and_(Authorization.org_id == org_id,
+                 or_(Authorization.corp_type_code == corp_type, Authorization.corp_type_code.is_(None)))).order_by(
             expression.case(((Authorization.org_membership == OWNER, 1),
                              (Authorization.org_membership == ADMIN, 2),
                              (Authorization.org_membership == MEMBER, 3)))).first()

--- a/auth-api/tests/unit/models/views/test_authorization.py
+++ b/auth-api/tests/unit/models/views/test_authorization.py
@@ -116,6 +116,14 @@ def test_find_user_authorization_by_org_id_and_invalid_corp_type(session):  # py
 
     assert authorization is None
 
+def test_find_user_authorization_by_org_id_and_invalid_corp_type_no_affliation(session):  # pylint:disable=unused-argument
+    """Assert that authorization view is returning result for an unclaimed/unaffiliated organisation for even invalid corp type """
+    user = factory_user_model()
+    org = factory_org_model()
+    factory_membership_model(user.id, org.id)
+    authorization = Authorization.find_user_authorization_by_org_id_and_corp_type(org.id, 'invalid_corp_type')
+    assert authorization is not None
+
 
 def test_find_user_authorization_by_business_number_and_corp_type(session):  # pylint:disable=unused-argument
     """Assert that authorization view returns result when fetched using Corp type instead of jwt.


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2024

*Description of changes:*

This change I missed to commit for service account story. Service accounts should be able to access the organisation without any affiliation.Some of the postman scripts need this.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
