### PR TITLE
add a reset data endpoint and serivce.

### DIFF
--- a/auth-api/src/auth_api/__init__.py
+++ b/auth-api/src/auth_api/__init__.py
@@ -51,7 +51,7 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
             integrations=[FlaskIntegration()]
         )
 
-    from auth_api.resources import API_BLUEPRINT, OPS_BLUEPRINT  # pylint: disable=import-outside-toplevel
+    from auth_api.resources import API_BLUEPRINT, OPS_BLUEPRINT, POSTMAN_BLUEPRINT  # pylint: disable=import-outside-toplevel
 
     db.init_app(app)
     ma.init_app(app)
@@ -59,6 +59,9 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
 
     app.register_blueprint(API_BLUEPRINT)
     app.register_blueprint(OPS_BLUEPRINT)
+
+    if os.getenv('FLASK_ENV', 'production') in ['development', 'testing']:
+        app.register_blueprint(POSTMAN_BLUEPRINT)
 
     setup_jwt_manager(app, JWT)
 

--- a/auth-api/src/auth_api/__init__.py
+++ b/auth-api/src/auth_api/__init__.py
@@ -51,7 +51,7 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
             integrations=[FlaskIntegration()]
         )
 
-    from auth_api.resources import API_BLUEPRINT, OPS_BLUEPRINT, POSTMAN_BLUEPRINT  # pylint: disable=import-outside-toplevel
+    from auth_api.resources import API_BLUEPRINT, OPS_BLUEPRINT, TEST_BLUEPRINT  # pylint: disable=import-outside-toplevel
 
     db.init_app(app)
     ma.init_app(app)
@@ -61,7 +61,7 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app.register_blueprint(OPS_BLUEPRINT)
 
     if os.getenv('FLASK_ENV', 'production') in ['development', 'testing']:
-        app.register_blueprint(POSTMAN_BLUEPRINT)
+        app.register_blueprint(TEST_BLUEPRINT)
 
     setup_jwt_manager(app, JWT)
 

--- a/auth-api/src/auth_api/models/base_model.py
+++ b/auth-api/src/auth_api/models/base_model.py
@@ -41,12 +41,12 @@ class BaseModel(db.Model):
     @declared_attr
     def created_by(cls):  # pylint:disable=no-self-argument, # noqa: N805
         """Return relationship for created by."""
-        return relationship('User', foreign_keys=[cls.created_by_id], uselist=False)
+        return relationship('User', foreign_keys=[cls.created_by_id], post_update=True, uselist=False)
 
     @declared_attr
     def modified_by(cls):  # pylint:disable=no-self-argument, # noqa: N805
         """Return relationship for modified by."""
-        return relationship('User', foreign_keys=[cls.modified_by_id], uselist=False)
+        return relationship('User', foreign_keys=[cls.modified_by_id], post_update=True, uselist=False)
 
     @staticmethod
     def _get_current_user():

--- a/auth-api/src/auth_api/models/contact.py
+++ b/auth-api/src/auth_api/models/contact.py
@@ -18,6 +18,7 @@ physical addresses, emails, and phone numbers.
 """
 
 from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
 
 from .base_model import BaseModel
 
@@ -40,3 +41,5 @@ class Contact(BaseModel):  # pylint: disable=too-few-public-methods
     email = Column('email', String(100))
     # MVP contact has been migrated over to the contact linking table (revised data model)
     entity_id = Column(Integer, ForeignKey('entity.id'))
+
+    links = relationship('ContactLink', cascade="all, delete-orphan")

--- a/auth-api/src/auth_api/resources/__init__.py
+++ b/auth-api/src/auth_api/resources/__init__.py
@@ -21,7 +21,7 @@ All services have 2 defaults sets of endpoints:
 That are used to expose operational health information about the service, and meta information.
 """
 
-from flask import Blueprint
+from flask import Blueprint, current_app
 from sbc_common_components.exception_handling.exception_handler import ExceptionHandler
 
 from .apihelper import Api
@@ -33,6 +33,7 @@ from .logout import API as LOGOUT_API
 from .meta import API as META_API
 from .ops import API as OPS_API
 from .org import API as ORG_API
+from .reset import API as RESET_API
 from .token import API as TOKEN_API
 from .user import API as USER_API
 
@@ -78,3 +79,18 @@ API.add_namespace(ORG_API, path='/orgs')
 API.add_namespace(INVITATION_API, path='/invitations')
 API.add_namespace(DOCUMENTS_API, path='/documents')
 API.add_namespace(CODES_API, path='/codes')
+
+POSTMAN_BLUEPRINT = Blueprint('POSTMAN', __name__, url_prefix='/postman')
+
+API_POSTMAN = Api(
+    POSTMAN_BLUEPRINT,
+    title='Authentication API for postman test',
+    version='1.0',
+    description='The API for the postman test',
+    security=['apikey'],
+    authorizations=AUTHORIZATIONS,
+)
+
+HANDLER = ExceptionHandler(API_POSTMAN)
+
+API_POSTMAN.add_namespace(RESET_API, path='/reset')

--- a/auth-api/src/auth_api/resources/__init__.py
+++ b/auth-api/src/auth_api/resources/__init__.py
@@ -80,17 +80,17 @@ API.add_namespace(INVITATION_API, path='/invitations')
 API.add_namespace(DOCUMENTS_API, path='/documents')
 API.add_namespace(CODES_API, path='/codes')
 
-POSTMAN_BLUEPRINT = Blueprint('POSTMAN', __name__, url_prefix='/postman')
+TEST_BLUEPRINT = Blueprint('TEST', __name__, url_prefix='/test')
 
-API_POSTMAN = Api(
-    POSTMAN_BLUEPRINT,
-    title='Authentication API for postman test',
+API_TEST = Api(
+    TEST_BLUEPRINT,
+    title='Authentication API for testing',
     version='1.0',
-    description='The API for the postman test',
+    description='The API for the testing',
     security=['apikey'],
     authorizations=AUTHORIZATIONS,
 )
 
-HANDLER = ExceptionHandler(API_POSTMAN)
+HANDLER = ExceptionHandler(API_TEST)
 
-API_POSTMAN.add_namespace(RESET_API, path='/reset')
+API_TEST.add_namespace(RESET_API, path='/reset')

--- a/auth-api/src/auth_api/resources/reset.py
+++ b/auth-api/src/auth_api/resources/reset.py
@@ -39,7 +39,7 @@ class Reset(Resource):
     @TRACER.trace()
     @cors.crossdomain(origin='*')
     @_JWT.requires_auth
-    @_JWT.has_one_of_roles([Role.POSTMAN.value])
+    @_JWT.has_one_of_roles([Role.TESTER.value])
     def post():
         """Cleanup test data by the provided token."""
         token = g.jwt_oidc_token_info

--- a/auth-api/src/auth_api/resources/reset.py
+++ b/auth-api/src/auth_api/resources/reset.py
@@ -1,0 +1,52 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Endpoints to reset test data from database."""
+
+from flask import g
+from flask_restplus import Namespace, Resource, cors
+
+from auth_api import status as http_status
+from auth_api.exceptions import BusinessException
+from auth_api.jwt_wrapper import JWTWrapper
+from auth_api.services import ResetTestData as ResetService
+from auth_api.tracer import Tracer
+from auth_api.utils.roles import Role
+from auth_api.utils.util import cors_preflight
+
+
+API = Namespace('reset', description='Authentication System - Reset test data')
+TRACER = Tracer.get_instance()
+_JWT = JWTWrapper.get_instance()
+
+
+@cors_preflight('POST,OPTIONS')
+@API.route('', methods=['POST', 'OPTIONS'])
+class Reset(Resource):
+    """Cleanup test data by the provided token."""
+
+    @staticmethod
+    @TRACER.trace()
+    @cors.crossdomain(origin='*')
+    @_JWT.requires_auth
+    @_JWT.has_one_of_roles([Role.POSTMAN.value])
+    def post():
+        """Cleanup test data by the provided token."""
+        token = g.jwt_oidc_token_info
+
+        try:
+            ResetService.reset(token)
+            response, status = '', http_status.HTTP_204_NO_CONTENT
+        except BusinessException as exception:
+            response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
+        return response, status

--- a/auth-api/src/auth_api/services/__init__.py
+++ b/auth-api/src/auth_api/services/__init__.py
@@ -20,4 +20,5 @@ from .entity import Entity
 from .invitation import Invitation
 from .membership import Membership
 from .org import Org
+from .reset import ResetTestData
 from .user import User

--- a/auth-api/src/auth_api/services/reset.py
+++ b/auth-api/src/auth_api/services/reset.py
@@ -1,0 +1,39 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Service for reset test data."""
+
+from auth_api.models import User as UserModel
+from auth_api.models import db
+
+
+class ResetTestData:  # pylint:disable=too-few-public-methods
+    """Cleanup all the data from model by created_by column."""
+
+    def __init__(self):
+        """Return a reset test data service instance."""
+
+    @staticmethod
+    def reset(token):
+        """Cleanup all the data from all tables create by the provided user id."""
+        user = UserModel.find_by_jwt_token(token)
+        if user:
+            for model_class in db.Model._decl_class_registry.values():  # pylint:disable=protected-access
+                if hasattr(model_class, 'created_by_id'):
+                    for model in model_class.query.filter_by(created_by_id=user.id).all():
+                        model.delete()
+
+            user.modified_by = None
+            user.modified_by_id = None
+            db.session.delete(user)
+            db.session.commit()

--- a/auth-api/src/auth_api/services/reset.py
+++ b/auth-api/src/auth_api/services/reset.py
@@ -28,6 +28,7 @@ class ResetTestData:  # pylint:disable=too-few-public-methods
         """Cleanup all the data from all tables create by the provided user id."""
         user = UserModel.find_by_jwt_token(token)
         if user:
+            # TODO need to find a way to avoid using protected function
             for model_class in db.Model._decl_class_registry.values():  # pylint:disable=protected-access
                 if hasattr(model_class, 'created_by_id'):
                     for model in model_class.query.filter_by(created_by_id=user.id).all():

--- a/auth-api/src/auth_api/utils/roles.py
+++ b/auth-api/src/auth_api/utils/roles.py
@@ -25,6 +25,7 @@ class Role(Enum):
     EDITOR = 'edit'
     ADMIN = 'admin'
     SYSTEM = 'system'
+    POSTMAN = 'postman'
 
 
 # Membership types

--- a/auth-api/src/auth_api/utils/roles.py
+++ b/auth-api/src/auth_api/utils/roles.py
@@ -25,7 +25,7 @@ class Role(Enum):
     EDITOR = 'edit'
     ADMIN = 'admin'
     SYSTEM = 'system'
-    POSTMAN = 'postman'
+    TESTER = 'tester'
 
 
 # Membership types

--- a/auth-api/tests/postman/auth-api.postman_collection.json
+++ b/auth-api/tests/postman/auth-api.postman_collection.json
@@ -1,0 +1,2868 @@
+{
+	"info": {
+		"_postman_id": "433fa9b5-4fb1-47b7-8e58-f862044c8eab",
+		"name": "auth-api-invitation",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Owner  Creates Org , Affliate , Sends . Invitation",
+			"item": [
+				{
+					"name": "Login Owner",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"firstname\");",
+									"    pm.expect(pm.response.text()).to.include(\"lastname\");",
+									"    pm.expect(pm.response.text()).to.include(\"username\");",
+									"});",
+									"",
+									"",
+									"var auth_token = pm.request.getHeaders()['Authorization'];",
+									"auth_token = auth_token.replace('Bearer ', '');",
+									"postman.setEnvironmentVariable('userToken', auth_token);",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"username\", jsonData.username);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "accessToken",
+									"value": "{{accessToken}}",
+									"type": "string"
+								},
+								{
+									"key": "tokenType",
+									"value": "bearer",
+									"type": "string"
+								},
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/users",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get user profile (me)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c2b33758-d4ed-4183-91dc-6faa99e55a04",
+								"exec": [
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"firstname\");",
+									"    pm.expect(pm.response.text()).to.include(\"lastname\");",
+									"    pm.expect(pm.response.text()).to.include(\"username\");",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"username\", jsonData.username);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/v1/users/@me",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"@me"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add contact to user profile (me)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"email\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"email\": \"{{sample_email}}\",\r\n   \"phone\": \"{{sample_phone}}\",\r\n   \"phoneExtension\": \"{{sample_extension}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/users/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update contact on user profile (me)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"email\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"email\": \"{{sample_updated_email}}\",\r\n   \"phone\": \"{{sample_phone}}\",\r\n   \"phoneExtension\": \"{{sample_extension}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/users/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete contact on user profile (me)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"email\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/users/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add contact back to user profile (me)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"email\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"email\": \"{{sample_email}}\",\r\n   \"phone\": \"{{sample_phone}}\",\r\n   \"phoneExtension\": \"{{sample_extension}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/users/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add entity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"businessIdentifier\");",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"entity_identifier\", jsonData.id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"businessIdentifier\": \"{{business_identifier}}\",\r\n   \"name\": \"{{business_name}}\",\r\n   \"businessNumber\": \"{{business_number}}\",\r\n   \"passCode\": \"{{entity_passcode}}\",\r\n    \"corpTypeCode\": \"CP\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/entities",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"entities"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get entity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"userId\", jsonData.id);",
+									"",
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"businessIdentifier\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/entities/{{business_identifier}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"entities",
+								"{{business_identifier}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get entity authorizations",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"userId\", jsonData.id);",
+									"",
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"businessIdentifier\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/entities/{{business_identifier}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"entities",
+								"{{business_identifier}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add contact to entity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"businessIdentifier\");",
+									"    pm.expect(pm.response.text()).to.include(\"contacts\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"email\": \"{{sample_email}}\",\r\n   \"phone\": \"{{sample_phone}}\",\r\n   \"phoneExtension\": \"{{sample_extension}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/entities/{{business_identifier}}/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"entities",
+								"{{business_identifier}}",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update contact for entity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"businessIdentifier\");",
+									"    pm.expect(pm.response.text()).to.include(\"contacts\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"email\": \"{{sample_updated_email}}\",\r\n   \"phone\": \"{{sample_phone}}\",\r\n   \"phoneExtension\": \"{{sample_extension}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/entities/{{business_identifier}}/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"entities",
+								"{{business_identifier}}",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete contact for entity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"businessIdentifier\");",
+									"    pm.expect(pm.response.text()).to.include(\"contacts\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{api_url}}/api/v1/entities/{{business_identifier}}/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"entities",
+								"{{business_identifier}}",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add contact back to entity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"businessIdentifier\");",
+									"    pm.expect(pm.response.text()).to.include(\"contacts\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"email\": \"{{sample_email}}\",\r\n   \"phone\": \"{{sample_phone}}\",\r\n   \"phoneExtension\": \"{{sample_extension}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/entities/{{business_identifier}}/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"entities",
+								"{{business_identifier}}",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create an org",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "58bd542c-3498-4e98-8d28-9fe2eb62ea3b",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"id\");",
+									"    //pm.expect(pm.response.text()).to.include(\"affiliatedEntities\")",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"org_identifier\", jsonData.id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\": \"{{test_org_name}}\"\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get a specific org",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"userId\", jsonData.id);",
+									"",
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"id\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update a specific org",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\": \"{{test_org_name_updated}}\"\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add contact to org",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"email\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"email\": \"{{sample_email}}\",\r\n   \"phone\": \"{{sample_phone}}\",\r\n   \"phoneExtension\": \"{{sample_extension}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create an affiliation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"var auth_token = pm.request.getHeaders()['Authorization'];",
+									"auth_token = auth_token.replace('Bearer ', '');",
+									"postman.setEnvironmentVariable('userToken', auth_token);",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"username\", jsonData.username);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n   \"businessIdentifier\": \"{{business_identifier}}\",\r\n   \"passCode\": \"{{entity_passcode}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/affiliations",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"affiliations"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete an affiliation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/affiliations/{{business_identifier}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"affiliations",
+								"{{business_identifier}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create back an affiliation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"var auth_token = pm.request.getHeaders()['Authorization'];",
+									"auth_token = auth_token.replace('Bearer ', '');",
+									"postman.setEnvironmentVariable('userToken', auth_token);",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"username\", jsonData.username);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n   \"businessIdentifier\": \"{{business_identifier}}\",\r\n   \"passCode\": \"{{entity_passcode}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/affiliations",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"affiliations"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get entities affiliated with an org",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"businessIdentifier\");",
+									"    pm.expect(pm.response.text()).to.include(\"name\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/affiliations",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"affiliations"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get orgs for user (me)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"id\");",
+									"    pm.expect(pm.response.text()).to.include(\"name\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{api_url}}/api/v1/users/orgs",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"orgs"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Send invitation for org",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"membershipType\");",
+									"    pm.expect(pm.response.text()).to.include(\"org\");",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"invitation_id\", jsonData.id);",
+									"pm.environment.set(\"inv_token\",jsonData.token)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"recipientEmail\": \"{{member_email}}\",\r\n   \"sentDate\": \"{{current_timestamp}}\",\r\n   \"membership\": [\r\n   \t\t{\r\n   \t\t\t\"membershipType\": \"MEMBER\",\r\n   \t\t\t\"orgId\": {{org_identifier}}\r\n   \t\t}\r\n   \t]\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/invitations",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"invitations"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get invitation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c17708a1-0325-46f7-8b21-b1991a1270d2",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"membership\");",
+									"    pm.expect(pm.response.text()).to.include(\"recipientEmail\");",
+									"    pm.expect(pm.response.text()).to.include(\"sentDate\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/v1/invitations/{{invitation_id}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"invitations",
+								"{{invitation_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Active members for org",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"userId\", jsonData.id);",
+									"",
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"membershipTypeCode\");",
+									"    pm.expect(pm.response.text()).to.include(\"user\");",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"// take the latest id",
+									"//pm.environment.set(\"member_id\", Math.max.apply(Math, jsonData.members.map(function(o) { return o.id; })));"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/members",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"members"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "The suit handles following cases\n\n1) Login Owner",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "f0439800-c800-4b5c-ba3d-054da6d9942f",
+						"type": "text/javascript",
+						"exec": [
+							"var current_timestamp = new Date()",
+							"postman.setEnvironmentVariable(\"current_timestamp\", current_timestamp.toISOString());",
+							"",
+							"function getvar(variableName) {",
+							"    let value = pm.variables.get(variableName);",
+							"    if (!value) throw new Error(",
+							"        `Variable '${variableName}' is not defined.`);",
+							"        return value;",
+							"    }",
+							"    ",
+							"    let tokenUrl = getvar('token_url');",
+							"    let accountId = getvar('service-account-id');",
+							"    let accountSecret = getvar('service-account-secret');",
+							"    ",
+							"    let getTokenRequest = {",
+							"    method: 'POST',",
+							"    url: tokenUrl,",
+							"    header: {",
+							"        'content-type': 'application/x-www-form-urlencoded',",
+							"        'Authorization': 'Basic '+ btoa(accountId+':'+accountSecret)",
+							"    },",
+							"    ",
+							"    body: 'grant_type=client_credentials'",
+							"",
+							"};",
+							"",
+							"pm.sendRequest(getTokenRequest, (err, response) => {",
+							"    let jsonResponse = response.json(),",
+							"    newAccessToken = jsonResponse.access_token;",
+							"    ",
+							"    console.log({ err, jsonResponse, newAccessToken })",
+							"    ",
+							"    pm.environment.set('accessToken', newAccessToken);",
+							"    pm.variables.set('accessToken', newAccessToken);",
+							"",
+							"});",
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "0285ff56-6d02-41ff-971b-6dc195287c95",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": []
+		},
+		{
+			"name": "Member accepts invitation",
+			"item": [
+				{
+					"name": "Login Member",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"firstname\");",
+									"    pm.expect(pm.response.text()).to.include(\"lastname\");",
+									"    pm.expect(pm.response.text()).to.include(\"username\");",
+									"});",
+									"",
+									"",
+									"var auth_token = pm.request.getHeaders()['Authorization'];",
+									"auth_token = auth_token.replace('Bearer ', '');",
+									"postman.setEnvironmentVariable('memberToken', auth_token);",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"username\", jsonData.username);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "accessToken",
+									"value": "{{memberAccessToken}}",
+									"type": "string"
+								},
+								{
+									"key": "tokenType",
+									"value": "bearer",
+									"type": "string"
+								},
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/users",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add contact to user profile (me)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"email\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{memberToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{  \r\n   \"email\": \"{{member_email}}\",\r\n   \"phone\": \"{{member_phone}}\",\r\n   \"phoneExtension\": \"{{member_extension}}\"\r\n}"
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/users/contacts",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users",
+								"contacts"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Validate Invitation Token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "50064553-46fd-4d90-a5a9-35690fa4386d",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{memberToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/v1/invitations/tokens/{{inv_token}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"invitations",
+								"tokens",
+								"{{inv_token}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Accept Invitation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "50064553-46fd-4d90-a5a9-35690fa4386d",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"status\");",
+									"});",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"new_member_id\", jsonData.id);",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{memberToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/invitations/tokens/{{inv_token}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"invitations",
+								"tokens",
+								"{{inv_token}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "ea73587d-be81-4b59-9dbd-056148082e90",
+						"type": "text/javascript",
+						"exec": [
+							"var current_timestamp = new Date()",
+							"postman.setEnvironmentVariable(\"current_timestamp\", current_timestamp.toISOString());",
+							"",
+							"function getvar(variableName) {",
+							"    let value = pm.variables.get(variableName);",
+							"    if (!value) throw new Error(",
+							"        `Variable '${variableName}' is not defined.`);",
+							"        return value;",
+							"    }",
+							"    ",
+							"    let tokenUrl = getvar('token_url');",
+							"    let accountId = getvar('service-account-member-id');",
+							"    let accountSecret = getvar('service-account-member-secret');",
+							"    ",
+							"    let getTokenRequest = {",
+							"    method: 'POST',",
+							"    url: tokenUrl,",
+							"    header: {",
+							"        'content-type': 'application/x-www-form-urlencoded',",
+							"        'Authorization': 'Basic '+ btoa(accountId+':'+accountSecret)",
+							"    },",
+							"    ",
+							"    body: 'grant_type=client_credentials'",
+							"",
+							"};",
+							"",
+							"pm.sendRequest(getTokenRequest, (err, response) => {",
+							"    let jsonResponse = response.json(),",
+							"    newAccessToken = jsonResponse.access_token;",
+							"    ",
+							"    console.log({ err, jsonResponse, newAccessToken })",
+							"    ",
+							"    pm.environment.set('memberAccessToken', newAccessToken);",
+							"    pm.variables.set('memeberAccessToken', newAccessToken);",
+							"",
+							"});",
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "fb73c79d-eabf-43f3-89e1-c8ddb2a3286c",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": []
+		},
+		{
+			"name": "owner approve member",
+			"item": [
+				{
+					"name": "Get Pending members for org",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"userId\", jsonData.id);",
+									"",
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"membershipTypeCode\");",
+									"    pm.expect(pm.response.text()).to.include(\"user\");",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"// take the latest id",
+									"pm.environment.set(\"member_id\", Math.max.apply(Math, jsonData.members.map(function(o) { return o.id; })));"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/members?status=PENDING_APPROVAL",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"members"
+							],
+							"query": [
+								{
+									"key": "status",
+									"value": "PENDING_APPROVAL"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Approve Pending Member",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d1a6bcaf-6909-43b3-8836-1c742855b4e2",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"membershipTypeCode\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"role\": \"OWNER\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/members/{{member_id}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"members",
+								"{{member_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Invitation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/v1/invitations/{{invitation_id}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"invitations",
+								"{{invitation_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update membership role to ADMIN",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d1a6bcaf-6909-43b3-8836-1c742855b4e2",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    //pm.response.to.have.jsonBody(\"\"); ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"membershipTypeCode\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"role\": \"OWNER\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{api_url}}/api/v1/orgs/{{org_identifier}}/members/{{member_id}}",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"orgs",
+								"{{org_identifier}}",
+								"members",
+								"{{member_id}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "70a64349-2436-44a7-a450-e0155851bc43",
+						"type": "text/javascript",
+						"exec": [
+							"var current_timestamp = new Date()",
+							"postman.setEnvironmentVariable(\"current_timestamp\", current_timestamp.toISOString());",
+							"",
+							"function getvar(variableName) {",
+							"    let value = pm.variables.get(variableName);",
+							"    if (!value) throw new Error(",
+							"        `Variable '${variableName}' is not defined.`);",
+							"    return value;",
+							"}",
+							"",
+							"let tokenUrl = getvar('token_url');",
+							"let accountId = getvar('service-account-id');",
+							"let accountSecret = getvar('service-account-secret');",
+							"",
+							"let getTokenRequest = {",
+							"    method: 'POST',",
+							"    url: tokenUrl,",
+							"    header: {",
+							"        'content-type': 'application/x-www-form-urlencoded',",
+							"        'Authorization': 'Basic '+ btoa(accountId+':'+accountSecret)",
+							"    },",
+							" ",
+							"    body: 'grant_type=client_credentials'",
+							"    ",
+							"};",
+							"",
+							"pm.sendRequest(getTokenRequest, (err, response) => {",
+							"    let jsonResponse = response.json(),",
+							"        newAccessToken = jsonResponse.access_token;",
+							"",
+							"    console.log({ err, jsonResponse, newAccessToken })",
+							"",
+							"    pm.environment.set('accessToken', newAccessToken);",
+							"    pm.variables.set('accessToken', newAccessToken);",
+							"});",
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "02856df1-10e1-40aa-a523-9ca2eff8439f",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": []
+		},
+		{
+			"name": "Staff endpoints",
+			"item": [
+				{
+					"name": "Login as Staff",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "cbeb8178-cd2f-447e-acac-8eb69efc0031",
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"pm.environment.set(\"staffToken\", jsonData.access_token);",
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "776fb4fd-4f46-4f00-91eb-fd796e49fcc8",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "grant_type=password&client_id={{web-client-id}}&username={{test_staff_username}}&password={{test_staff_password}}&client_secret={{web-client-secret}}"
+						},
+						"url": {
+							"raw": "{{token_url}}",
+							"host": [
+								"{{token_url}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get users (Staff Only)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "92f21fda-badd-426a-9c9e-2f71ddb1cd90",
+								"exec": [
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"response should be okay to process\", function () { ",
+									"    pm.response.to.not.be.error; ",
+									"    pm.response.to.not.have.jsonBody(\"error\"); ",
+									"});",
+									"",
+									"pm.test(\"response must be valid and have a body\", function () {",
+									"     // assert that the response has a valid JSON body",
+									"     pm.response.to.be.withBody;",
+									"     pm.response.to.be.json; // this assertion also checks if a body  exists, so the above check is not needed",
+									"});",
+									"",
+									"pm.test(\"Verify payload\",  () => {",
+									"    pm.expect(pm.response.text()).to.include(\"firstname\");",
+									"    pm.expect(pm.response.text()).to.include(\"lastname\");",
+									"    pm.expect(pm.response.text()).to.include(\"username\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{staffToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{api_url}}/api/v1/users",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"users"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "cleanup",
+			"item": [
+				{
+					"name": "Reset owner data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									"",
+									"postman.setEnvironmentVariable('userToken', '');",
+									"postman.setEnvironmentVariable('accessToken', '');"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{userToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/test/reset",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"test",
+								"reset"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Reset member Data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a27660f6-b1e5-473c-8149-e5309b672fa7",
+								"exec": [
+									"pm.test(\"Response time is less than 5000ms\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(5000);",
+									"});",
+									"",
+									"pm.test(\"response is ok\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									"",
+									"postman.setEnvironmentVariable('memberToken', '');",
+									"postman.setEnvironmentVariable('memberAccessToken', '');"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{memberToken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{api_url}}/test/reset",
+							"host": [
+								"{{api_url}}"
+							],
+							"path": [
+								"test",
+								"reset"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": []
+		}
+	],
+	"protocolProfileBehavior": []
+}

--- a/auth-api/tests/postman/auth-api.postman_environment.json
+++ b/auth-api/tests/postman/auth-api.postman_environment.json
@@ -1,0 +1,184 @@
+{
+	"id": "0e411076-5a3e-48de-a238-39c225981824",
+	"name": "Auth-Api-DEV",
+	"values": [
+		{
+			"key": "base_url",
+			"value": "sso-dev.pathfinder.gov.bc.ca",
+			"enabled": false
+		},
+		{
+			"key": "realm_name",
+			"value": "fcf0kpqr",
+			"enabled": false
+		},
+		{
+			"key": "token_url",
+			"value": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/fcf0kpqr/protocol/openid-connect/token",
+			"enabled": true
+		},
+		{
+			"key": "api_url",
+			"value": "https://auth-api-dev.pathfinder.gov.bc.ca",
+			"enabled": true
+		},
+		{
+			"key": "business_identifier",
+			"value": "CP0001847",
+			"enabled": true
+		},
+		{
+			"key": "service-account-id",
+			"value": "registries-public-user-test",
+			"enabled": true
+		},
+		{
+			"key": "service-account-secret",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "service-account-member-id",
+			"value": "registries-public-user-member-test",
+			"enabled": true
+		},
+		{
+			"key": "service-account-member-secret",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "web-client-id",
+			"value": "sbc-auth-web",
+			"enabled": true
+		},
+		{
+			"key": "web-client-secret",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "accessToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "userToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "adminToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "adminRefreshToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "memberAccessToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "memberToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "staffToken",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "test_staff_username",
+			"value": "test_staff",
+			"enabled": true
+		},
+		{
+			"key": "test_staff_password",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "test_org_name",
+			"value": "manchest4er",
+			"enabled": true
+		},
+		{
+			"key": "org_identifier",
+			"value": 120,
+			"enabled": true
+		},
+		{
+			"key": "test_org_name_updated",
+			"value": "Manchester United",
+			"enabled": true
+		},
+		{
+			"key": "sample_email",
+			"value": "test@test.com",
+			"enabled": true
+		},
+		{
+			"key": "sample_phone",
+			"value": "1111",
+			"enabled": true
+		},
+		{
+			"key": "sample_extension",
+			"value": "11111",
+			"enabled": true
+		},
+		{
+			"key": "sample_updated_email",
+			"value": "test1@test.com",
+			"enabled": true
+		},
+		{
+			"key": "business_number",
+			"value": "CP0001847",
+			"enabled": true
+		},
+		{
+			"key": "business_name",
+			"value": "Business",
+			"enabled": true
+		},
+		{
+			"key": "member_email",
+			"value": "test_member@test.com",
+			"enabled": true
+		},
+		{
+			"key": "member_phone",
+			"value": "2508881234",
+			"enabled": true
+		},
+		{
+			"key": "member_extension",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "current_timestamp",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "username",
+			"value": "",
+			"enabled": true
+		},
+		{
+			"key": "userId",
+			"value": "",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-01-17T16:46:47.285Z",
+	"_postman_exported_using": "Postman/7.16.0"
+}

--- a/auth-api/tests/unit/api/test_reset.py
+++ b/auth-api/tests/unit/api/test_reset.py
@@ -14,7 +14,7 @@
 
 """Tests to verify the reset API end-point.
 
-Test-Suite to ensure that the /postman/reset endpoint is working as expected.
+Test-Suite to ensure that the /tester/reset endpoint is working as expected.
 """
 import json
 from unittest.mock import patch
@@ -33,25 +33,25 @@ def test_reset(client, jwt, session):  # pylint:disable=unused-argument
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.postman_role)
-    rv = client.post('/postman/reset', headers=headers, content_type='application/json')
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.tester_role)
+    rv = client.post('/test/reset', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_204_NO_CONTENT
 
 
 def test_reset_unauthorized(client, jwt, session):  # pylint:disable=unused-argument
-    """Assert the endpoint get a unauthorized error if haven't postman role."""
+    """Assert the endpoint get a unauthorized error if don't have tester role."""
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
-    rv = client.post('/postman/reset', headers=headers, content_type='application/json')
+    rv = client.post('/test/reset', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_401_UNAUTHORIZED
 
 
 def test_reset_returns_exception(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that the code type can not be fetched and with expcetion."""
     with patch.object(ResetDataService, 'reset', side_effect=BusinessException(Error.UNDEFINED_ERROR, None)):
-        headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.postman_role)
-        rv = client.post('/postman/reset', headers=headers, content_type='application/json')
+        headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.tester_role)
+        rv = client.post('/test/reset', headers=headers, content_type='application/json')
         assert rv.status_code == http_status.HTTP_400_BAD_REQUEST

--- a/auth-api/tests/unit/api/test_reset.py
+++ b/auth-api/tests/unit/api/test_reset.py
@@ -1,0 +1,57 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the reset API end-point.
+
+Test-Suite to ensure that the /postman/reset endpoint is working as expected.
+"""
+import json
+from unittest.mock import patch
+
+from auth_api import status as http_status
+from auth_api.exceptions import BusinessException
+from auth_api.exceptions.errors import Error
+from auth_api.services import ResetTestData as ResetDataService
+from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo
+from tests.utilities.factory_utils import factory_auth_header
+
+
+def test_reset(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert the endpoint can reset the test data."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
+    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
+                     headers=headers, content_type='application/json')
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.postman_role)
+    rv = client.post('/postman/reset', headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_204_NO_CONTENT
+
+
+def test_reset_unauthorized(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert the endpoint get a unauthorized error if haven't postman role."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
+    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
+                     headers=headers, content_type='application/json')
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    rv = client.post('/postman/reset', headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_401_UNAUTHORIZED
+
+
+def test_reset_returns_exception(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that the code type can not be fetched and with expcetion."""
+    with patch.object(ResetDataService, 'reset', side_effect=BusinessException(Error.UNDEFINED_ERROR, None)):
+        headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.postman_role)
+        rv = client.post('/postman/reset', headers=headers, content_type='application/json')
+        assert rv.status_code == http_status.HTTP_400_BAD_REQUEST

--- a/auth-api/tests/unit/services/test_reset.py
+++ b/auth-api/tests/unit/services/test_reset.py
@@ -33,14 +33,14 @@ from tests.utilities.factory_utils import (
 
 def test_reset(session, auth_mock):  # pylint: disable=unused-argument
     """Assert that can be reset data by the provided token."""
-    user_with_token = TestUserInfo.user_postman
-    user_with_token['keycloak_guid'] = TestJwtClaims.postman_role['sub']
+    user_with_token = TestUserInfo.user_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.tester_role['sub']
     user = factory_user_model(user_info=user_with_token)
     org = factory_org_model(user_id=user.id)
     factory_membership_model(user.id, org.id)
     entity = factory_entity_model(user_id=user.id)
 
-    ResetDataService.reset(TestJwtClaims.postman_role)
+    ResetDataService.reset(TestJwtClaims.tester_role)
 
     with pytest.raises(BusinessException) as exception:
         UserService.find_by_jwt_token(user_with_token)
@@ -58,5 +58,5 @@ def test_reset(session, auth_mock):  # pylint: disable=unused-argument
 
 def test_reset_user_notexists(session, auth_mock):  # pylint: disable=unused-argument
     """Assert that can not be reset data by the provided token not exists in database."""
-    response = ResetDataService.reset(TestJwtClaims.postman_role)
+    response = ResetDataService.reset(TestJwtClaims.tester_role)
     assert response is None

--- a/auth-api/tests/unit/services/test_reset.py
+++ b/auth-api/tests/unit/services/test_reset.py
@@ -1,0 +1,62 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the reset data Service.
+
+Test-Suite to ensure that the reset data Service is working as expected.
+"""
+
+import pytest
+
+from auth_api.exceptions import BusinessException
+from auth_api.exceptions.errors import Error
+from auth_api.services import Membership as MembershipService
+from auth_api.services import Org as OrgService
+from auth_api.services import ResetTestData as ResetDataService
+from auth_api.services import User as UserService
+from auth_api.services.entity import Entity as EntityService
+from tests.utilities.factory_scenarios import TestJwtClaims, TestUserInfo
+from tests.utilities.factory_utils import (
+    factory_entity_model, factory_membership_model, factory_org_model, factory_user_model)
+
+
+def test_reset(session, auth_mock):  # pylint: disable=unused-argument
+    """Assert that can be reset data by the provided token."""
+    user_with_token = TestUserInfo.user_postman
+    user_with_token['keycloak_guid'] = TestJwtClaims.postman_role['sub']
+    user = factory_user_model(user_info=user_with_token)
+    org = factory_org_model(user_id=user.id)
+    factory_membership_model(user.id, org.id)
+    entity = factory_entity_model(user_id=user.id)
+
+    ResetDataService.reset(TestJwtClaims.postman_role)
+
+    with pytest.raises(BusinessException) as exception:
+        UserService.find_by_jwt_token(user_with_token)
+    assert exception.value.code == Error.DATA_NOT_FOUND.name
+
+    found_org = OrgService.find_by_org_id(org.id)
+    assert found_org is None
+
+    found_entity = EntityService.find_by_entity_id(entity.id)
+    assert found_entity is None
+
+    found_memeber = MembershipService.get_members_for_org(org.id)
+    assert found_memeber is None
+
+
+def test_reset_user_notexists(session, auth_mock):  # pylint: disable=unused-argument
+    """Assert that can not be reset data by the provided token not exists in database."""
+    response = ResetDataService.reset(TestJwtClaims.postman_role)
+    assert response is None

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -156,6 +156,19 @@ class TestJwtClaims(dict, Enum):
         'loginSource': 'PASSCODE'
     }
 
+    postman_role = {
+        'iss': os.getenv('JWT_OIDC_ISSUER'),
+        'sub': 'f7a4a1d3-73a8-4cbc-a40f-bb1145302064',
+        'firstname': 'Test',
+        'lastname': 'User',
+        'preferred_username': 'testuser',
+        'realm_access': {
+            'roles': [
+                'postman'
+            ]
+        }
+    }
+
     @staticmethod
     def get_test_user(sub):
         """Return test user with subject from argument."""
@@ -291,5 +304,12 @@ class TestUserInfo(dict, Enum):
         'firstname': 'Test',
         'lastname': 'User',
         'roles': '{edit, uma_authorization, staff}',
+        'keycloak_guid': '1b20db59-19a0-4727-affe-c6f64309fd04'
+    }
+    user_postman = {
+        'username': 'CP1234567',
+        'firstname': 'Test',
+        'lastname': 'User',
+        'roles': '{edit, uma_authorization, postman}',
         'keycloak_guid': '1b20db59-19a0-4727-affe-c6f64309fd04'
     }

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -156,7 +156,7 @@ class TestJwtClaims(dict, Enum):
         'loginSource': 'PASSCODE'
     }
 
-    postman_role = {
+    tester_role = {
         'iss': os.getenv('JWT_OIDC_ISSUER'),
         'sub': 'f7a4a1d3-73a8-4cbc-a40f-bb1145302064',
         'firstname': 'Test',
@@ -164,7 +164,7 @@ class TestJwtClaims(dict, Enum):
         'preferred_username': 'testuser',
         'realm_access': {
             'roles': [
-                'postman'
+                'tester'
             ]
         }
     }
@@ -306,10 +306,10 @@ class TestUserInfo(dict, Enum):
         'roles': '{edit, uma_authorization, staff}',
         'keycloak_guid': '1b20db59-19a0-4727-affe-c6f64309fd04'
     }
-    user_postman = {
+    user_tester = {
         'username': 'CP1234567',
         'firstname': 'Test',
         'lastname': 'User',
-        'roles': '{edit, uma_authorization, postman}',
+        'roles': '{edit, uma_authorization, tester}',
         'keycloak_guid': '1b20db59-19a0-4727-affe-c6f64309fd04'
     }

--- a/auth-api/tests/utilities/factory_utils.py
+++ b/auth-api/tests/utilities/factory_utils.py
@@ -40,9 +40,10 @@ def factory_auth_header(jwt, claims):
     return {'Authorization': 'Bearer ' + jwt.create_jwt(claims=claims, header=JWT_HEADER)}
 
 
-def factory_entity_model(entity_info: dict = TestEntityInfo.entity1):
+def factory_entity_model(entity_info: dict = TestEntityInfo.entity1, user_id=None):
     """Produce a templated entity model."""
     entity = EntityModel.create_from_dict(entity_info)
+    entity.created_by_id = user_id
     entity.save()
     return entity
 
@@ -73,6 +74,7 @@ def factory_membership_model(user_id, org_id, member_type='OWNER', member_status
                                  membership_type_code=member_type,
                                  membership_type_status=member_status)
 
+    membership.created_by_id = user_id
     membership.save()
     return membership
 
@@ -80,7 +82,8 @@ def factory_membership_model(user_id, org_id, member_type='OWNER', member_status
 def factory_org_model(org_info: dict = TestOrgInfo.org1,
                       org_type_info: dict = TestOrgTypeInfo.test_type,
                       org_status_info: dict = TestOrgStatusInfo.test_status,
-                      payment_type_info: dict = TestPaymentTypeInfo.test_type):
+                      payment_type_info: dict = TestPaymentTypeInfo.test_type,
+                      user_id=None):
     """Produce a templated org model."""
     org_type = OrgTypeModel.get_default_type()
     if org_type_info['code'] != TestOrgTypeInfo.implicit['code']:
@@ -97,6 +100,7 @@ def factory_org_model(org_info: dict = TestOrgInfo.org1,
     org.org_type = org_type
     org.org_status = org_status
     org.preferred_payment = preferred_payment
+    org.created_by_id = user_id
     org.save()
 
     return org


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2246

*Description of changes:*
1. add a service to reset all the table records created by the token user;
2. add a endpoint that only allow  'potman' role access it;
3. add new restplus blueprint group 'postman' and not allow production environment to run the endpoint;

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
