### PR TITLE
#2186 Restrict notifications to non-member role change

### DIFF
--- a/auth-api/src/auth_api/__init__.py
+++ b/auth-api/src/auth_api/__init__.py
@@ -51,7 +51,8 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
             integrations=[FlaskIntegration()]
         )
 
-    from auth_api.resources import API_BLUEPRINT, OPS_BLUEPRINT, TEST_BLUEPRINT  # pylint: disable=import-outside-toplevel
+    from auth_api.resources import API_BLUEPRINT, OPS_BLUEPRINT, \
+        TEST_BLUEPRINT  # pylint: disable=import-outside-toplevel
 
     db.init_app(app)
     ma.init_app(app)

--- a/auth-api/src/auth_api/models/contact.py
+++ b/auth-api/src/auth_api/models/contact.py
@@ -42,4 +42,4 @@ class Contact(BaseModel):  # pylint: disable=too-few-public-methods
     # MVP contact has been migrated over to the contact linking table (revised data model)
     entity_id = Column(Integer, ForeignKey('entity.id'))
 
-    links = relationship('ContactLink', cascade="all, delete-orphan")
+    links = relationship('ContactLink', cascade='all, delete-orphan')

--- a/auth-api/src/auth_api/models/views/authorization.py
+++ b/auth-api/src/auth_api/models/views/authorization.py
@@ -68,9 +68,9 @@ class Authorization(db.Model):
         return db.session.query(Authorization).filter(
             and_(Authorization.org_id == org_id,
                  or_(Authorization.corp_type_code == corp_type, Authorization.corp_type_code.is_(None)))).order_by(
-            expression.case(((Authorization.org_membership == OWNER, 1),
-                             (Authorization.org_membership == ADMIN, 2),
-                             (Authorization.org_membership == MEMBER, 3)))).first()
+                     expression.case(((Authorization.org_membership == OWNER, 1),
+                                      (Authorization.org_membership == ADMIN, 2),
+                                      (Authorization.org_membership == MEMBER, 3)))).first()
 
     @classmethod
     def find_all_authorizations_for_user(cls, keycloak_guid):

--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -297,6 +297,7 @@ class OrgMember(Resource):
                 updated_fields_dict['membership_status'] = \
                     MembershipService.get_membership_status_by_code(membership_status)
             membership = MembershipService.find_membership_by_id(membership_id, token)
+            is_own_membership = membership.as_dict()['user']['username'] == UserService.find_by_jwt_token(token).as_dict()['username']
             if not membership:
                 response, status = {'message': 'The requested membership record could not be found.'}, \
                                    http_status.HTTP_404_NOT_FOUND
@@ -306,7 +307,7 @@ class OrgMember(Resource):
                 # if user status changed to active , mail the user
                 if membership_status == Status.ACTIVE.name:
                     membership.send_notification_to_member(origin, NotificationType.MEMBERSHIP_APPROVED.value)
-                elif notify_user and updated_role and updated_role.code != MEMBER:
+                elif notify_user and updated_role and updated_role.code != MEMBER and not is_own_membership:
                     membership.send_notification_to_member(origin, NotificationType.ROLE_CHANGED.value)
 
             return response, status

--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -28,7 +28,7 @@ from auth_api.services import Org as OrgService
 from auth_api.services import User as UserService
 from auth_api.tracer import Tracer
 from auth_api.utils.enums import NotificationType
-from auth_api.utils.roles import ALL_ALLOWED_ROLES, CLIENT_ADMIN_ROLES, Role, Status
+from auth_api.utils.roles import ALL_ALLOWED_ROLES, CLIENT_ADMIN_ROLES, MEMBER, Role, Status
 from auth_api.utils.util import cors_preflight
 
 
@@ -306,7 +306,7 @@ class OrgMember(Resource):
                 # if user status changed to active , mail the user
                 if membership_status == Status.ACTIVE.name:
                     membership.send_notification_to_member(origin, NotificationType.MEMBERSHIP_APPROVED.value)
-                elif notify_user and updated_role:
+                elif notify_user and updated_role and updated_role.code != MEMBER:
                     membership.send_notification_to_member(origin, NotificationType.ROLE_CHANGED.value)
 
             return response, status

--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -297,7 +297,8 @@ class OrgMember(Resource):
                 updated_fields_dict['membership_status'] = \
                     MembershipService.get_membership_status_by_code(membership_status)
             membership = MembershipService.find_membership_by_id(membership_id, token)
-            is_own_membership = membership.as_dict()['user']['username'] == UserService.find_by_jwt_token(token).as_dict()['username']
+            is_own_membership = membership.as_dict()['user']['username'] == \
+                UserService.find_by_jwt_token(token).as_dict()['username']
             if not membership:
                 response, status = {'message': 'The requested membership record could not be found.'}, \
                                    http_status.HTTP_404_NOT_FOUND

--- a/auth-api/src/auth_api/services/invitation.py
+++ b/auth-api/src/auth_api/services/invitation.py
@@ -230,7 +230,7 @@ class Invitation:
         admin_list = UserService.get_admins_for_membership(membership_id)
         invitation: InvitationModel = InvitationModel.find_invitation_by_id(invitation_id)
         context_path = CONFIG.AUTH_WEB_TOKEN_CONFIRM_PATH
-        admin_emails = ",".join([str(x.contacts[0].contact.email) for x in admin_list if x.contacts])
+        admin_emails = ','.join([str(x.contacts[0].contact.email) for x in admin_list if x.contacts])
         Invitation.send_admin_notification(user.as_dict(),
                                            '{}/{}'.format(invitation_origin, context_path),
                                            admin_emails, invitation.membership[0].org.name)

--- a/auth-api/src/auth_api/services/membership.py
+++ b/auth-api/src/auth_api/services/membership.py
@@ -31,10 +31,12 @@ from auth_api.schemas import MembershipSchema
 from auth_api.utils.enums import NotificationType
 from auth_api.utils.roles import ADMIN, ALL_ALLOWED_ROLES, OWNER, Status
 from config import get_named_config
+
 from .authorization import check_auth
 from .notification import send_email
 from .org import Org as OrgService
 from .user import User as UserService
+
 
 ENV = Environment(loader=FileSystemLoader('.'), autoescape=True)
 CONFIG = get_named_config()

--- a/auth-api/tests/unit/models/views/test_authorization.py
+++ b/auth-api/tests/unit/models/views/test_authorization.py
@@ -116,8 +116,9 @@ def test_find_user_authorization_by_org_id_and_invalid_corp_type(session):  # py
 
     assert authorization is None
 
-def test_find_user_authorization_by_org_id_and_invalid_corp_type_no_affliation(session):  # pylint:disable=unused-argument
-    """Assert that authorization view is returning result for an unclaimed/unaffiliated organisation for even invalid corp type """
+
+def test_find_user_authorization_by_org_id_and_invalid_corp_type_no_affliation(session):  # pylint:disable=unused-argument # noqa: E501
+    """Assert that authorization view is returning correct result for an unclaimed/unaffiliated organization."""
     user = factory_user_model()
     org = factory_org_model()
     factory_membership_model(user.id, org.id)

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -29,8 +29,8 @@ from auth_api.services import User as UserService
 from auth_api.services.entity import Entity as EntityService
 from tests.utilities.factory_scenarios import TestContactInfo, TestJwtClaims, TestOrgInfo, TestUserInfo
 from tests.utilities.factory_utils import (
-    factory_contact_model, factory_entity_model, factory_invitation, factory_org_service, factory_user_model,
-    factory_membership_model)
+    factory_contact_model, factory_entity_model, factory_invitation, factory_membership_model, factory_org_service,
+    factory_user_model)
 
 
 def test_as_dict(session):  # pylint:disable=unused-argument

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -21,7 +21,7 @@
     "moment": "^2.24.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "^2.0.32",
+    "sbc-common-components": "^2.0.33",
     "vue": "^2.6.10",
     "vue-i18n": "^8.0.0",
     "vue-property-decorator": "^8.3.0",


### PR DESCRIPTION
*Issue #:* 2186
https://github.com/bcgov/entity/issues/2186

*Description of changes:*

Change to exclude notifications on member role change when going to MEMBER from another role.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
