### PR TITLE
Adding overrides for flake8 errors

### DIFF
--- a/auth-api/src/auth_api/exceptions/__init__.py
+++ b/auth-api/src/auth_api/exceptions/__init__.py
@@ -8,8 +8,8 @@ status_code - where possible use HTTP Error Codes
 """
 import traceback
 
-from auth_api.exceptions.errors import Error
-from sbc_common_components.tracing.exception_tracing import ExceptionTracing  # noqa: I001
+from auth_api.exceptions.errors import Error  # noqa: I001, I003
+from sbc_common_components.tracing.exception_tracing import ExceptionTracing  # noqa: I001, I003
 
 
 class BusinessException(Exception):

--- a/auth-api/src/auth_api/models/__init__.py
+++ b/auth-api/src/auth_api/models/__init__.py
@@ -15,7 +15,7 @@
 """This exports all of the models and schemas used by the application."""
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
-
+# noqa: I004, I001
 from sbc_common_components.tracing.db_tracing import DBTracing  # noqa: I001
 
 from .affiliation import Affiliation

--- a/auth-api/src/auth_api/models/__init__.py
+++ b/auth-api/src/auth_api/models/__init__.py
@@ -15,7 +15,7 @@
 """This exports all of the models and schemas used by the application."""
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
-# noqa: I004, I001
+# noqa: I001, I003, I004
 from sbc_common_components.tracing.db_tracing import DBTracing  # noqa: I001
 
 from .affiliation import Affiliation

--- a/auth-api/src/auth_api/resources/__init__.py
+++ b/auth-api/src/auth_api/resources/__init__.py
@@ -22,7 +22,7 @@ That are used to expose operational health information about the service, and me
 """
 
 from flask import Blueprint, current_app
-
+# noqa: I004
 from sbc_common_components.exception_handling.exception_handler import ExceptionHandler
 
 from .apihelper import Api

--- a/auth-api/src/auth_api/resources/__init__.py
+++ b/auth-api/src/auth_api/resources/__init__.py
@@ -22,7 +22,7 @@ That are used to expose operational health information about the service, and me
 """
 
 from flask import Blueprint, current_app
-# noqa: I004
+# noqa: I001, I003, I004
 from sbc_common_components.exception_handling.exception_handler import ExceptionHandler
 
 from .apihelper import Api

--- a/auth-api/src/auth_api/services/contact.py
+++ b/auth-api/src/auth_api/services/contact.py
@@ -15,8 +15,8 @@
 
 This module manages the Contact information for a user or entity.
 """
-from auth_api.schemas import ContactSchema
-from sbc_common_components.tracing.service_tracing import ServiceTracing
+from auth_api.schemas import ContactSchema  # noqa: I003
+from sbc_common_components.tracing.service_tracing import ServiceTracing  # noqa: I001, I004
 
 
 @ServiceTracing.trace(ServiceTracing.enable_tracing, ServiceTracing.should_be_tracing)

--- a/auth-api/src/auth_api/services/documents.py
+++ b/auth-api/src/auth_api/services/documents.py
@@ -18,7 +18,7 @@ from jinja2 import Environment, FileSystemLoader
 from auth_api.models import Documents as DocumentsModel
 from auth_api.schemas import DocumentSchema
 from config import get_named_config
-from sbc_common_components.tracing.service_tracing import ServiceTracing
+from sbc_common_components.tracing.service_tracing import ServiceTracing  # noqa: I001
 
 
 ENV = Environment(loader=FileSystemLoader('.'), autoescape=True)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*

Adding flake8 overrides to satisfy flake8 on both mac and linux/unix.  There were some differences related to the use of common component modules that were preventing the GH action checks from working properly for mac users.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
