### PR TITLE
[entity2402] Update Language from 'Team' to 'Account'

### DIFF
--- a/auth-web/src/components/auth/CreateAccountInfoForm.vue
+++ b/auth-web/src/components/auth/CreateAccountInfoForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="organizations.length > 0">
-      You already belong to a team: <span class="font-weight-bold">{{ organizations[0].name }}</span>
+      You already belong to an account: <strong>{{ organizations[0].name }}</strong>
       <v-row>
         <v-col cols="12" class="form__btns pb-0">
           <v-btn large color="primary" @click="redirectToNext">OK</v-btn>
@@ -9,25 +9,29 @@
       </v-row>
     </div>
     <div>
-      <v-form v-if="organizations.length === 0" ref="createTeamForm">
+      <v-form v-if="organizations.length === 0" ref="createAccountInfoForm">
         <v-radio-group class="mt-0 mb-4 pt-0" v-model="teamType" :mandatory="true">
-          <v-radio class="mb-3" label="I manage my own business" value="BASIC" data-test="select-manage-own-business" />
-          <v-radio label="I manage multiple businesses on behalf of my clients" value="PREMIUM" data-test="select-manage-multiple-business" />
+          <v-radio color="primary" class="mb-3" label="I manage my own business" value="BASIC" data-test="select-manage-own-business" />
+          <v-radio color="primary" label="I manage multiple businesses on behalf of my clients" value="PREMIUM" data-test="select-manage-multiple-business" />
         </v-radio-group>
-        <v-text-field filled :rules="teamNameRules" v-model.trim="teamName"
-                      :label="teamType === 'BASIC' ? 'Your Business Name' : 'Your Management Company or Law Firm Name'"/>
-        <v-alert v-show="orgCreateMessage !== 'success'" class="mb-0"
-                 dense
-                 outlined
-                 type="error"
+
+        <v-alert type="error"
+          v-show="orgCreateMessage !== 'dirty'"
         >{{orgCreateMessage}}
         </v-alert>
+
+        <v-text-field filled
+          label="Account Name"
+          v-model.trim="teamName"
+          :rules="teamNameRules"
+          persistent-hint
+          :hint="teamType === 'BASIC' ? 'Example: Your Business Name' : 'Example: Your Management Company or Law Firm Name'"/>
         <v-row>
           <v-col cols="12" class="form__btns pb-0">
             <v-btn large color="primary" class="mr-2" :disabled='!isFormValid()' @click="save" data-test="save-button">
               Save and Continue
             </v-btn>
-            <v-btn large color="default" @click="cancel" data-test="cancel-button">
+            <v-btn large depressed color="default" @click="cancel" data-test="cancel-button">
               Cancel
             </v-btn>
           </v-col>
@@ -53,7 +57,7 @@ import { getModule } from 'vuex-module-decorators'
     ...mapActions('org', ['syncOrganizations'])
   }
 })
-export default class TeamForm extends Vue {
+export default class CreateAccountInfoForm extends Vue {
     private orgStore = getModule(OrgModule, this.$store)
     private teamName: string = ''
     private teamType: string = 'BASIC'
@@ -63,15 +67,14 @@ export default class TeamForm extends Vue {
     private readonly orgCreateMessage: string
 
     $refs: {
-      createTeamForm: HTMLFormElement
+      createAccountInfoForm: HTMLFormElement
     }
 
     private readonly teamNameRules = [
-      v => !!v || 'You must provide a team name'
-    ]
+      v => !!v || 'An account name is required']
 
     private async mounted () {
-      this.orgStore.setOrgCreateMessage('success') // reset
+      this.orgStore.setOrgCreateMessage('dirty') // reset
       if (!this.organizations) {
         await this.syncOrganizations()
       }

--- a/auth-web/src/components/auth/NextPageMixin.vue
+++ b/auth-web/src/components/auth/NextPageMixin.vue
@@ -30,7 +30,7 @@ export default class NextPageMixin extends Vue {
     if (!this.userContact || !this.userProfile.userTerms.isTermsOfUseAccepted) {
       nextStep = Pages.USER_PROFILE
     } else if (!this.currentOrganization) {
-      nextStep = Pages.CREATE_TEAM
+      nextStep = Pages.CREATE_ACCOUNT
     } else if (this.myOrgMembership.membershipStatus === MembershipStatus.Active) {
       nextStep = Pages.MAIN
     } else if (this.myOrgMembership.membershipStatus === MembershipStatus.Pending) {

--- a/auth-web/src/router.ts
+++ b/auth-web/src/router.ts
@@ -2,7 +2,7 @@ import { Role, SessionStorageKeys } from '@/util/constants'
 import AcceptInviteLandingView from '@/views/auth/AcceptInviteLandingView.vue'
 import AcceptInviteView from '@/views/auth/AcceptInviteView.vue'
 import BusinessProfileView from '@/views/auth/BusinessProfileView.vue'
-import CreateTeamView from '@/views/auth/CreateTeamView.vue'
+import CreateAccountView from '@/views/auth/CreateAccountView.vue'
 import DashboardView from '@/views/auth/DashboardView.vue'
 import DuplicateTeamWarningView from '@/views/auth/DuplicateTeamWarningView.vue'
 import EntityManagement from '@/components/auth/EntityManagement.vue'
@@ -71,7 +71,7 @@ export function getRoutes () {
       ]
     },
     { path: '/userprofile', component: UserProfileView, props: true, meta: { requiresAuth: true } },
-    { path: '/createteam', component: CreateTeamView, meta: { requiresAuth: true } },
+    { path: '/createaccount', component: CreateAccountView, meta: { requiresAuth: true } },
     { path: '/duplicateteam', component: DuplicateTeamWarningView, meta: { requiresAuth: true } },
     { path: '/validatetoken/:token', component: AcceptInviteLandingView, props: true, meta: { requiresAuth: false, disabledRoles: [Role.Staff] } },
     { path: '/confirmtoken/:token', component: AcceptInviteView, props: true, meta: { requiresAuth: true, disabledRoles: [Role.Staff] } },

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -119,13 +119,13 @@ export default class OrgModule extends VuexModule {
     } catch (err) {
       switch (err.response.status) {
         case 409:
-          this.context.commit('setOrgCreateMessage', 'Teams with similar names exists')
+          this.context.commit('setOrgCreateMessage', 'An account with this name already exists. Try a different account name.')
           break
         case 400:
-          this.context.commit('setOrgCreateMessage', 'Invalid team name')
+          this.context.commit('setOrgCreateMessage', 'Invalid account name')
           break
         default:
-          this.context.commit('setOrgCreateMessage', 'Error happened while creating team')
+          this.context.commit('setOrgCreateMessage', 'An error occurred while attempting to create your account.')
           break
       }
     }
@@ -141,13 +141,13 @@ export default class OrgModule extends VuexModule {
     } catch (err) {
       switch (err.response.status) {
         case 409:
-          this.context.commit('setOrgCreateMessage', 'Teams with similar names exists')
+          this.context.commit('setOrgCreateMessage', 'An account with this name already exists.')
           break
         case 400:
-          this.context.commit('setOrgCreateMessage', 'Invalid team name')
+          this.context.commit('setOrgCreateMessage', 'Invalid account name')
           break
         default:
-          this.context.commit('setOrgCreateMessage', 'Error happened while updating team')
+          this.context.commit('setOrgCreateMessage', 'An error occurred while updating your account name.')
           break
       }
     }

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -21,7 +21,7 @@ export enum Role {
 
 export enum Pages {
     USER_PROFILE = 'userprofile',
-    CREATE_TEAM = 'createteam',
+    CREATE_ACCOUNT = 'createaccount',
     DUPLICATE_TEAM_MESAGE = 'duplicateteam',
     PENDING_APPROVAL = 'pendingapproval',
     MAIN = 'main'

--- a/auth-web/src/views/auth/CreateAccountView.vue
+++ b/auth-web/src/views/auth/CreateAccountView.vue
@@ -2,15 +2,13 @@
   <v-container>
     <div class="view-container">
       <article>
-        <h1 class="mb-5">Create Team</h1>
-        <p class="intro-text">Tell us about your team and enter a team name.</p>
+        <h1 class="mb-5">Create Account</h1>
+        <p class="intro-text">Tell us about this account, and enter an account name.</p>
         <v-card class="profile-card">
           <v-container>
-            <v-card-title>
-              <h2 class="mb-4">Your Team Profile</h2>
-            </v-card-title>
+            <v-card-title class="mb-3">Account Information</v-card-title>
             <v-card-text>
-              <TeamForm />
+              <CreateAccountInfoForm />
             </v-card-text>
           </v-container>
         </v-card>
@@ -22,16 +20,16 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import { mapActions, mapState } from 'vuex'
+import CreateAccountInfoForm from '@/components/auth/CreateAccountInfoForm.vue'
 import { Organization } from '@/models/Organization'
-import TeamForm from '@/components/auth/TeamForm.vue'
 import { getModule } from 'vuex-module-decorators'
 
 @Component({
   components: {
-    TeamForm
+    CreateAccountInfoForm
   }
 })
-export default class CreateTeamView extends Vue { }
+export default class CreateAccountView extends Vue { }
 </script>
 
 <style lang="scss" scoped>

--- a/auth-web/src/views/auth/DashboardView.vue
+++ b/auth-web/src/views/auth/DashboardView.vue
@@ -76,7 +76,7 @@ export default class DashboardView extends Vue {
 
     // If user is not an active member of a team at all, redirect to create team page
     if (!this.myOrgMembership) {
-      this.$router.push('/createteam')
+      this.$router.push('/createaccount')
     }
   }
 }

--- a/auth-web/src/views/auth/DuplicateTeamWarningView.vue
+++ b/auth-web/src/views/auth/DuplicateTeamWarningView.vue
@@ -7,7 +7,7 @@
         <v-card class="profile-card">
           <v-container>
             <v-card-text>
-              <TeamForm />
+              <CreateAccountInfoForm />
             </v-card-text>
           </v-container>
         </v-card>
@@ -19,13 +19,13 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import { mapActions, mapState } from 'vuex'
+import CreateAccountInfoForm from '@/components/auth/CreateAccountInfoForm.vue'
 import { Organization } from '@/models/Organization'
-import TeamForm from '@/components/auth/TeamForm.vue'
 import { getModule } from 'vuex-module-decorators'
 
 @Component({
   components: {
-    TeamForm
+    CreateAccountInfoForm
   }
 })
 export default class DuplicateTeamWarningView extends Vue { }

--- a/auth-web/tests/unit/components/CreateAccountInfoForm.spec.ts
+++ b/auth-web/tests/unit/components/CreateAccountInfoForm.spec.ts
@@ -1,6 +1,6 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils'
+import CreateAccountInfoForm from '@/components/auth/CreateAccountInfoForm.vue'
 import OrgModule from '@/store/modules/org'
-import TeamForm from '@/components/auth/TeamForm.vue'
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import VueRouter from 'vue-router'
@@ -15,7 +15,7 @@ jest.mock('axios', () => ({
   post: jest.fn(() => Promise.resolve({ data: { } }))
 }))
 
-describe('TeamForm.vue', () => {
+describe('CreateAccountInfoForm.vue', () => {
   let localVue
   let store
 
@@ -58,7 +58,7 @@ describe('TeamForm.vue', () => {
 
   it('Mounting works', () => {
     const $t = () => 'test'
-    const wrapper = shallowMount(TeamForm, {
+    const wrapper = shallowMount(CreateAccountInfoForm, {
       store,
       localVue,
       mocks: { $t }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/entity2402

Updating the language from 'Team' to 'Account' for both the 'Create Account' and 'Account Information' interfaces

- Renamed 'TeamForm.vue' to 'CreateAccountInfoForm.vue'
- Renamed 'CreateTeamView.vue' to 'CreateAccountView.vue'
- Updated constants.ts with new naming convention (CREATE_ACCOUNT, createaccount)
- Fixed router push in DashboardView.vue to the new URL path ('/createaccount')
- Updated DuplicateTeamWarningView.vue with new component name (TeamForm --> CreateAccountInfoForm). No additional work required here considering this page will be redundant once multiple accounts come into play.
- Renamed 'TeamForm.spec.ts' to 'CreateAccountInfoForm.spec.ts' and updated naming conventions within this file

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
