### PR TITLE
Add reset test data to deactivate user endpoint for tester role.

### DIFF
--- a/auth-api/src/auth_api/services/reset.py
+++ b/auth-api/src/auth_api/services/reset.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Service for reset test data."""
+from typing import Dict
 
 from auth_api.models import User as UserModel
 from auth_api.models import db
+from auth_api.utils.roles import Role
 
 
 class ResetTestData:  # pylint:disable=too-few-public-methods
@@ -24,17 +26,18 @@ class ResetTestData:  # pylint:disable=too-few-public-methods
         """Return a reset test data service instance."""
 
     @staticmethod
-    def reset(token):
+    def reset(token_info: Dict):
         """Cleanup all the data from all tables create by the provided user id."""
-        user = UserModel.find_by_jwt_token(token)
-        if user:
-            # TODO need to find a way to avoid using protected function
-            for model_class in db.Model._decl_class_registry.values():  # pylint:disable=protected-access
-                if hasattr(model_class, 'created_by_id'):
-                    for model in model_class.query.filter_by(created_by_id=user.id).all():
-                        model.delete()
+        if Role.TESTER.value in token_info.get('realm_access').get('roles'):
+            user = UserModel.find_by_jwt_token(token_info)
+            if user:
+                # TODO need to find a way to avoid using protected function
+                for model_class in db.Model._decl_class_registry.values():  # pylint:disable=protected-access
+                    if hasattr(model_class, 'created_by_id'):
+                        for model in model_class.query.filter_by(created_by_id=user.id).all():
+                            model.delete()
 
-            user.modified_by = None
-            user.modified_by_id = None
-            db.session.delete(user)
-            db.session.commit()
+                user.modified_by = None
+                user.modified_by_id = None
+                db.session.delete(user)
+                db.session.commit()

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -487,3 +487,19 @@ def test_delete_user_is_member_returns_204(client, jwt, session):  # pylint:disa
 
     rv = client.delete('/api/v1/users/@me', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_204_NO_CONTENT
+
+
+def test_delete_user_with_tester_role(client, jwt, session):  # pylint:disable=unused-argument
+    """Test delete the user by tester role assert status is 204."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.tester_role)
+    rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_201_CREATED
+
+    # post token with updated claims
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.tester_role)
+
+    rv = client.delete('/api/v1/users/@me', headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_204_NO_CONTENT
+
+    rv = client.get('/api/v1/users/@me', headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_404_NOT_FOUND

--- a/auth-api/tests/unit/services/test_reset.py
+++ b/auth-api/tests/unit/services/test_reset.py
@@ -60,3 +60,17 @@ def test_reset_user_notexists(session, auth_mock):  # pylint: disable=unused-arg
     """Assert that can not be reset data by the provided token not exists in database."""
     response = ResetDataService.reset(TestJwtClaims.tester_role)
     assert response is None
+
+
+def test_reset_user_without_tester_role(session, auth_mock):  # pylint: disable=unused-argument
+    """Assert that can not be reset data by the user doesn't have tester role."""
+    user_with_token = TestUserInfo.user_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.tester_role['sub']
+    user = factory_user_model(user_info=user_with_token)
+    org = factory_org_model(user_id=user.id)
+
+    response = ResetDataService.reset(TestJwtClaims.edit_role)
+    assert response is None
+
+    found_org = OrgService.find_by_org_id(org.id)
+    assert found_org is not None


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2455

*Description of changes:*
Add reset test data to deactivate user endpoint for tester role.


*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
