### PR TITLE
2209: Adding redirect url to the signin url from router to fix staff bookmark

### DIFF
--- a/auth-web/src/router.ts
+++ b/auth-web/src/router.ts
@@ -113,10 +113,18 @@ router.beforeEach((to, from, next) => {
         })
       }
     } else {
-      return next({
-        path: '/', // TODO Change this to login home page once it's ready
-        query: { redirect: to.fullPath }
-      })
+      let nextPath
+      if (to.meta.allowedRoles.length === 1 && to.meta.allowedRoles[0] === Role.Staff) {
+        nextPath = {
+          path: '/signin/idir' + to.path
+        }
+      } else {
+        nextPath = {
+          path: '/',
+          query: { redirect: to.fullPath }
+        }
+      }
+      return next(nextPath)
     }
   }
   next()


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2209

*Description of changes:*
- Changes to redirect to staff login if the page is secured for only staff roles
- Since client can have multiple login mechanisms, not changing it for client login now

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
