### PR TITLE
Add fallback URL for manage businesses

### DIFF
--- a/auth-web/src/router.ts
+++ b/auth-web/src/router.ts
@@ -2,6 +2,7 @@ import { Role, SessionStorageKeys } from '@/util/constants'
 import AcceptInviteLandingView from '@/views/auth/AcceptInviteLandingView.vue'
 import AcceptInviteView from '@/views/auth/AcceptInviteView.vue'
 import BusinessProfileView from '@/views/auth/BusinessProfileView.vue'
+import ConfigHelper from '@/util/config-helper'
 import CreateAccountView from '@/views/auth/CreateAccountView.vue'
 import DashboardView from '@/views/auth/DashboardView.vue'
 import DuplicateTeamWarningView from '@/views/auth/DuplicateTeamWarningView.vue'
@@ -20,7 +21,6 @@ import SigninView from '@/views/auth/SigninView.vue'
 import SignoutView from '@/views/auth/SignoutView.vue'
 import UnauthorizedView from '@/views/auth/UnauthorizedView.vue'
 import UserProfileView from '@/views/auth/UserProfileView.vue'
-
 import Vue from 'vue'
 
 Vue.use(Router)
@@ -40,6 +40,10 @@ export function getRoutes () {
   const routes = [
     { path: '/', name: 'root', component: HomeView },
     { path: '/home', name: 'home', component: HomeView },
+    { path: '/business',
+      name: 'business-root',
+      redirect: `/account/${JSON.parse(ConfigHelper.getFromSession(SessionStorageKeys.CurrentAccount) || '{}').id || 0}/business`
+    },
     { path: '/account/:orgId',
       name: 'account',
       component: DashboardView,


### PR DESCRIPTION
*Issue #:* 2655
https://github.com/bcgov/entity/issues/2655

*Description of changes:*

This PR adds a fallback URL for Manage Businesses for when the account id cannot be expressed in the route parameter.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
