### PR TITLE
Handled the case of pending approval and active account switching

### DIFF
--- a/auth-api/src/auth_api/models/__init__.py
+++ b/auth-api/src/auth_api/models/__init__.py
@@ -15,8 +15,8 @@
 """This exports all of the models and schemas used by the application."""
 from sqlalchemy import event
 from sqlalchemy.engine import Engine  # noqa: I001, I003, I004
-
-from sbc_common_components.tracing.db_tracing import DBTracing  # noqa: I001
+# noqa: I001, I004
+from sbc_common_components.tracing.db_tracing import DBTracing  # noqa: I001, I004
 
 from .affiliation import Affiliation
 from .contact import Contact

--- a/auth-api/src/auth_api/services/contact.py
+++ b/auth-api/src/auth_api/services/contact.py
@@ -15,8 +15,8 @@
 
 This module manages the Contact information for a user or entity.
 """
-from auth_api.schemas import ContactSchema  # noqa: I003
 from sbc_common_components.tracing.service_tracing import ServiceTracing  # noqa: I001, I004
+from auth_api.schemas import ContactSchema  # noqa: I003
 
 
 @ServiceTracing.trace(ServiceTracing.enable_tracing, ServiceTracing.should_be_tracing)

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -30,8 +30,6 @@ from auth_api.utils.util import camelback2snake
 
 from .authorization import check_auth
 from .contact import Contact as ContactService
-from .invitation import Invitation as InvitationService
-
 
 class Org:
     """Manages all aspects of Org data.
@@ -195,10 +193,6 @@ class Org:
                 contact.delete()
                 return contact
         return None
-
-    def get_invitations(self, status='ALL', token_info: Dict = None):
-        """Return the unresolved (pending or failed) invitations for this org."""
-        return {'invitations': InvitationService.get_invitations_for_org(self._model.id, status, token_info)}
 
     def get_owner_count(self):
         """Get the number of owners for the specified org."""

--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -13386,9 +13386,9 @@
       }
     },
     "sbc-common-components": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.0.47.tgz",
-      "integrity": "sha512-OWA+emNFsBROAdaQd20eyo5z7iEOlTmndTYnQSXlhjDZ8dq5UsbC4tYtFV/YYYb0nCRThVJ+vd+5CH8PKZGrvw==",
+      "version": "2.0.49",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-2.0.49.tgz",
+      "integrity": "sha512-1qmkxWD6Z6qipebLcIxlidH+LTUmfBAfZkJhOjR7DzI0uMeSx/Y4PRop1iZmKtP/Kk4NJyqcFRn33iY+jF2fwQ==",
       "requires": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.18.0",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -20,7 +20,7 @@
     "moment": "^2.24.0",
     "regenerator-runtime": "^0.13.3",
     "register-service-worker": "^1.6.2",
-    "sbc-common-components": "^2.0.47",
+    "sbc-common-components": "^2.0.49",
     "vue": "^2.6.11",
     "vue-i18n": "^8.0.0",
     "vue-property-decorator": "^8.3.0",

--- a/auth-web/public/config/configuration.json
+++ b/auth-web/public/config/configuration.json
@@ -1,11 +1,7 @@
 {
+  "AUTH_URL": "https://dev.bcregistry.ca/cooperatives/auth/",
   "VUE_APP_PAY_ROOT_API": "https://pay-api-dev.pathfinder.gov.bc.ca/api/v1",
   "VUE_APP_AUTH_ROOT_API": "https://auth-api-dev.pathfinder.gov.bc.ca/api/v1",
   "VUE_APP_LEGAL_ROOT_API": "https://legal-api-dev.pathfinder.gov.bc.ca/api/v1",
-  "VUE_APP_STATUS_ROOT_API": "https://status-api-dev.pathfinder.gov.bc.ca/api/v1",
-  "VUE_APP_FLAVOR": "post-mvp",
-  "VUE_APP_FEATURE_HIDE": {
-    "BCSC": false,
-    "USER_MGMT": false
-  }
+  "VUE_APP_STATUS_ROOT_API": "https://status-api-dev.pathfinder.gov.bc.ca/api/v1"
 }

--- a/auth-web/src/App.vue
+++ b/auth-web/src/App.vue
@@ -63,7 +63,9 @@ export default class App extends Mixins(NextPageMixin) {
   showLoading = true
 
   get signingIn (): boolean {
-    return this.$route.name === 'signin' || this.$route.name === 'signin-redirect'
+    return this.$route.name === 'signin' ||
+           this.$route.name === 'signin-redirect' ||
+           this.$route.name === 'signin-redirect-full'
   }
 
   private async mounted (): Promise<void> {

--- a/auth-web/src/App.vue
+++ b/auth-web/src/App.vue
@@ -88,14 +88,13 @@ export default class App extends Mixins(NextPageMixin) {
             this.showNotification = switchingToNewAccount
           }
           this.showLoading = false
-          // if user was in a pending approval page and switched to an active account , take him to home page
+          // if user was in a pending approval page and switched to an active account, take him to home page
           if (this.$route.path.indexOf(Pages.PENDING_APPROVAL) > 0) {
             this.$router.push(`/home`)
           }
         } else if (membership.membershipStatus === MembershipStatus.Pending) {
           this.setCurrentOrganization({ id: +currentAccount.id, name: currentAccount.label })
-          // pending member..always take him to pending page
-          this.$router.push(`/${Pages.PENDING_APPROVAL}/${currentAccount?.label}`)
+          this.$router.push(`/${Pages.PENDING_APPROVAL}/${currentAccount.label}`)
           this.showLoading = false
           return
         }

--- a/auth-web/src/App.vue
+++ b/auth-web/src/App.vue
@@ -21,6 +21,7 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
 import { Member, MembershipStatus, Organization } from '@/models/Organization'
+import { Pages, SessionStorageKeys } from '@/util/constants'
 import { mapActions, mapMutations, mapState } from 'vuex'
 import { AccountSettings } from '@/models/account-settings'
 import BusinessModule from '@/store/modules/business'
@@ -31,7 +32,6 @@ import PaySystemAlert from 'sbc-common-components/src/components/PaySystemAlert.
 import SbcFooter from 'sbc-common-components/src/components/SbcFooter.vue'
 import SbcHeader from 'sbc-common-components/src/components/SbcHeader.vue'
 import SbcLoader from 'sbc-common-components/src/components/SbcLoader.vue'
-import { SessionStorageKeys } from '@/util/constants'
 import TokenService from 'sbc-common-components/src/services/token.services'
 import Vue from 'vue'
 import { getModule } from 'vuex-module-decorators'
@@ -48,7 +48,7 @@ import { getModule } from 'vuex-module-decorators'
   },
   methods: {
     ...mapActions('org', ['syncMembership', 'syncOrganization']),
-    ...mapMutations('org', ['setCurrentAccountSettings'])
+    ...mapMutations('org', ['setCurrentAccountSettings', 'setCurrentOrganization'])
   }
 })
 export default class App extends Mixins(NextPageMixin) {
@@ -56,6 +56,7 @@ export default class App extends Mixins(NextPageMixin) {
   private readonly syncMembership!: (currentAccountId: string) => Promise<Member>
   private readonly syncOrganization!: (currentAccountId: string) => Promise<Organization>
   private readonly setCurrentAccountSettings!: (accountSettings: AccountSettings) => void
+  private readonly setCurrentOrganization!: (org: Organization) => void
   private businessStore = getModule(BusinessModule, this.$store)
   showNotification = false
   notificationText = ''
@@ -87,6 +88,16 @@ export default class App extends Mixins(NextPageMixin) {
             this.showNotification = switchingToNewAccount
           }
           this.showLoading = false
+          // if user was in a pending approval page and switched to an active account , take him to home page
+          if (this.$route.path.indexOf(Pages.PENDING_APPROVAL) > 0) {
+            this.$router.push(`/home`)
+          }
+        } else if (membership.membershipStatus === MembershipStatus.Pending) {
+          this.setCurrentOrganization({ id: +currentAccount.id, name: currentAccount.label })
+          // pending member..always take him to pending page
+          this.$router.push(`/${Pages.PENDING_APPROVAL}/${currentAccount?.label}`)
+          this.showLoading = false
+          return
         }
       }
 

--- a/auth-web/src/components/auth/AccountInfo.vue
+++ b/auth-web/src/components/auth/AccountInfo.vue
@@ -42,7 +42,7 @@ import { getModule } from 'vuex-module-decorators'
   components: {
   },
   computed: {
-    ...mapState('org', ['currentOrganization', 'orgCreateMessage']),
+    ...mapState('org', ['currentOrganization']),
     ...mapGetters('org', ['myOrgMembership'])
   },
   methods: {
@@ -56,7 +56,6 @@ export default class AccountInfo extends Vue {
   private readonly updateOrg!: (requestBody: CreateRequestBody) => Promise<Organization>
   private readonly myOrgMembership!: Member
   private orgName = ''
-  private readonly orgCreateMessage
   private touched = false
   private errorMessage: string = ''
 

--- a/auth-web/src/components/auth/AccountInfo.vue
+++ b/auth-web/src/components/auth/AccountInfo.vue
@@ -5,8 +5,8 @@
     </header>
     <v-form ref="editAccountForm">
       <v-alert type="error" class="mb-6"
-        v-show="orgCreateMessage !== 'success'">
-        {{orgCreateMessage}}
+        v-show="errorMessage">
+        {{errorMessage}}
       </v-alert>
       <v-text-field filled clearable required label="Account Name" :disabled="!canChangeAccountName()"
         :rules="accountNameRules"
@@ -58,6 +58,7 @@ export default class AccountInfo extends Vue {
   private orgName = ''
   private readonly orgCreateMessage
   private touched = false
+  private errorMessage: string = ''
 
   private isFormValid (): boolean {
     return !!this.orgName || this.orgName === this.currentOrganization?.name
@@ -91,14 +92,24 @@ export default class AccountInfo extends Vue {
     const createRequestBody: CreateRequestBody = {
       name: this.orgName
     }
-    await this.updateOrg(createRequestBody)
-    if (this.orgCreateMessage === 'success') {
+    try {
+      await this.updateOrg(createRequestBody)
       this.$store.commit('updateHeader')
       this.btnLabel = 'Saved'
-    } else {
-      this.btnLabel = 'Save'
+    } catch (err) {
+      this.btnLable = 'Save'
+      this.touched = false
+      switch (err.response.status) {
+        case 409:
+          this.errorMessage = 'An account with this name already exists. Try a different account name.'
+          break
+        case 400:
+          this.errorMessage = 'Invalid account name'
+          break
+        default:
+          this.errorMessage = 'An error occurred while attempting to create your account.'
+      }
     }
-    this.touched = false
   }
 
   private readonly accountNameRules = [

--- a/auth-web/src/components/auth/CreateAccountInfoForm.vue
+++ b/auth-web/src/components/auth/CreateAccountInfoForm.vue
@@ -47,7 +47,7 @@ import { getModule } from 'vuex-module-decorators'
 
 @Component({
   computed: {
-    ...mapState('org', ['currentOrganization', 'orgCreateMessage'])
+    ...mapState('org', ['currentOrganization'])
   },
   methods: {
     ...mapActions('org', ['createOrg', 'syncMembership', 'syncOrganization'])
@@ -62,7 +62,6 @@ export default class CreateAccountInfoForm extends Vue {
     private readonly createOrg!: (requestBody: CreateRequestBody) => Promise<Organization>
     private readonly syncMembership!: (orgId: number) => Promise<Member>
     private readonly syncOrganization!: (orgId: number) => Promise<Organization>
-    private readonly orgCreateMessage: string
     private readonly currentOrganization!: Organization
 
     $refs: {

--- a/auth-web/src/components/auth/NextPageMixin.vue
+++ b/auth-web/src/components/auth/NextPageMixin.vue
@@ -50,7 +50,7 @@ export default class NextPageMixin extends Vue {
       if (CommonUtils.isUrl(this.redirectAfterLoginUrl)) {
         window.location.href = decodeURIComponent(this.redirectAfterLoginUrl)
       } else {
-        this.$router.push(this.redirectAfterLoginUrl)
+        this.$router.push(`/${this.redirectAfterLoginUrl}`)
       }
     } else {
       this.$router.push(this.getNextPageUrl())

--- a/auth-web/src/components/auth/UserProfileForm.vue
+++ b/auth-web/src/components/auth/UserProfileForm.vue
@@ -146,7 +146,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue } from 'vue-property-decorator'
+import { Component, Mixins, Prop, Vue } from 'vue-property-decorator'
 import { User, UserTerms } from '@/models/user'
 import { Contact } from '@/models/contact'
 import ModalDialog from '@/components/auth/ModalDialog.vue'
@@ -199,6 +199,7 @@ export default class UserProfileForm extends Mixins(NextPageMixin) {
     private editing = false
     private deactivateProfileDialog = false
     private isDeactivating = false
+    @Prop() token: string
 
     $refs: {
       deactivateUserConfirmationDialog: ModalDialog,
@@ -272,6 +273,10 @@ export default class UserProfileForm extends Mixins(NextPageMixin) {
           await this.updateUserContact(contact)
         }
         await this.getUserProfile('@me')
+        if (this.token) {
+          this.$router.push('/confirmtoken/' + this.token)
+          return
+        }
         this.redirectToNext()
       }
     }

--- a/auth-web/src/components/auth/UserProfileForm.vue
+++ b/auth-web/src/components/auth/UserProfileForm.vue
@@ -273,6 +273,8 @@ export default class UserProfileForm extends Mixins(NextPageMixin) {
           await this.updateUserContact(contact)
         }
         await this.getUserProfile('@me')
+        // If a token was provided, that means we are in the accept invitation flow
+        // so redirect to /confirmtoken
         if (this.token) {
           this.$router.push('/confirmtoken/' + this.token)
           return

--- a/auth-web/src/router.ts
+++ b/auth-web/src/router.ts
@@ -78,7 +78,7 @@ export function getRoutes () {
         }
       ]
     },
-    { path: '/userprofile', name: 'userprofile', component: UserProfileView, props: true, meta: { requiresAuth: true } },
+    { path: '/userprofile/:token?', name: 'userprofile', component: UserProfileView, props: true, meta: { requiresAuth: true } },
     { path: '/createaccount', name: 'createaccount', component: CreateAccountView, meta: { requiresAuth: true } },
     { path: '/duplicateteam', name: 'duplicateteam', component: DuplicateTeamWarningView, meta: { requiresAuth: true } },
     { path: '/validatetoken/:token', name: 'validatetoken', component: AcceptInviteLandingView, props: true, meta: { requiresAuth: false, disabledRoles: [Role.Staff] } },

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -114,23 +114,9 @@ export default class OrgModule extends VuexModule {
 
   @Action({ rawError: true })
   public async updateOrg (createRequestBody: CreateOrgRequestBody) {
-    try {
-      const response = await OrgService.updateOrg(this.context.state['currentOrganization'].id, createRequestBody)
-      this.context.commit('setOrgCreateMessage', 'success')
-      this.context.commit('setCurrentOrganization', response.data)
-    } catch (err) {
-      switch (err.response.status) {
-        case 409:
-          this.context.commit('setOrgCreateMessage', 'An account with this name already exists.')
-          break
-        case 400:
-          this.context.commit('setOrgCreateMessage', 'Invalid account name')
-          break
-        default:
-          this.context.commit('setOrgCreateMessage', 'An error occurred while updating your account name.')
-          break
-      }
-    }
+    const response = await OrgService.updateOrg(this.context.state['currentOrganization'].id, createRequestBody)
+    this.context.commit('setCurrentOrganization', response.data)
+    return response?.data
   }
 
   @Action({ rawError: true })

--- a/auth-web/src/views/auth/AcceptInviteView.vue
+++ b/auth-web/src/views/auth/AcceptInviteView.vue
@@ -8,13 +8,14 @@
 <script lang="ts">
 import { Component, Mixins, Prop, Vue } from 'vue-property-decorator'
 import { Member, Organization } from '@/models/Organization'
+import { Pages, SessionStorageKeys } from '@/util/constants'
 import { mapActions, mapGetters, mapState } from 'vuex'
+import ConfigHelper from '@/util/config-helper'
 import { Contact } from '@/models/contact'
 import InterimLanding from '@/components/auth/InterimLanding.vue'
 import { Invitation } from '@/models/Invitation'
 import NextPageMixin from '@/components/auth/NextPageMixin.vue'
 import OrgModule from '@/store/modules/org'
-import { Pages } from '@/util/constants'
 import { User } from '@/models/user'
 import UserModule from '@/store/modules/user'
 import { getModule } from 'vuex-module-decorators'
@@ -48,21 +49,19 @@ export default class AcceptInviteView extends Mixins(NextPageMixin) {
   }
 
   /**
-   * do they have a user profile already : accept invitation ; set orgid to sessionstorage ; reset header
-   * no user profile :  do nothing; redirect to user profile
-   *
+   * User profile filled out?: Accept invitation, set orgid in sessionstorage, update header
+   * User profile incomplete?:  Redirect to user profile, user profile will direct here after
    */
   private async accept () {
     try {
       if (!this.userContact || !this.userProfile.userTerms.isTermsOfUseAccepted) {
-        // or simply go to user profile
+        // Go to user profile, with the token, so that we can continue acceptance flow afterwards
         this.$router.push(`/${Pages.USER_PROFILE}/${this.token}`)
         return
       } else {
         const invitation = await this.acceptInvitation(this.token)
-        sessionStorage.setItem('CURRENT_ACCOUNT', JSON.stringify({ id: invitation.membership[0].org.id }))
+        ConfigHelper.addToSession(SessionStorageKeys.CurrentAccount, JSON.stringify({ id: invitation.membership[0].org.id }))
         this.$store.commit('updateHeader')
-        // this.$router.push(this.getNextPageUrl())
       }
 
       const invitation = await this.acceptInvitation(this.token)

--- a/auth-web/src/views/auth/AcceptInviteView.vue
+++ b/auth-web/src/views/auth/AcceptInviteView.vue
@@ -8,16 +8,23 @@
 <script lang="ts">
 import { Component, Mixins, Prop, Vue } from 'vue-property-decorator'
 import { Member, Organization } from '@/models/Organization'
-import { mapActions, mapState } from 'vuex'
+import { mapActions, mapGetters, mapState } from 'vuex'
+import { Contact } from '@/models/contact'
 import InterimLanding from '@/components/auth/InterimLanding.vue'
 import { Invitation } from '@/models/Invitation'
 import NextPageMixin from '@/components/auth/NextPageMixin.vue'
 import OrgModule from '@/store/modules/org'
+import { Pages } from '@/util/constants'
 import { User } from '@/models/user'
 import UserModule from '@/store/modules/user'
 import { getModule } from 'vuex-module-decorators'
 
 @Component({
+  computed: {
+    ...mapState('user', ['userProfile', 'userContact', 'redirectAfterLoginUrl']),
+    ...mapState('org', ['currentOrganization', 'currentMembership', 'currentAccountSettings']),
+    ...mapGetters('org', ['myOrgMembership'])
+  },
   methods: {
     ...mapActions('org', ['acceptInvitation']),
     ...mapActions('user', ['getUserProfile'])
@@ -29,6 +36,8 @@ export default class AcceptInviteView extends Mixins(NextPageMixin) {
   private userStore = getModule(UserModule, this.$store)
   private readonly acceptInvitation!: (token: string) => Promise<Invitation>
   private readonly getUserProfile!: (identifier: string) => Promise<User>
+  protected readonly userContact!: Contact
+  protected readonly userProfile!: User
 
   @Prop() token: string
   private inviteError: boolean = false
@@ -38,8 +47,24 @@ export default class AcceptInviteView extends Mixins(NextPageMixin) {
     await this.accept()
   }
 
+  /**
+   * do they have a user profile already : accept invitation ; set orgid to sessionstorage ; reset header
+   * no user profile :  do nothing; redirect to user profile
+   *
+   */
   private async accept () {
     try {
+      if (!this.userContact || !this.userProfile.userTerms.isTermsOfUseAccepted) {
+        // or simply go to user profile
+        this.$router.push(`/${Pages.USER_PROFILE}/${this.token}`)
+        return
+      } else {
+        const invitation = await this.acceptInvitation(this.token)
+        sessionStorage.setItem('CURRENT_ACCOUNT', JSON.stringify({ id: invitation.membership[0].org.id }))
+        this.$store.commit('updateHeader')
+        // this.$router.push(this.getNextPageUrl())
+      }
+
       const invitation = await this.acceptInvitation(this.token)
       this.$store.commit('updateHeader')
       this.$router.push(this.getNextPageUrl())

--- a/auth-web/src/views/auth/UserProfileView.vue
+++ b/auth-web/src/views/auth/UserProfileView.vue
@@ -7,7 +7,6 @@
         <v-progress-circular size="50" width="5" color="primary" :indeterminate="isLoading"/>
       </div>
     </v-fade-transition>
-
     <div class="user-profile-container" v-if="!isLoading">
       <v-row justify="center">
         <v-col lg="8" class="pt-0 pb-0">
@@ -30,7 +29,7 @@
                 {{ userProfile.firstname }} {{ userProfile.lastname }}
               </v-card-title>
               <v-card-text>
-                <UserProfileForm/>
+                <UserProfileForm v-bind:token="token"> </UserProfileForm>
               </v-card-text>
             </v-container>
           </v-card>
@@ -41,7 +40,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from 'vue-property-decorator'
+import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { mapActions, mapState } from 'vuex'
 import { Contact } from '@/models/contact'
 import NextPageMixin from '@/components/auth/NextPageMixin.vue'
@@ -64,6 +63,7 @@ import { getModule } from 'vuex-module-decorators'
 export default class UserProfileView extends Mixins(NextPageMixin) {
   private userStore = getModule(UserModule, this.$store)
   private readonly getUserProfile!: (identifier: string) => User
+  @Prop() token: string
   private editing = false
   private isLoading = true
 


### PR DESCRIPTION
*Issue #:*

- https://github.com/bcgov/entity/issues/2580

- handled the case of an account switch between an active account and a pending account :  When switching to a pending account , now user is always taken to pending_approval page
When switching to an active account from pending_Approval page , user is being taken to home page



*Description of changes:*

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
