### PR TITLE
Adding search orgs endpoint

### DIFF
--- a/auth-api/src/auth_api/models/affiliation.py
+++ b/auth-api/src/auth_api/models/affiliation.py
@@ -20,6 +20,7 @@ from sqlalchemy import Column, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
 from .base_model import BaseModel
+from .entity import Entity as EntityModel
 
 
 class Affiliation(BaseModel):  # pylint: disable=too-few-public-methods # Temporarily disable until methods defined
@@ -48,3 +49,8 @@ class Affiliation(BaseModel):  # pylint: disable=too-few-public-methods # Tempor
     def find_affiliations_by_org_id(cls, org_id: int):
         """Return the affiliations with the provided org id."""
         return cls.query.filter_by(org_id=org_id).all()
+
+    @classmethod
+    def find_affiliations_by_business_identifier(cls, business_identifier: str):
+        """Return the affiliation with the provided business identifier."""
+        return cls.query.join(EntityModel).filter(EntityModel.business_identifier == business_identifier).one_or_none()

--- a/auth-api/src/auth_api/models/entity.py
+++ b/auth-api/src/auth_api/models/entity.py
@@ -45,7 +45,7 @@ class Entity(BaseModel):  # pylint: disable=too-few-public-methods
     @classmethod
     def find_by_business_identifier(cls, business_identifier):
         """Return the first entity with the provided business identifier."""
-        return cls.query.filter_by(business_identifier=business_identifier).first()
+        return cls.query.filter_by(business_identifier=business_identifier).one_or_none()
 
     @classmethod
     def create_from_dict(cls, entity_info: dict):

--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -69,6 +69,20 @@ class Orgs(Resource):
             response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
         return response, status
 
+    @staticmethod
+    @TRACER.trace()
+    @cors.crossdomain(origin='*')
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value])
+    def get():
+        """Search orgs."""
+        # Search based on request arguments
+        business_identifier = request.args.get('affiliation', None)
+        try:
+            response, status = OrgService.search_orgs(business_identifier=business_identifier), http_status.HTTP_200_OK
+        except BusinessException as exception:
+            response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
+        return response, status
+
 
 @cors_preflight('GET,PUT,OPTIONS,DELETE')
 @API.route('/<string:org_id>', methods=['GET', 'PUT', 'DELETE', 'OPTIONS'])

--- a/auth-api/src/auth_api/services/keycloak.py
+++ b/auth-api/src/auth_api/services/keycloak.py
@@ -135,7 +135,6 @@ class KeycloakService:
         # Delete User
         if user_id_keycloak is not None:
             try:
-                print('-----', KeycloakConfig().get_keycloak_admin(), user_id_keycloak)
                 response = KeycloakConfig().get_keycloak_admin().delete_user(user_id_keycloak)
                 return response
             except Exception as err:

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -20,6 +20,7 @@ from sbc_common_components.tracing.service_tracing import ServiceTracing  # noqa
 
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
+from auth_api.models import Affiliation as AffiliationModel
 from auth_api.models import Contact as ContactModel
 from auth_api.models import ContactLink as ContactLinkModel
 from auth_api.models import Membership as MembershipModel
@@ -239,4 +240,15 @@ class Org:
             # fix for https://github.com/bcgov/entity/issues/1951   # noqa:E501
             org.members = list(
                 filter(lambda member: (member.user_id == user_id and (member.status in VALID_STATUSES)), org.members))
+        return orgs
+
+    @staticmethod
+    def search_orgs(**kwargs):
+        """Search for orgs based on input parameters."""
+        orgs = {'orgs': []}
+        if kwargs.get('business_identifier', None):
+            affiliation: AffiliationModel = AffiliationModel.\
+                find_affiliations_by_business_identifier(kwargs.get('business_identifier'))
+            if affiliation:
+                orgs['orgs'].append(Org(OrgModel.find_by_org_id(affiliation.org_id)).as_dict())
         return orgs


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2522

*Description of changes:*
- Adding a new GET /orgs endpoint which can be a generic search orgs endpoint for future requirements. Currently supports only searching by affiliation

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [x] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
