### PR TITLE
Fix pytest to run with Keycloak Test values

### DIFF
--- a/auth-api/config.py
+++ b/auth-api/config.py
@@ -169,6 +169,7 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     JWT_OIDC_TEST_AUDIENCE = os.getenv('JWT_OIDC_TEST_AUDIENCE')
     JWT_OIDC_TEST_CLIENT_SECRET = os.getenv('JWT_OIDC_TEST_CLIENT_SECRET')
     JWT_OIDC_TEST_ISSUER = os.getenv('JWT_OIDC_TEST_ISSUER')
+    JWT_OIDC_TEST_ALGORITHMS = os.getenv('JWT_OIDC_TEST_ALGORITHMS')
     JWT_OIDC_TEST_KEYS = {
         "keys": [
             {

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -23,9 +23,9 @@ from config import get_named_config
 CONFIG = get_named_config('testing')
 
 JWT_HEADER = {
-    'alg': CONFIG.JWT_OIDC_ALGORITHMS,
+    'alg': CONFIG.JWT_OIDC_TEST_ALGORITHMS,
     'typ': 'JWT',
-    'kid': CONFIG.JWT_OIDC_AUDIENCE
+    'kid': CONFIG.JWT_OIDC_TEST_AUDIENCE
 }
 
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
- Fix pytest to run with Keycloak Test values

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
