### PR TITLE
Fixed reset endpoint 500 error issue.

### DIFF
--- a/auth-api/src/auth_api/models/entity.py
+++ b/auth-api/src/auth_api/models/entity.py
@@ -41,6 +41,7 @@ class Entity(BaseModel):  # pylint: disable=too-few-public-methods
 
     contacts = relationship('ContactLink', back_populates='entity')
     corp_type = relationship('CorpType', foreign_keys=[corp_type_code], lazy='joined', innerjoin=True)
+    affiliations = relationship('Affiliation', cascade='all,delete,delete-orphan', lazy='select')
 
     @classmethod
     def find_by_business_identifier(cls, business_identifier):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2828

*Description of changes:*
The reset endpoint can not find the proper relationship between affiliation and entity table. Add the relationship into entity model class. 


*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
