### PR TITLE
API for notifications count - first pass

### DIFF
--- a/auth-api/src/auth_api/models/membership.py
+++ b/auth-api/src/auth_api/models/membership.py
@@ -19,7 +19,7 @@ The Membership object connects User models to one or more Org models.
 from sqlalchemy import Column, ForeignKey, Integer, and_, desc, func
 from sqlalchemy.orm import relationship
 
-from auth_api.utils.roles import VALID_STATUSES, Status, Role, ADMIN, OWNER
+from auth_api.utils.roles import VALID_STATUSES, Status, ADMIN, OWNER
 
 from .base_model import BaseModel
 from .db import db

--- a/auth-api/src/auth_api/resources/__init__.py
+++ b/auth-api/src/auth_api/resources/__init__.py
@@ -39,6 +39,7 @@ from .reset import API as RESET_API
 from .token import API as TOKEN_API
 from .user import API as USER_API
 from .user_settings import API as USER_SETTINGS_API
+from .notifications import API as NOTIFICATIONS_API
 
 
 __all__ = ('API_BLUEPRINT', 'OPS_BLUEPRINT')
@@ -84,6 +85,8 @@ API.add_namespace(INVITATION_API, path='/invitations')
 API.add_namespace(DOCUMENTS_API, path='/documents')
 API.add_namespace(CODES_API, path='/codes')
 API.add_namespace(ACCOUNTS_API, path='/accounts')
+API.add_namespace(NOTIFICATIONS_API, path='/users/<string:user_id>/org/<string:org_id>/notifications')
+
 
 TEST_BLUEPRINT = Blueprint('TEST', __name__, url_prefix='/test')
 

--- a/auth-api/src/auth_api/resources/notifications.py
+++ b/auth-api/src/auth_api/resources/notifications.py
@@ -1,0 +1,48 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""API endpoints for managing an Org resource."""
+
+from auth_api import status as http_status
+from auth_api.exceptions import BusinessException
+from auth_api.jwt_wrapper import JWTWrapper
+from auth_api.services import Membership as MembershipService
+from auth_api.tracer import Tracer
+from auth_api.utils.roles import Role
+from auth_api.utils.util import cors_preflight
+from flask import g
+from flask_restplus import Namespace, Resource, cors
+
+API = Namespace('notifications', description='Endpoints for notification management')
+TRACER = Tracer.get_instance()
+_JWT = JWTWrapper.get_instance()
+
+
+@cors_preflight('GET,OPTIONS')
+@API.route('', methods=['GET', 'OPTIONS'])
+class Notifications(Resource):
+    """Resource for managing the notifications."""
+
+    @staticmethod
+    @TRACER.trace()
+    @cors.crossdomain(origin='*')
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
+    def get(user_id, org_id):
+        """Finds the count of notification remaining.If any details invalid, it returns zero"""
+        try:
+            pending_count = MembershipService.get_pending_member_count_for_org(org_id,
+                                                                               token_info=g.jwt_oidc_token_info)
+            response, status = {'count': pending_count}, http_status.HTTP_200_OK
+        except BusinessException as exception:
+            response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
+        return response, status

--- a/auth-api/src/auth_api/resources/notifications.py
+++ b/auth-api/src/auth_api/resources/notifications.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""API endpoints for managing an Org resource."""
+"""API endpoints for managing an Notification resource."""
+
+from flask import g
+from flask_restplus import Namespace, Resource, cors
 
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
@@ -20,8 +23,7 @@ from auth_api.services import Membership as MembershipService
 from auth_api.tracer import Tracer
 from auth_api.utils.roles import Role
 from auth_api.utils.util import cors_preflight
-from flask import g
-from flask_restplus import Namespace, Resource, cors
+
 
 API = Namespace('notifications', description='Endpoints for notification management')
 TRACER = Tracer.get_instance()
@@ -37,9 +39,10 @@ class Notifications(Resource):
     @TRACER.trace()
     @cors.crossdomain(origin='*')
     @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
-    def get(user_id, org_id):
+    def get(user_id, org_id):# pylint:disable=unused-argument
         """Finds the count of notification remaining.If any details invalid, it returns zero"""
         try:
+            # todo use the user_id instead of jwt
             pending_count = MembershipService.get_pending_member_count_for_org(org_id,
                                                                                token_info=g.jwt_oidc_token_info)
             response, status = {'count': pending_count}, http_status.HTTP_200_OK

--- a/auth-api/src/auth_api/services/membership.py
+++ b/auth-api/src/auth_api/services/membership.py
@@ -71,10 +71,11 @@ class Membership:  # pylint: disable=too-many-instance-attributes,too-few-public
 
     @staticmethod
     def get_pending_member_count_for_org(org_id, token_info: Dict = None):
+        """Return the number of pending notification for a user."""
         default_count = 0
         try:
             current_user: UserService = UserService.find_by_jwt_token(token_info)
-        except BusinessException as exception:
+        except BusinessException:
             return default_count
         is_active_admin_or_owner = MembershipModel.check_if_active_admin_or_owner_org_id(org_id, current_user.identifier)
         if is_active_admin_or_owner < 1:

--- a/auth-api/src/auth_api/services/membership.py
+++ b/auth-api/src/auth_api/services/membership.py
@@ -38,7 +38,6 @@ from .notification import send_email
 from .org import Org as OrgService
 from .user import User as UserService
 
-
 ENV = Environment(loader=FileSystemLoader('.'), autoescape=True)
 CONFIG = get_named_config()
 
@@ -69,6 +68,19 @@ class Membership:  # pylint: disable=too-many-instance-attributes,too-few-public
     def get_membership_type_by_code(type_code):
         """Get a membership type by the given code."""
         return MembershipTypeModel.get_membership_type_by_code(type_code=type_code)
+
+    @staticmethod
+    def get_pending_member_count_for_org(org_id, token_info: Dict = None):
+        default_count = 0
+        try:
+            current_user: UserService = UserService.find_by_jwt_token(token_info)
+        except BusinessException as exception:
+            return default_count
+        is_active_admin_or_owner = MembershipModel.check_if_active_admin_or_owner_org_id(org_id, current_user.identifier)
+        if is_active_admin_or_owner < 1:
+            return default_count
+        pending_member_count = MembershipModel.get_pending_members_count_by_org_id(org_id)
+        return pending_member_count
 
     @staticmethod
     def get_members_for_org(org_id, status=Status.ACTIVE,  # pylint:disable=too-many-return-statements


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2841

*Description of changes:*

Came up with an API to return the count.

This is just a first pass. Lot of TODO ; But before that I just want to make sure the approach is fast

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
