### PR TITLE
Fix for After account switch user is always taken to manage business;…

### DIFF
--- a/auth-web/src/App.vue
+++ b/auth-web/src/App.vue
@@ -145,8 +145,6 @@ export default class App extends Mixins(NextPageMixin) {
       this.setupNavigationBar()
       if (this.signingIn) {
         this.redirectAfterLogin()
-      } else {
-        this.$router.push(this.getNextPageUrl())
       }
     })
   }

--- a/auth-web/src/views/auth/AcceptInviteView.vue
+++ b/auth-web/src/views/auth/AcceptInviteView.vue
@@ -36,7 +36,7 @@ export default class AcceptInviteView extends Mixins(NextPageMixin) {
   private orgStore = getModule(OrgModule, this.$store)
   private userStore = getModule(UserModule, this.$store)
   private readonly acceptInvitation!: (token: string) => Promise<Invitation>
-  private readonly syncMembership!: (currentAccountId: string) => Promise<Member>
+  private readonly syncMembership!: (currentAccountId: number) => Promise<Member>
 
   private readonly getUserProfile!: (identifier: string) => Promise<User>
   protected readonly userContact!: Contact
@@ -63,7 +63,7 @@ export default class AcceptInviteView extends Mixins(NextPageMixin) {
       } else {
         const invitation = await this.acceptInvitation(this.token)
         ConfigHelper.addToSession(SessionStorageKeys.CurrentAccount, JSON.stringify({ id: invitation.membership[0].org.id }))
-        await this.syncMembership(invitation.membership[0].org.id.toString())
+        await this.syncMembership(invitation?.membership[0]?.org?.id)
         this.$store.commit('updateHeader') // this event eventually redirects to Pending approval page.No extra navigation needed
         this.$router.push(this.getNextPageUrl())
         return

--- a/auth-web/src/views/auth/AcceptInviteView.vue
+++ b/auth-web/src/views/auth/AcceptInviteView.vue
@@ -27,7 +27,7 @@ import { getModule } from 'vuex-module-decorators'
     ...mapGetters('org', ['myOrgMembership'])
   },
   methods: {
-    ...mapActions('org', ['acceptInvitation']),
+    ...mapActions('org', ['acceptInvitation', 'syncMembership']),
     ...mapActions('user', ['getUserProfile'])
   },
   components: { InterimLanding }
@@ -36,6 +36,8 @@ export default class AcceptInviteView extends Mixins(NextPageMixin) {
   private orgStore = getModule(OrgModule, this.$store)
   private userStore = getModule(UserModule, this.$store)
   private readonly acceptInvitation!: (token: string) => Promise<Invitation>
+  private readonly syncMembership!: (currentAccountId: string) => Promise<Member>
+
   private readonly getUserProfile!: (identifier: string) => Promise<User>
   protected readonly userContact!: Contact
   protected readonly userProfile!: User
@@ -61,7 +63,9 @@ export default class AcceptInviteView extends Mixins(NextPageMixin) {
       } else {
         const invitation = await this.acceptInvitation(this.token)
         ConfigHelper.addToSession(SessionStorageKeys.CurrentAccount, JSON.stringify({ id: invitation.membership[0].org.id }))
+        await this.syncMembership(invitation.membership[0].org.id.toString())
         this.$store.commit('updateHeader') // this event eventually redirects to Pending approval page.No extra navigation needed
+        this.$router.push(this.getNextPageUrl())
         return
       }
     } catch (exception) {


### PR DESCRIPTION
…user should stay in the same page

*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*

Now when account is switched , user is always taken to manage business.This change to put the original behaviour back



*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
