### PR TITLE
2951: pytest changes to use prism mock

### DIFF
--- a/auth-api/config.py
+++ b/auth-api/config.py
@@ -231,10 +231,11 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     # Legal-API URL
     LEGAL_API_URL = 'https://mock-auth-tools.pathfinder.gov.bc.ca/rest/legal-api/2.7/api/v1'
 
-    NOTIFY_API_URL = 'https://mock-auth-tools.pathfinder.gov.bc.ca/rest/SBC+Notify+API+Reference/2.0.0/api/v1'
+    NOTIFY_API_URL = 'http://localhost:8080/notify-api/api/v1'
 
     # If any value is present in this flag, starts up a keycloak docker
     USE_TEST_KEYCLOAK_DOCKER = os.getenv('USE_TEST_KEYCLOAK_DOCKER', None)
+    USE_DOCKER_MOCK = 'YES'
 
 
 class ProdConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/auth-api/tests/conftest.py
+++ b/auth-api/tests/conftest.py
@@ -129,13 +129,17 @@ def session(app, db):  # pylint: disable=redefined-outer-name, invalid-name
 
 
 @pytest.fixture(scope='session', autouse=True)
-def keycloak(docker_services, app):
+def auto(docker_services, app):
     """Spin up a keycloak instance and initialize jwt."""
     if app.config['USE_TEST_KEYCLOAK_DOCKER']:
         docker_services.start('keycloak')
         docker_services.wait_for_service('keycloak', 8081)
 
     setup_jwt_manager(app, _JWT)
+
+    if app.config['USE_DOCKER_MOCK']:
+        docker_services.start('notify')
+        docker_services.start('proxy')
 
 
 @pytest.fixture(scope='session')

--- a/auth-api/tests/docker/docker-compose.yml
+++ b/auth-api/tests/docker/docker-compose.yml
@@ -22,3 +22,42 @@ services:
       retries: 10
     volumes:
       - ./setup:/tmp/keycloak/test/
+  
+  proxy:
+        image: nginx:alpine
+        volumes:
+          - ./nginx.conf:/etc/nginx/nginx.conf
+        ports:
+          - '8080:80'
+        depends_on:
+          - notify
+  bcol:
+    image: stoplight/prism:3.3.0
+    command: >
+      mock -p 4010 --host 0.0.0.0
+      https://raw.githubusercontent.com/bcgov/sbc-pay/development/docs/docs/api_contract/bcol-api-1.0.0.yaml
+  pay:
+    image: stoplight/prism:3.3.0
+    command: >
+      mock -p 4010 --host 0.0.0.0
+      https://raw.githubusercontent.com/bcgov/sbc-pay/development/docs/docs/api_contract/pay-api-1.0.0.yaml
+  reports:
+    image: stoplight/prism:3.3.0
+    command: >
+      mock -p 4010 --host 0.0.0.0
+      https://raw.githubusercontent.com/bcgov/sbc-pay/development/docs/docs/api_contract/report-api-1.0.0.yaml
+  paybc:
+    image: stoplight/prism:3.3.0
+    command: >
+      mock -p 4010 --host 0.0.0.0
+      https://raw.githubusercontent.com/bcgov/sbc-pay/development/docs/docs/PayBC%20Mocking/paybc-1.0.0.yaml
+  auth:
+    image: stoplight/prism:3.3.0
+    command: >
+      mock -p 4010 --host 0.0.0.0
+      https://raw.githubusercontent.com/bcgov/sbc-auth/development/docs/docs/api_contract/auth-api-1.0.0.yaml
+  notify:
+    image: stoplight/prism:3.3.0
+    command: >
+      mock -p 4010 --host 0.0.0.0
+      https://raw.githubusercontent.com/sumesh-aot/sbc-auth/contract/docs/docs/api_contract/notify-api-1.0.0.yaml

--- a/auth-api/tests/docker/nginx.conf
+++ b/auth-api/tests/docker/nginx.conf
@@ -1,0 +1,17 @@
+worker_processes auto;
+
+events {
+  worker_connections 512;
+}
+
+http {
+  server {
+    listen 80;
+
+    location /notify-api {
+      rewrite ^/notify-api/(.*) /$1 break;
+      proxy_pass http://notify:4010/;
+    }
+
+  }
+}

--- a/docs/docs/api_contract/auth-api-1.0.0.yaml
+++ b/docs/docs/api_contract/auth-api-1.0.0.yaml
@@ -963,7 +963,7 @@ paths:
         required: true
         schema:
           type: string
-        examples:
+        example:
           example1:
             value: '1234'
     put:
@@ -1076,12 +1076,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/org'
-              examples:
-                example1:
-                  value:
-                    id: '1234'
-                    name: Mock Account
-                    preferred_payment: CC
         '404':
           description: Not Found
           content:
@@ -1101,7 +1095,6 @@ paths:
         - orgs
       summary: Get the org specified by the provided id.
       description: Get the org specified by the provided id.
-    
   /orgs:
     post:
       responses:
@@ -1187,7 +1180,7 @@ paths:
           examples:
             example1:
               value: CP0001234
-            CP0002000:
+            example2:
               value: CP0002000
       tags:
         - authorization
@@ -1306,17 +1299,15 @@ paths:
               examples:
                 example1:
                   value:
-                    orgs:
-                    - id: '1234'
-                      name: Mock Account
-                      preferred_payment: CC
-
-                CP0002000:
+                    id: '1234'
+                    name: Mock Account
+                    preferred_payment: CC
+                example2:
                   value:
-                    - id: '2000'
-                      name: Mock Account
-                      preferred_payment: DRAWDOWN
-                      bc_online_user_id: PB25020
+                    id: '2000'
+                    name: Mock Account
+                    preferred_payment: PREMIUM
+                    bc_online_user_id: PB25020
         default:
           description: unexpected error
           content:
@@ -3147,13 +3138,13 @@ paths:
                 type: string
               description: X-Application-Context
               examples:
-                CP0001234:
+                owner:
                   value: 'application:prod'
-                CP0001235:
+                admin:
                   value: 'application:prod'
-                CP0001236:
+                member:
                   value: 'application:prod'
-                CP0001237:
+                staff:
                   value: 'application:prod'
             Access-Control-Allow-Origin:
               schema:
@@ -3217,7 +3208,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/authorizations'
               examples:
-                CP0001234:
+                owner:
                   value:
                     orgMembership: OWNER
                     roles:
@@ -3233,7 +3224,7 @@ paths:
                         methodOfPayment: CC
                         bcOnlineUserId: PB25020
                         bcOnlineAccountId: ''
-                CP0001235:
+                admin:
                   value:
                     orgMembership: ADMIN
                     roles:
@@ -3246,7 +3237,7 @@ paths:
                         methodOfPayment: CC
                         bcOnlineUserId: PB25020
                         bcOnlineAccountId: ''
-                CP0001236:
+                member:
                   value:
                     orgMembership: MEMBER
                     roles:
@@ -3259,14 +3250,14 @@ paths:
                         methodOfPayment: CC
                         bcOnlineUserId: PB25020
                         bcOnlineAccountId: ''
-                CP0001237:
+                staff:
                   value:
                     roles:
                       - view
                       - edit
-                CP0000000:
+                unauthorized:
                   value: {}
-                CP0002000:
+                expanded_premium:
                   value:
                     orgMembership: OWNER
                     roles:
@@ -3279,10 +3270,10 @@ paths:
                       id: '1234'
                       name: Mock Account
                       paymentPreference:
-                        methodOfPayment: DRAWDOWN
+                        methodOfPayment: PREMIUM
                         bcOnlineUserId: PB25020
                         bcOnlineAccountId: ''
-                CP0001238:
+                expanded_cc:
                   value:
                     orgMembership: OWNER
                     roles:
@@ -3313,19 +3304,19 @@ paths:
         required: true
         description: Corp Num/Incorporation Number of the entity
         examples:
-          CP0001234:
+          owner:
             value: CP0001234
-          CP0001235:
+          admin:
             value: CP0001235
-          CP0001236:
+          member:
             value: CP0001236
-          CP0001237:
+          staff:
             value: CP0001237
-          CP0000000:
+          unauthorized:
             value: CP0000000
-          CP0001238:
+          expanded_cc:
             value: CP0001238
-          CP0002000:
+          expanded_premium:
             value: CP0002000
   '/accounts/{account_id}/products/{product_code}/authorizations':
     get:
@@ -3587,7 +3578,7 @@ paths:
                   - modifiedBy
                   - name
                   - passCodeClaimed
-                examples:
+                x-example:
                   CP0001578:
                     businessIdentifier: CP0001578
                     businessNumber: CP0001847
@@ -5333,7 +5324,7 @@ components:
         - sentDate
         - status
         - token
-    orgMembershipRequest: 
+    orgMembershipRequest:
       title: orgMembershipRequest
       type: object
       properties:


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2951

*Description of changes:*
- 2951: pytest changes to use prism mock

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
