### PR TITLE
setting anonymous if not passed from UI

### DIFF
--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -53,7 +53,9 @@ def test_add_org_staff_admin(client, jwt, session, keycloak_mock):  # pylint:dis
     dictionary = json.loads(rv.data)
     assert dictionary['access_type'] == 'ANONYMOUS'
 
-def test_add_org_staff_admin_anonymous_not_passed(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
+
+def test_add_org_staff_admin_anonymous_not_passed(client, jwt, session,
+                                                  keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be POSTed."""
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
@@ -62,7 +64,6 @@ def test_add_org_staff_admin_anonymous_not_passed(client, jwt, session, keycloak
     assert rv.status_code == http_status.HTTP_201_CREATED
     dictionary = json.loads(rv.data)
     assert dictionary['access_type'] == 'ANONYMOUS'
-
 
 
 def test_add_org_staff_admin_any_number_of_orgs(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -53,6 +53,17 @@ def test_add_org_staff_admin(client, jwt, session, keycloak_mock):  # pylint:dis
     dictionary = json.loads(rv.data)
     assert dictionary['access_type'] == 'ANONYMOUS'
 
+def test_add_org_staff_admin_anonymous_not_passed(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
+    """Assert that an org can be POSTed."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
+    rv = client.post('/api/v1/orgs', data=json.dumps({'name': 'My Test Org'}),
+                     headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_201_CREATED
+    dictionary = json.loads(rv.data)
+    assert dictionary['access_type'] == 'ANONYMOUS'
+
+
 
 def test_add_org_staff_admin_any_number_of_orgs(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be POSTed."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
