### PR TITLE
Added role check for APIs and fixed all Tests

### DIFF
--- a/auth-api/src/auth_api/resources/bulk_user.py
+++ b/auth-api/src/auth_api/resources/bulk_user.py
@@ -37,7 +37,6 @@ class BulkUser(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
     def post():
         """Admin users can post multiple users to his org.Use it for anonymous purpose only."""
         try:

--- a/auth-api/src/auth_api/resources/bulk_user.py
+++ b/auth-api/src/auth_api/resources/bulk_user.py
@@ -37,7 +37,7 @@ class BulkUser(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_JWT.requires_auth
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
     def post():
         """Admin users can post multiple users to his org.Use it for anonymous purpose only."""
         try:

--- a/auth-api/src/auth_api/resources/invitation.py
+++ b/auth-api/src/auth_api/resources/invitation.py
@@ -16,6 +16,7 @@
 from flask import g, request
 from flask_restplus import Namespace, Resource, cors
 
+from auth_api.utils.roles import Role
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
 from auth_api.jwt_wrapper import JWTWrapper
@@ -39,7 +40,7 @@ class Invitations(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_JWT.requires_auth
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
     def post():
         """Send a new invitation using the details in request and saves the invitation."""
         token = g.jwt_oidc_token_info
@@ -100,7 +101,7 @@ class Invitation(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_JWT.requires_auth
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
     def delete(invitation_id):
         """Delete the specified invitation."""
         token = g.jwt_oidc_token_info

--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -44,7 +44,7 @@ class Orgs(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_JWT.has_one_of_roles([Role.EDITOR.value, Role.STAFF_ADMIN.value])
+    @_JWT.has_one_of_roles([Role.PUBLIC_USER.value, Role.STAFF_ADMIN.value])
     def post():
         """Post a new org using the request body.
 
@@ -126,7 +126,7 @@ class Org(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_JWT.requires_auth
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
     def delete(org_id):
         """Inactivates the org if it has no active members or affiliations."""
         token = g.jwt_oidc_token_info
@@ -207,7 +207,7 @@ class OrgAffiliations(Resource):
     """Resource for managing affiliations for an org."""
 
     @staticmethod
-    @_JWT.requires_auth
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
     @TRACER.trace()
     @cors.crossdomain(origin='*')
     def post(org_id):
@@ -250,7 +250,7 @@ class OrgAffiliation(Resource):
     """Resource for managing a single affiliation between an org and an entity."""
 
     @staticmethod
-    @_JWT.requires_auth
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF.value, Role.PUBLIC_USER.value])
     @TRACER.trace()
     @cors.crossdomain(origin='*')
     def delete(org_id, business_identifier):

--- a/auth-api/tests/unit/api/test_account.py
+++ b/auth-api/tests/unit/api/test_account.py
@@ -33,7 +33,7 @@ def test_authorizations_for_account_returns_200(app, client, jwt, session):  # p
     org = factory_org_model()
     factory_membership_model(user.id, org.id)
 
-    claims = copy.deepcopy(TestJwtClaims.edit_role.value)
+    claims = copy.deepcopy(TestJwtClaims.public_user_role.value)
     claims['sub'] = str(user.keycloak_guid)
 
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -52,7 +52,7 @@ def test_authorizations_for_account_with_search_returns_200(client, jwt, session
     factory_membership_model(user.id, org.id)
     factory_product_model(org.id)
 
-    claims = copy.deepcopy(TestJwtClaims.edit_role.value)
+    claims = copy.deepcopy(TestJwtClaims.public_user_role.value)
     claims['sub'] = str(user.keycloak_guid)
 
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -75,7 +75,7 @@ def test_authorizations_with_multiple_accounts_returns_200(client, jwt, session)
                              payment_type_info=None)
     factory_membership_model(user.id, org.id)
 
-    claims = copy.deepcopy(TestJwtClaims.edit_role.value)
+    claims = copy.deepcopy(TestJwtClaims.public_user_role.value)
     claims['sub'] = str(user.keycloak_guid)
 
     headers = factory_auth_header(jwt=jwt, claims=claims)

--- a/auth-api/tests/unit/api/test_bulk_user.py
+++ b/auth-api/tests/unit/api/test_bulk_user.py
@@ -22,7 +22,7 @@ from auth_api import status as http_status
 from auth_api.services.keycloak import KeycloakService
 
 from tests.utilities.factory_scenarios import BulkUserTestScenario, TestJwtClaims, \
-    TestOrgInfo, TestUserInfo
+    TestOrgInfo
 from tests.utilities.factory_utils import (
     factory_auth_header, factory_invitation_anonymous)
 

--- a/auth-api/tests/unit/api/test_bulk_user.py
+++ b/auth-api/tests/unit/api/test_bulk_user.py
@@ -49,12 +49,21 @@ def test_add_user_admin_valid_bcros(client, jwt, session, keycloak_mock):  # pyl
     dictionary = json.loads(rv.data)
     assert dictionary.get('token') is not None
     assert rv.status_code == http_status.HTTP_201_CREATED
-    rv = client.post('/api/v1/users/bcros', data=json.dumps(TestUserInfo.user_anonymous_1),
+    user = {
+        'username': 'testuser',
+        'password': 'testuser',
+    }
+    rv = client.post('/api/v1/users/bcros', data=json.dumps(user),
                      headers={'invitation_token': dictionary.get('token')}, content_type='application/json')
     dictionary = json.loads(rv.data)
 
+    # post token with updated claims
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.anonymous_bcros_role)
+    rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_201_CREATED
+
     headers = factory_auth_header(jwt=jwt,
-                                  claims=TestJwtClaims.get_test_real_user(dictionary['users'][0]['keycloakGuid']))
+                                  claims=TestJwtClaims.anonymous_bcros_role)
     rv = client.post('/api/v1/bulk/users', headers=headers,
                      data=json.dumps(BulkUserTestScenario.get_bulk_user1_for_org(org_id)),
                      content_type='application/json')

--- a/auth-api/tests/unit/api/test_bulk_user.py
+++ b/auth-api/tests/unit/api/test_bulk_user.py
@@ -31,7 +31,7 @@ KEYCLOAK_SERVICE = KeycloakService()
 
 def test_add_user(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a user can be POSTed."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
 

--- a/auth-api/tests/unit/api/test_entity.py
+++ b/auth-api/tests/unit/api/test_entity.py
@@ -86,7 +86,7 @@ def test_get_entity_unauthorized_user_returns_403(client, jwt, session):  # pyli
     client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity1),
                 headers=headers, content_type='application/json')
 
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
 
     rv = client.get('/api/v1/entities/{}'.format(TestEntityInfo.entity1['businessIdentifier']),
                     headers=headers, content_type='application/json')
@@ -129,7 +129,7 @@ def test_add_contact(client, jwt, session):  # pylint:disable=unused-argument
 
 def test_add_contact_invalid_format_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that adding an invalidly formatted contact returns a 400."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity1),
                 headers=headers, content_type='application/json')
     rv = client.post('/api/v1/entities/{}/contacts'.format(TestEntityInfo.entity1['businessIdentifier']),
@@ -177,7 +177,7 @@ def test_update_contact(client, jwt, session):  # pylint:disable=unused-argument
 
 def test_update_contact_invalid_format_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that updating with an invalidly formatted contact returns a 400."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity1),
                 headers=headers, content_type='application/json')
     client.post('/api/v1/entities/{}/contacts'.format(TestEntityInfo.entity1['businessIdentifier']),

--- a/auth-api/tests/unit/api/test_invitation.py
+++ b/auth-api/tests/unit/api/test_invitation.py
@@ -27,7 +27,7 @@ from auth_api.services import Invitation as InvitationService
 
 def test_add_invitation(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an invitation can be POSTed."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -42,7 +42,7 @@ def test_add_invitation(client, jwt, session, keycloak_mock):  # pylint:disable=
 
 def test_add_invitation_invalid(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that POSTing an invalid invitation returns a 400."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/invitations', data=json.dumps(factory_invitation(org_id=None)),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
@@ -50,7 +50,7 @@ def test_add_invitation_invalid(client, jwt, session):  # pylint:disable=unused-
 
 def test_get_invitations_by_id(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an invitation can be retrieved."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -66,7 +66,7 @@ def test_get_invitations_by_id(client, jwt, session, keycloak_mock):  # pylint:d
 
 def test_delete_invitation(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an invitation can be deleted."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -86,7 +86,7 @@ def test_delete_invitation(client, jwt, session, keycloak_mock):  # pylint:disab
 
 def test_update_invitation(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an invitation can be updated."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -106,7 +106,7 @@ def test_update_invitation(client, jwt, session, keycloak_mock):  # pylint:disab
 
 def test_validate_token(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a token is valid."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -124,7 +124,7 @@ def test_validate_token(client, jwt, session, keycloak_mock):  # pylint:disable=
 
 def test_accept_invitation(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an invitation can be accepted."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -34,7 +34,7 @@ from tests.utilities.factory_utils import factory_auth_header, factory_invitatio
 
 def test_add_org(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be POSTed."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -56,7 +56,7 @@ def test_add_anonymous_org_staff_admin(client, jwt, session, keycloak_mock):  # 
 
 def test_add_anonymous_org_by_user_exception(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be POSTed."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org_anonymous),
                      headers=headers, content_type='application/json')
@@ -98,7 +98,7 @@ def test_add_org_staff_admin_any_number_of_orgs(client, jwt, session, keycloak_m
 
 def test_add_org_multiple(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be POSTed.But in limited number."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv1 = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                       headers=headers, content_type='application/json')
@@ -117,7 +117,7 @@ def test_add_org_multiple(client, jwt, session, keycloak_mock):  # pylint:disabl
 
 def test_add_same_org_409(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be POSTed."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -129,7 +129,7 @@ def test_add_same_org_409(client, jwt, session, keycloak_mock):  # pylint:disabl
 
 def test_add_org_invalid_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that POSTing an invalid org returns a 400."""
-    headers = factory_auth_header(jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.invalid),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
@@ -137,7 +137,7 @@ def test_add_org_invalid_returns_400(client, jwt, session):  # pylint:disable=un
 
 def test_add_org_invalid_space_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that POSTing an invalid org returns a 400."""
-    headers = factory_auth_header(jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.invalid_name_space),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
@@ -145,7 +145,7 @@ def test_add_org_invalid_space_returns_400(client, jwt, session):  # pylint:disa
 
 def test_add_org_invalid_spaces_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that POSTing an invalid org returns a 400."""
-    headers = factory_auth_header(jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.invalid_name_spaces),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
@@ -153,7 +153,7 @@ def test_add_org_invalid_spaces_returns_400(client, jwt, session):  # pylint:dis
 
 def test_add_org_invalid_end_space_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that POSTing an invalid org returns a 400."""
-    headers = factory_auth_header(jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.invalid_name_end_space),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
@@ -161,7 +161,7 @@ def test_add_org_invalid_end_space_returns_400(client, jwt, session):  # pylint:
 
 def test_add_org_invalid_start_space_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that POSTing an invalid org returns a 400."""
-    headers = factory_auth_header(jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.invalid_name_start_space),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
@@ -185,7 +185,7 @@ def test_add_org_normal_staff_invalid_returns_401(client, jwt, session):  # pyli
 
 def test_add_org_invalid_user_returns_401(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that POSTing an org with invalid user returns a 401."""
-    headers = factory_auth_header(jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt, claims=TestJwtClaims.public_user_role)
 
     with patch.object(UserService, 'find_by_jwt_token', return_value=None):
         rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
@@ -195,7 +195,7 @@ def test_add_org_invalid_user_returns_401(client, jwt, session):  # pylint:disab
 
 def test_add_org_invalid_returns_exception(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that POSTing an invalid org returns an exception."""
-    headers = factory_auth_header(jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     with patch.object(OrgService, 'create_org', side_effect=BusinessException(Error.DATA_ALREADY_EXISTS, None)):
@@ -206,7 +206,7 @@ def test_add_org_invalid_returns_exception(client, jwt, session):  # pylint:disa
 
 def test_get_org(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be retrieved via GET."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -222,7 +222,7 @@ def test_get_org(client, jwt, session, keycloak_mock):  # pylint:disable=unused-
 
 def test_get_org_no_auth_returns_401(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org cannot be retrieved without an authorization header."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -235,7 +235,7 @@ def test_get_org_no_auth_returns_401(client, jwt, session, keycloak_mock):  # py
 
 def test_get_org_no_org_returns_404(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that attempting to retrieve a non-existent org returns a 404."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.get('/api/v1/orgs/{}'.format(999),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_404_NOT_FOUND
@@ -243,7 +243,7 @@ def test_get_org_no_org_returns_404(client, jwt, session):  # pylint:disable=unu
 
 def test_update_org(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be updated via PUT."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -263,7 +263,7 @@ def test_update_org(client, jwt, session, keycloak_mock):  # pylint:disable=unus
 
 def test_update_org_returns_400(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can not be updated and return 400 error via PUT."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -277,7 +277,7 @@ def test_update_org_returns_400(client, jwt, session, keycloak_mock):  # pylint:
 
 def test_update_org_no_org_returns_404(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that attempting to update a non-existent org returns a 404."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.put('/api/v1/orgs/{}'.format(999), data=json.dumps(TestOrgInfo.org1),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_404_NOT_FOUND
@@ -285,7 +285,7 @@ def test_update_org_no_org_returns_404(client, jwt, session):  # pylint:disable=
 
 def test_update_org_returns_exception(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that attempting to update a non-existent org returns an exception."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -300,7 +300,7 @@ def test_update_org_returns_exception(client, jwt, session, keycloak_mock):  # p
 
 def test_add_contact(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a contact can be added to an org."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -316,7 +316,7 @@ def test_add_contact(client, jwt, session, keycloak_mock):  # pylint:disable=unu
 
 def test_add_contact_invalid_format_returns_400(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that adding an invalidly formatted contact returns a 400."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -330,7 +330,7 @@ def test_add_contact_invalid_format_returns_400(client, jwt, session, keycloak_m
 
 def test_add_contact_valid_email_returns_201(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that adding an valid formatted contact with special characters in email returns a 201."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -344,7 +344,7 @@ def test_add_contact_valid_email_returns_201(client, jwt, session, keycloak_mock
 
 def test_add_contact_no_org_returns_404(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that adding a contact to a non-existant org returns 404."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/orgs/{}/contacts'.format(99),
                      headers=headers, data=json.dumps(TestContactInfo.contact1), content_type='application/json')
     assert rv.status_code == http_status.HTTP_404_NOT_FOUND
@@ -352,7 +352,7 @@ def test_add_contact_no_org_returns_404(client, jwt, session):  # pylint:disable
 
 def test_add_contact_duplicate_returns_400(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that adding a duplicate contact to an org returns 400."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -368,7 +368,7 @@ def test_add_contact_duplicate_returns_400(client, jwt, session, keycloak_mock):
 
 def test_update_contact(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a contact can be updated on an org."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -390,7 +390,7 @@ def test_update_contact(client, jwt, session, keycloak_mock):  # pylint:disable=
 def test_update_contact_invalid_format_returns_400(client, jwt, session,
                                                    keycloak_mock):  # pylint:disable=unused-argument
     """Assert that updating with an invalidly formatted contact returns a 400."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -407,7 +407,7 @@ def test_update_contact_invalid_format_returns_400(client, jwt, session,
 def test_update_contact_valid_email_format_returns_200(client, jwt, session,
                                                        keycloak_mock):  # pylint:disable=unused-argument
     """Assert that updating with an validly formatted contact with special characters in email returns a 200."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -423,7 +423,7 @@ def test_update_contact_valid_email_format_returns_200(client, jwt, session,
 
 def test_update_contact_no_org_returns_404(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that updating a contact on a non-existant entity returns 404."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.put('/api/v1/orgs/{}/contacts'.format(99),
                     headers=headers, data=json.dumps(TestContactInfo.contact1), content_type='application/json')
     assert rv.status_code == http_status.HTTP_404_NOT_FOUND
@@ -431,7 +431,7 @@ def test_update_contact_no_org_returns_404(client, jwt, session):  # pylint:disa
 
 def test_update_contact_missing_returns_404(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that updating a non-existant contact returns 404."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -445,7 +445,7 @@ def test_update_contact_missing_returns_404(client, jwt, session, keycloak_mock)
 
 def test_delete_contact(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a contact can be deleted on an org."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -471,7 +471,7 @@ def test_delete_contact(client, jwt, session, keycloak_mock):  # pylint:disable=
 
 def test_delete_contact_no_org_returns_404(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that deleting a contact on a non-existant entity returns 404."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.delete('/api/v1/orgs/{}/contacts'.format(99),
                        headers=headers, data=json.dumps(TestContactInfo.contact1), content_type='application/json')
     assert rv.status_code == http_status.HTTP_404_NOT_FOUND
@@ -479,7 +479,7 @@ def test_delete_contact_no_org_returns_404(client, jwt, session):  # pylint:disa
 
 def test_delete_contact_returns_exception(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that attempting to delete an org returns an exception."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -493,7 +493,7 @@ def test_delete_contact_returns_exception(client, jwt, session, keycloak_mock): 
 
 def test_get_members(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a list of members for an org can be retrieved."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -512,7 +512,7 @@ def test_get_members(client, jwt, session, keycloak_mock):  # pylint:disable=unu
 
 def test_delete_org(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be deleted."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -528,7 +528,7 @@ def test_delete_org_failure_affiliation(client, jwt, session, keycloak_mock):  #
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.passcode)
     rv = client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity_lear_mock),
                      headers=headers, content_type='application/json')
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -546,7 +546,7 @@ def test_delete_org_failure_affiliation(client, jwt, session, keycloak_mock):  #
 def test_delete_org_failure_members(client, jwt, session, auth_mock, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a member of an org can have their role updated."""
     # Set up: create/login user, create org
-    headers_invitee = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers_invitee = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers_invitee, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers_invitee, content_type='application/json')
@@ -598,7 +598,7 @@ def test_delete_org_failure_members(client, jwt, session, auth_mock, keycloak_mo
 
 def test_get_invitations(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a list of invitations for an org can be retrieved."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -625,7 +625,7 @@ def test_get_invitations(client, jwt, session, keycloak_mock):  # pylint:disable
 def test_update_member(client, jwt, session, auth_mock, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a member of an org can have their role updated."""
     # Set up: create/login user, create org
-    headers_invitee = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers_invitee = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers_invitee, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers_invitee, content_type='application/json')
@@ -676,7 +676,7 @@ def test_add_affiliation(client, jwt, session, keycloak_mock):  # pylint:disable
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.passcode)
     rv = client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity_lear_mock),
                      headers=headers, content_type='application/json')
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -693,7 +693,7 @@ def test_add_affiliation(client, jwt, session, keycloak_mock):  # pylint:disable
 def test_add_affiliation_invalid_format_returns_400(client, jwt, session,
                                                     keycloak_mock):  # pylint:disable=unused-argument
     """Assert that adding an invalidly formatted affiliations returns a 400."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -707,7 +707,7 @@ def test_add_affiliation_invalid_format_returns_400(client, jwt, session,
 
 def test_add_affiliation_no_org_returns_404(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that adding a contact to a non-existant org returns 404."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/orgs/{}/affiliations'.format(99), headers=headers,
                      data=json.dumps(TestAffliationInfo.affliation1), content_type='application/json')
     assert rv.status_code == http_status.HTTP_404_NOT_FOUND
@@ -718,7 +718,7 @@ def test_add_affiliation_returns_exception(client, jwt, session, keycloak_mock):
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.passcode)
     rv = client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity1),
                      headers=headers, content_type='application/json')
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -741,7 +741,7 @@ def test_get_affiliations(client, jwt, session, keycloak_mock):  # pylint:disabl
                      headers=headers, content_type='application/json')
     rv = client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity_lear_mock2),
                      headers=headers, content_type='application/json')
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -769,7 +769,7 @@ def test_search_orgs_for_affiliation(client, jwt, session, keycloak_mock):  # py
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.passcode)
     client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity_lear_mock),
                 headers=headers, content_type='application/json')
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -793,7 +793,7 @@ def test_unauthorized_search_orgs_for_affiliation(client, jwt, session,
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.passcode)
     client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity_lear_mock),
                 headers=headers, content_type='application/json')
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -803,6 +803,7 @@ def test_unauthorized_search_orgs_for_affiliation(client, jwt, session,
     client.post('/api/v1/orgs/{}/affiliations'.format(org_id), headers=headers,
                 data=json.dumps(TestAffliationInfo.affiliation3), content_type='application/json')
     # Create a system token
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_user_role)
     rv = client.get('/api/v1/orgs?affiliation={}'.format(TestAffliationInfo.affiliation3.get('businessIdentifier')),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_401_UNAUTHORIZED

--- a/auth-api/tests/unit/api/test_reset.py
+++ b/auth-api/tests/unit/api/test_reset.py
@@ -29,7 +29,7 @@ from tests.utilities.factory_utils import factory_auth_header
 
 def test_reset(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert the endpoint can reset the test data."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
@@ -40,11 +40,11 @@ def test_reset(client, jwt, session, keycloak_mock):  # pylint:disable=unused-ar
 
 def test_reset_unauthorized(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert the endpoint get a unauthorized error if don't have tester role."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/test/reset', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_401_UNAUTHORIZED
 

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -536,8 +536,9 @@ def test_delete_user_with_tester_role(client, jwt, session, keycloak_mock):  # p
 def test_add_user_adds_to_account_holders_group(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a user gets added to account_holders group if the user has any active account."""
     # Create a user in keycloak
-    KEYCLOAK_SERVICE.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
     user_id = user.id
 
     # Create user, org and membserhip in DB

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -42,7 +42,7 @@ KEYCLOAK_SERVICE = KeycloakService()
 
 def test_add_user(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a user can be POSTed."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
 
@@ -85,7 +85,7 @@ def test_add_user_invalid_token_returns_401(client, jwt, session):  # pylint:dis
 
 def test_update_user(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a POST to an existing user updates that user."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
     user = json.loads(rv.data)
@@ -101,7 +101,7 @@ def test_update_user(client, jwt, session):  # pylint:disable=unused-argument
 
 def test_update_user_terms_of_use(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a PATCH to an existing user updates that user."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
     user = json.loads(rv.data)
@@ -119,7 +119,7 @@ def test_update_user_terms_of_use(client, jwt, session):  # pylint:disable=unuse
 
 def test_update_user_terms_of_use_invalid_input(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a PATCH to an existing user updates that user."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
     user = json.loads(rv.data)
@@ -135,7 +135,7 @@ def test_update_user_terms_of_use_invalid_input(client, jwt, session):  # pylint
 
 def test_update_user_terms_of_use_no_jwt(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a PATCH to an existing user updates that user."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
     user = json.loads(rv.data)
@@ -151,13 +151,13 @@ def test_update_user_terms_of_use_no_jwt(client, jwt, session):  # pylint:disabl
 def test_staff_get_user(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a staff user can GET a user by id."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
 
     # GET the test user as a staff user
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_role)
-    rv = client.get('/api/v1/users/{}'.format(TestJwtClaims.edit_role['preferred_username']),
+    rv = client.get('/api/v1/users/{}'.format(TestJwtClaims.public_user_role['preferred_username']),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
     user = json.loads(rv.data)
@@ -174,7 +174,7 @@ def test_staff_get_user_invalid_id_returns_404(client, jwt, session):  # pylint:
 def test_staff_search_users(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a staff user can GET a list of users with search parameters."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
 
@@ -201,7 +201,7 @@ def test_staff_search_users(client, jwt, session):  # pylint:disable=unused-argu
 def test_get_user(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a user can retrieve their own profile."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
     rv = client.get('/api/v1/users/@me', headers=headers, content_type='application/json')
@@ -218,7 +218,7 @@ def test_get_user_returns_401(client, session):  # pylint:disable=unused-argumen
 
 def test_get_user_returns_404(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that the endpoint returns 404 when user is not found."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.get('/api/v1/users/@me', headers=headers, content_type='application/json')
     assert rv.status_code == Error.DATA_NOT_FOUND.status_code
 
@@ -226,7 +226,7 @@ def test_get_user_returns_404(client, jwt, session):  # pylint:disable=unused-ar
 def test_add_contact(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a contact can be added (POST) to an existing user."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     # POST a contact to test user
@@ -240,7 +240,7 @@ def test_add_contact(client, jwt, session):  # pylint:disable=unused-argument
 def test_add_contact_valid_email_with_special_characters(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that a contact can be added (POST) to an existing user."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     # POST a contact to test user
@@ -261,7 +261,7 @@ def test_add_contact_no_token_returns_401(client, session):  # pylint:disable=un
 def test_add_contact_invalid_format_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that adding a contact in an invalid format returns a 400."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     rv = client.post('/api/v1/users/contacts', data=json.dumps(TestContactInfo.invalid),
@@ -272,7 +272,7 @@ def test_add_contact_invalid_format_returns_400(client, jwt, session):  # pylint
 def test_add_contact_duplicate_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that adding a contact for a user who already has a contact returns a 400."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     # POST a contact to test user
@@ -288,7 +288,7 @@ def test_add_contact_duplicate_returns_400(client, jwt, session):  # pylint:disa
 def test_update_contact(client, jwt, session):  # pylint:disable=unused-argument, invalid-name
     """Assert that a contact can be updated (PUT) on an existing user."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     # POST a contact to test user
@@ -314,7 +314,7 @@ def test_update_contact_no_token_returns_401(client, session):  # pylint:disable
 def test_update_contact_invalid_format_returns_400(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that adding a contact in an invalid format returns a 400."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     rv = client.put('/api/v1/users/contacts', data=json.dumps(TestContactInfo.invalid),
@@ -325,7 +325,7 @@ def test_update_contact_invalid_format_returns_400(client, jwt, session):  # pyl
 def test_update_contact_missing_contact_returns_404(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that updating a contact for a non-existent user returns a 404."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     # PUT a contact to test user
@@ -337,7 +337,7 @@ def test_update_contact_missing_contact_returns_404(client, jwt, session):  # py
 def test_delete_contact(client, jwt, session):  # pylint:disable=unused-argument, invalid-name
     """Assert that a contact can be deleted on an existing user."""
     # POST a test user
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     # POST a contact to test user
@@ -363,7 +363,7 @@ def test_delete_contact_no_token_returns_401(client, session):  # pylint:disable
 
 def test_delete_contact_no_contact_returns_404(client, jwt, session):  # pylint:disable=unused-argument, invalid-name
     """Assert that deleting a contact that doesn't exist returns a 404."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     rv = client.delete('/api/v1/users/contacts', headers=headers, content_type='application/json')
@@ -372,7 +372,7 @@ def test_delete_contact_no_contact_returns_404(client, jwt, session):  # pylint:
 
 def test_get_orgs_for_user(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that retrieving a list of orgs for a user functions."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
 
     # Add an org - the current user should be auto-added as an OWNER
@@ -397,7 +397,7 @@ def test_user_authorizations_returns_200(client, jwt, session):  # pylint:disabl
     entity = factory_entity_model()
     factory_affiliation_model(entity.id, org.id)
 
-    claims = copy.deepcopy(TestJwtClaims.edit_role.value)
+    claims = copy.deepcopy(TestJwtClaims.public_user_role.value)
     claims['sub'] = str(user.keycloak_guid)
 
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -417,7 +417,7 @@ def test_user_authorizations_returns_200(client, jwt, session):  # pylint:disabl
 
 def test_delete_user_with_no_orgs_returns_204(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Test if the user doesn't have any teams/orgs assert status is 204."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
 
@@ -430,7 +430,7 @@ def test_delete_user_with_no_orgs_returns_204(client, jwt, session, keycloak_moc
 
 def test_delete_inactive_user_returns_400(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Test if the user doesn't have any teams/orgs assert status is 204."""
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.edit_role)
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
 
@@ -471,7 +471,7 @@ def test_delete_user_as_only_admin_returns_400(client, jwt, session, keycloak_mo
     affiliation = AffiliationModel(org_id=org_id, entity_id=entity.id)
     affiliation.save()
 
-    claims = copy.deepcopy(TestJwtClaims.edit_role.value)
+    claims = copy.deepcopy(TestJwtClaims.public_user_role.value)
     claims['sub'] = str(user_model.keycloak_guid)
 
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -508,7 +508,7 @@ def test_delete_user_is_member_returns_204(client, jwt, session, keycloak_mock):
                                  membership_type_status=Status.ACTIVE.value)
     membership.save()
 
-    claims = copy.deepcopy(TestJwtClaims.edit_role.value)
+    claims = copy.deepcopy(TestJwtClaims.public_user_role.value)
     claims['sub'] = str(user_model2.keycloak_guid)
 
     headers = factory_auth_header(jwt=jwt, claims=claims)

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -35,7 +35,7 @@ from tests.utilities.factory_utils import (
     factory_membership_model, factory_org_model, factory_user_model, factory_invitation_anonymous)
 
 from auth_api.services.keycloak import KeycloakService
-from auth_api.utils.constants import GROUP_ACCOUNT_HOLDERS
+from auth_api.utils.constants import GROUP_ACCOUNT_HOLDERS, BCROS
 
 KEYCLOAK_SERVICE = KeycloakService()
 
@@ -64,7 +64,7 @@ def test_add_user_admin_valid_bcros(client, jwt, session, keycloak_mock):  # pyl
                      headers={'invitation_token': dictionary.get('token')}, content_type='application/json')
     dictionary = json.loads(rv.data)
     assert rv.status_code == http_status.HTTP_201_CREATED
-    assert dictionary['users'][0].get('username') == TestUserInfo.user_anonymous_1['username']
+    assert dictionary['users'][0].get('username') == BCROS+'/'+TestUserInfo.user_anonymous_1['username']
     assert dictionary['users'][0].get('password') is None
     assert dictionary['users'][0].get('type') == 'ANONYMOUS'
 

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -64,7 +64,7 @@ def test_add_user_admin_valid_bcros(client, jwt, session, keycloak_mock):  # pyl
                      headers={'invitation_token': dictionary.get('token')}, content_type='application/json')
     dictionary = json.loads(rv.data)
     assert rv.status_code == http_status.HTTP_201_CREATED
-    assert dictionary['users'][0].get('username') == BCROS+'/'+TestUserInfo.user_anonymous_1['username']
+    assert dictionary['users'][0].get('username') == BCROS + '/' + TestUserInfo.user_anonymous_1['username']
     assert dictionary['users'][0].get('password') is None
     assert dictionary['users'][0].get('type') == 'ANONYMOUS'
 

--- a/auth-api/tests/unit/services/test_entity.py
+++ b/auth-api/tests/unit/services/test_entity.py
@@ -96,7 +96,7 @@ def test_update_entity_existing_success(session):  # pylint:disable=unused-argum
         'corpTypeCode': TestEntityInfo.bc_entity_passcode4['corpTypeCode']
     }
     user_with_token = TestUserInfo.user_test
-    user_with_token['keycloak_guid'] = TestJwtClaims.edit_role['sub']
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_user_role['sub']
 
     updated_entity = EntityService.update_entity(entity.as_dict().get('businessIdentifier'), updated_entity_info,
                                                  {'loginSource': '', 'realm_access': {'roles': ['system']},
@@ -127,7 +127,7 @@ def test_update_entity_existing_failures(session):  # pylint:disable=unused-argu
         'corpTypeCode': TestEntityInfo.bc_entity_passcode4['corpTypeCode']
     }
     user_with_token = TestUserInfo.user_test
-    user_with_token['keycloak_guid'] = TestJwtClaims.edit_role['sub']
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_user_role['sub']
 
     with pytest.raises(BusinessException) as exception:
         EntityService.update_entity(entity.as_dict().get('businessIdentifier'), updated_entity_info,
@@ -163,7 +163,7 @@ def test_update_entity_existing_failures_no_cp_for_saved_entity(session):  # pyl
         'corpTypeCode': TestEntityInfo.bc_entity_passcode4['corpTypeCode']
     }
     user_with_token = TestUserInfo.user_test
-    user_with_token['keycloak_guid'] = TestJwtClaims.edit_role['sub']
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_user_role['sub']
 
     with pytest.raises(BusinessException) as exception:
         EntityService.update_entity(entity.as_dict().get('businessIdentifier'), updated_entity_info,

--- a/auth-api/tests/unit/services/test_invitation.py
+++ b/auth-api/tests/unit/services/test_invitation.py
@@ -181,7 +181,7 @@ def test_accept_invitation(session, auth_mock, keycloak_mock):  # pylint:disable
         with patch.object(auth, 'check_auth', return_value=True):
             with patch.object(InvitationService, 'notify_admin', return_value=None):
                 user_with_token = TestUserInfo.user_test
-                user_with_token['keycloak_guid'] = TestJwtClaims.edit_role['sub']
+                user_with_token['keycloak_guid'] = TestJwtClaims.public_user_role['sub']
                 user = factory_user_model(user_with_token)
                 org = OrgService.create_org(TestOrgInfo.org1, user_id=user.id)
                 org_dictionary = org.as_dict()
@@ -194,7 +194,7 @@ def test_accept_invitation(session, auth_mock, keycloak_mock):  # pylint:disable
                 InvitationService.accept_invitation(new_invitation_dict['id'], User(user_invitee), '')
                 members = MembershipService.get_members_for_org(org_dictionary['id'],
                                                                 'PENDING_APPROVAL',
-                                                                token_info=TestJwtClaims.edit_role)
+                                                                token_info=TestJwtClaims.public_user_role)
                 assert members
                 assert len(members) == 1
 
@@ -239,7 +239,7 @@ def test_get_invitations_by_org_id(session, auth_mock, keycloak_mock):  # pylint
     """Find an existing invitation with the provided org id."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
         user_with_token = TestUserInfo.user_test
-        user_with_token['keycloak_guid'] = TestJwtClaims.edit_role['sub']
+        user_with_token['keycloak_guid'] = TestJwtClaims.public_user_role['sub']
         user = factory_user_model(user_with_token)
         org = OrgService.create_org(TestOrgInfo.org1, user_id=user.id)
         org_dictionary = org.as_dict()
@@ -248,7 +248,7 @@ def test_get_invitations_by_org_id(session, auth_mock, keycloak_mock):  # pylint
         InvitationService.create_invitation(invitation_info, User(user), {}, '').as_dict()
         invitations: list = InvitationService.get_invitations_for_org(org_id,
                                                                       status='PENDING',
-                                                                      token_info=TestJwtClaims.edit_role)
+                                                                      token_info=TestJwtClaims.public_user_role)
         assert invitations
         assert len(invitations) == 1
 

--- a/auth-api/tests/unit/services/test_keycloak.py
+++ b/auth-api/tests/unit/services/test_keycloak.py
@@ -34,7 +34,6 @@ def test_keycloak_add_user(session):
     request = KeycloakScenario.create_user_request()
     user = KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
     assert user.user_name == request.user_name
-    KEYCLOAK_SERVICE.delete_user_by_username(request.user_name)
 
 
 def test_keycloak_get_user_by_username(session):
@@ -44,7 +43,6 @@ def test_keycloak_get_user_by_username(session):
     KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
     user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
     assert user.user_name == request.user_name
-    KEYCLOAK_SERVICE.delete_user_by_username(request.user_name)
 
 
 def test_keycloak_get_user_by_username_not_exist(session):
@@ -84,8 +82,9 @@ def test_keycloak_get_token_user_not_exist(session):
 def test_keycloak_delete_user_by_username(session):
     """Delete user by username.Assert response is not None."""
     # with app.app_context():
-    KEYCLOAK_SERVICE.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    KEYCLOAK_SERVICE.delete_user_by_username(request.user_name)
     assert True
 
 
@@ -93,12 +92,6 @@ def test_keycloak_delete_user_by_username_user_not_exist(session):
     """Delete user by invalid username. Assert response is None, error code data not found."""
     # with app.app_context():
     # First delete the user if it exists
-    try:
-        if KEYCLOAK_SERVICE.get_user_by_username(KeycloakScenario.create_user_request().user_name):
-            KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)
-    except Exception:
-        pass
-
     response = None
     try:
         response = KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)

--- a/auth-api/tests/unit/services/test_keycloak.py
+++ b/auth-api/tests/unit/services/test_keycloak.py
@@ -103,8 +103,9 @@ def test_keycloak_delete_user_by_username_user_not_exist(session):
 def test_join_users_group(app, session):
     """Test the public_users group membership for public users."""
     # with app.app_context():
-    KEYCLOAK_SERVICE.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
     user_id = user.id
     KEYCLOAK_SERVICE.join_users_group({'sub': user_id,
                                        'loginSource': BCSC,
@@ -125,14 +126,13 @@ def test_join_users_group(app, session):
         groups.append(group.get('name'))
     assert GROUP_ANONYMOUS_USERS in groups
 
-    KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)
-
 
 def test_join_users_group_for_staff_users(session, app):
     """Test the staff user account creation, and assert the public_users group is not added."""
     # with app.app_context():
-    KEYCLOAK_SERVICE.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
     user_id = user.id
     KEYCLOAK_SERVICE.join_users_group({'sub': user_id, 'loginSource': STAFF, 'realm_access': {'roles': []}})
     # Get the user groups and verify the public_users group is in the list
@@ -142,13 +142,12 @@ def test_join_users_group_for_staff_users(session, app):
         groups.append(group.get('name'))
     assert GROUP_PUBLIC_USERS not in groups
 
-    KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)
-
 
 def test_join_users_group_for_existing_users(session):
     """Test the existing user account, and assert the public_users group is not added."""
-    KEYCLOAK_SERVICE.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
     user_id = user.id
     KEYCLOAK_SERVICE.join_users_group(
         {'sub': user_id, 'loginSource': BCSC, 'realm_access': {'roles': [Role.EDITOR.value]}})
@@ -159,13 +158,12 @@ def test_join_users_group_for_existing_users(session):
         groups.append(group.get('name'))
     assert GROUP_PUBLIC_USERS not in groups
 
-    KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)
-
 
 def test_join_account_holders_group(session):
     """Assert that the account_holders group is getting added to the user."""
-    KEYCLOAK_SERVICE.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
     user_id = user.id
     KEYCLOAK_SERVICE.join_account_holders_group(keycloak_guid=user_id)
     # Get the user groups and verify the public_users group is in the list
@@ -175,13 +173,12 @@ def test_join_account_holders_group(session):
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS in groups
 
-    KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)
-
 
 def test_join_account_holders_group_from_token(session, monkeypatch):
     """Assert that the account_holders group is getting added to the user."""
-    KEYCLOAK_SERVICE.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
     user_id = user.id
 
     # Patch token info
@@ -205,13 +202,12 @@ def test_join_account_holders_group_from_token(session, monkeypatch):
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS in groups
 
-    KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)
-
 
 def test_remove_from_account_holders_group(session):
     """Assert that the account_holders group is removed from the user."""
-    KEYCLOAK_SERVICE.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
     user_id = user.id
     KEYCLOAK_SERVICE.join_account_holders_group(keycloak_guid=user_id)
     # Get the user groups and verify the public_users group is in the list
@@ -226,5 +222,3 @@ def test_remove_from_account_holders_group(session):
     for group in user_groups:
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS not in groups
-
-    KEYCLOAK_SERVICE.delete_user_by_username(KeycloakScenario.create_user_request().user_name)

--- a/auth-api/tests/unit/services/test_membership.py
+++ b/auth-api/tests/unit/services/test_membership.py
@@ -33,8 +33,9 @@ def test_accept_invite_adds_group_to_the_user(session, monkeypatch):  # pylint:d
     """Assert that accepting an invite adds group to the user."""
     # Create a user in keycloak
     keycloak_service = KeycloakService()
-    keycloak_service.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    kc_user = keycloak_service.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    keycloak_service.add_user(request, return_if_exists=True)
+    kc_user = keycloak_service.get_user_by_username(request.user_name)
     user = factory_user_model(TestUserInfo.get_user_with_kc_guid(kc_guid=kc_user.id))
 
     # Patch token info
@@ -51,8 +52,9 @@ def test_accept_invite_adds_group_to_the_user(session, monkeypatch):  # pylint:d
     monkeypatch.setattr('auth_api.services.keycloak.KeycloakService._get_token_info', token_info)
     org = OrgService.create_org(TestOrgInfo.org1, user_id=user.id)
     # Create another user
-    keycloak_service.add_user(KeycloakScenario.create_user_request_2(), return_if_exists=True)
-    kc_user2 = keycloak_service.get_user_by_username(KeycloakScenario.create_user_request_2().user_name)
+    request = KeycloakScenario.create_user_request()
+    keycloak_service.add_user(request, return_if_exists=True)
+    kc_user2 = keycloak_service.get_user_by_username(request.user_name)
     user2 = factory_user_model(TestUserInfo.get_user_with_kc_guid(kc_guid=kc_user2.id))
 
     # Add a membership to the user for the org created
@@ -75,8 +77,9 @@ def test_remove_member_removes_group_to_the_user(session, monkeypatch):  # pylin
     """Assert that accepting an invite adds group to the user."""
     # Create a user in keycloak
     keycloak_service = KeycloakService()
-    keycloak_service.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    kc_user = keycloak_service.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    keycloak_service.add_user(request, return_if_exists=True)
+    kc_user = keycloak_service.get_user_by_username(request.user_name)
     user = factory_user_model(TestUserInfo.get_user_with_kc_guid(kc_guid=kc_user.id))
 
     # Patch token info
@@ -93,8 +96,9 @@ def test_remove_member_removes_group_to_the_user(session, monkeypatch):  # pylin
     monkeypatch.setattr('auth_api.services.keycloak.KeycloakService._get_token_info', token_info)
     org = OrgService.create_org(TestOrgInfo.org1, user_id=user.id)
     # Create another user
-    keycloak_service.add_user(KeycloakScenario.create_user_request_2(), return_if_exists=True)
-    kc_user2 = keycloak_service.get_user_by_username(KeycloakScenario.create_user_request_2().user_name)
+    request = KeycloakScenario.create_user_request()
+    keycloak_service.add_user(request, return_if_exists=True)
+    kc_user2 = keycloak_service.get_user_by_username(request.user_name)
     user2 = factory_user_model(TestUserInfo.get_user_with_kc_guid(kc_guid=kc_user2.id))
 
     # Add a membership to the user for the org created

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -328,8 +328,9 @@ def test_create_org_adds_user_to_account_holders_group(session, monkeypatch):  #
     """Assert that an Org creation adds the user to account holders group."""
     # Create a user in keycloak
     keycloak_service = KeycloakService()
-    keycloak_service.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    kc_user = keycloak_service.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    keycloak_service.add_user(request, return_if_exists=True)
+    kc_user = keycloak_service.get_user_by_username(request.user_name)
     user = factory_user_model(TestUserInfo.get_user_with_kc_guid(kc_guid=kc_user.id))
 
     # Patch token info
@@ -358,8 +359,9 @@ def test_delete_org_removes_user_from_account_holders_group(session, monkeypatch
     """Assert that an Org deletion removes the user from account holders group."""
     # Create a user in keycloak
     keycloak_service = KeycloakService()
-    keycloak_service.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    kc_user = keycloak_service.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    keycloak_service.add_user(request, return_if_exists=True)
+    kc_user = keycloak_service.get_user_by_username(request.user_name)
     user = factory_user_model(TestUserInfo.get_user_with_kc_guid(kc_guid=kc_user.id))
 
     # Patch token info
@@ -389,8 +391,9 @@ def test_delete_does_not_remove_user_from_account_holder_group(session, monkeypa
     """Assert that if the user has multiple Orgs, and deleting one doesn't remove account holders group."""
     # Create a user in keycloak
     keycloak_service = KeycloakService()
-    keycloak_service.add_user(KeycloakScenario.create_user_request(), return_if_exists=True)
-    kc_user = keycloak_service.get_user_by_username(KeycloakScenario.create_user_request().user_name)
+    request = KeycloakScenario.create_user_request()
+    keycloak_service.add_user(request, return_if_exists=True)
+    kc_user = keycloak_service.get_user_by_username(request.user_name)
     user = factory_user_model(TestUserInfo.get_user_with_kc_guid(kc_guid=kc_user.id))
 
     # Patch token info

--- a/auth-api/tests/unit/services/test_reset.py
+++ b/auth-api/tests/unit/services/test_reset.py
@@ -69,7 +69,7 @@ def test_reset_user_without_tester_role(session, auth_mock):  # pylint: disable=
     user = factory_user_model(user_info=user_with_token)
     org = factory_org_model(user_id=user.id)
 
-    response = ResetDataService.reset(TestJwtClaims.edit_role)
+    response = ResetDataService.reset(TestJwtClaims.public_user_role)
     assert response is None
 
     found_org = OrgService.find_by_org_id(org.id)

--- a/auth-api/tests/unit/services/test_user.py
+++ b/auth-api/tests/unit/services/test_user.py
@@ -174,7 +174,7 @@ def test_create_user_and_add_membership_admin_bulk_mode_unauthorised(session, au
     membership = [TestAnonymousMembership.generate_random_user(MEMBER)]
 
     with pytest.raises(HTTPException) as excinfo:
-        UserService.create_user_and_add_membership(membership, org.id, token_info=TestJwtClaims.edit_role)
+        UserService.create_user_and_add_membership(membership, org.id, token_info=TestJwtClaims.public_user_role)
     assert excinfo.value.code == 403
 
 
@@ -219,7 +219,7 @@ def test_create_user_and_add_membership_multiple_error_skip_auth_mode(session, a
     membership = [TestAnonymousMembership.generate_random_user(MEMBER),
                   TestAnonymousMembership.generate_random_user(ADMIN)]
     with pytest.raises(BusinessException) as exception:
-        UserService.create_user_and_add_membership(membership, org.id, TestJwtClaims.edit_role,
+        UserService.create_user_and_add_membership(membership, org.id, TestJwtClaims.public_user_role,
                                                    skip_auth=True)
     assert exception.value.code == Error.INVALID_USER_CREDENTIALS.name
 
@@ -403,7 +403,7 @@ def test_user_find_by_username_missing_username(session):  # pylint: disable=unu
 def test_delete_contact_user_link(session, auth_mock, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a contact can not be deleted if contact link exists."""
     user_with_token = TestUserInfo.user_test
-    user_with_token['keycloak_guid'] = TestJwtClaims.edit_role['sub']
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_user_role['sub']
     user_model = factory_user_model(user_info=user_with_token)
     user = UserService(user_model)
 
@@ -420,7 +420,7 @@ def test_delete_contact_user_link(session, auth_mock, keycloak_mock):  # pylint:
     contact_link = contact_link.flush()
     contact_link.commit()
 
-    deleted_contact = UserService.delete_contact(TestJwtClaims.edit_role)
+    deleted_contact = UserService.delete_contact(TestJwtClaims.public_user_role)
 
     assert deleted_contact is None
 

--- a/auth-api/tests/unit/services/test_user_settings.py
+++ b/auth-api/tests/unit/services/test_user_settings.py
@@ -27,7 +27,7 @@ from tests.utilities.factory_utils import factory_user_model
 def test_user_settings(session, auth_mock, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that a contact can not be deleted if contact link exists."""
     user_with_token = TestUserInfo.user_test
-    user_with_token['keycloak_guid'] = TestJwtClaims.edit_role['sub']
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_user_role['sub']
     user_model = factory_user_model(user_info=user_with_token)
     user = UserService(user_model)
 

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -468,20 +468,6 @@ class KeycloakScenario:
         create_user_request.enabled = True
         return create_user_request
 
-    @staticmethod
-    def create_user_request_2():
-        """Return create user request."""
-        create_user_request = KeycloakUser()
-        create_user_request.user_name = 'testuser2'
-        create_user_request.password = '1111'
-        create_user_request.first_name = 'test_first'
-        create_user_request.last_name = 'test_last'
-        create_user_request.email = 'testuser2@gov.bc.ca'
-        create_user_request.attributes = {'corp_type': 'CP', 'source': 'BCSC'}
-        create_user_request.enabled = True
-
-        return create_user_request
-
     # Patch token info
     @staticmethod
     def token_info(kc_guid: str):  # pylint: disable=unused-argument; mocks of library methods

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -19,7 +19,7 @@ import uuid
 from enum import Enum
 from auth_api.services.keycloak_user import KeycloakUser
 from random import choice
-from string import ascii_uppercase
+from string import ascii_uppercase, ascii_lowercase
 
 from config import get_named_config
 
@@ -458,7 +458,7 @@ class KeycloakScenario:
     def create_user_request():
         """Return create user request."""
         create_user_request = KeycloakUser()
-        create_user_request.user_name = 'testuser1'
+        create_user_request.user_name = ''.join(choice(ascii_lowercase) for i in range(5))
         create_user_request.password = '1111'
         create_user_request.first_name = 'test_first'
         create_user_request.last_name = 'test_last'

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -54,7 +54,20 @@ class TestJwtClaims(dict, Enum):
         'preferred_username': 'troublemaker'
     }
 
-    edit_role = {
+    public_user_role = {
+        'iss': CONFIG.JWT_OIDC_TEST_ISSUER,
+        'sub': 'f7a4a1d3-73a8-4cbc-a40f-bb1145302064',
+        'firstname': 'Test',
+        'lastname': 'User',
+        'preferred_username': 'testuser',
+        'realm_access': {
+            'roles': [
+                'public_user'
+            ]
+        }
+    }
+
+    edit_user_role = {
         'iss': CONFIG.JWT_OIDC_TEST_ISSUER,
         'sub': 'f7a4a1d3-73a8-4cbc-a40f-bb1145302064',
         'firstname': 'Test',

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -427,10 +427,6 @@ class TestUserInfo(dict, Enum):
         'username': 'testuser12345',
         'password': 'testuser12345',
     }
-    user_anonymous_2 = {
-        'username': 'testuser12345',
-        'password': 'testuser12345',
-    }
     user_bcros = {
         'username': 'BCROS/CP1234567',
         'firstname': 'Test',

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -458,11 +458,12 @@ class KeycloakScenario:
     def create_user_request():
         """Return create user request."""
         create_user_request = KeycloakUser()
-        create_user_request.user_name = ''.join(choice(ascii_lowercase) for i in range(5))
+        user_name = ''.join(choice(ascii_lowercase) for i in range(5))
+        create_user_request.user_name = user_name
         create_user_request.password = '1111'
         create_user_request.first_name = 'test_first'
         create_user_request.last_name = 'test_last'
-        create_user_request.email = 'testuser1@gov.bc.ca'
+        create_user_request.email = f'{user_name}@gov.bc.ca'
         create_user_request.attributes = {'corp_type': 'CP', 'source': 'BCSC'}
         create_user_request.enabled = True
         return create_user_request

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -201,10 +201,10 @@ class TestJwtClaims(dict, Enum):
     }
     anonymous_bcros_role = {
         'iss': CONFIG.JWT_OIDC_TEST_ISSUER,
-        'sub': 'f7a4a1d3-73a8-4cbc-a40f-bb1145302064',
+        'sub': 'f7a4a1d3-73a8-4cbc-a40f-bb1145302069',
         'firstname': 'Test',
         'lastname': 'User',
-        'preferred_username': 'bcros/testuser',
+        'preferred_username': 'BCROS/testuser',
         'accessType': 'ANONYMOUS',
         'loginSource': 'BCROS',
         'realm_access': {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/3050

*Description of changes:*
Secured many of the endpoints using public role so that anonymous cant use them.
Keycloak tests using random user name and email.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
