### PR TITLE
Adding staff user auth to return expanded details

### DIFF
--- a/auth-api/src/auth_api/models/views/authorization.py
+++ b/auth-api/src/auth_api/models/views/authorization.py
@@ -48,9 +48,16 @@ class Authorization(db.Model):
     folio_number = Column(String)
 
     @classmethod
-    def find_user_authorization_by_business_number(cls, keycloak_guid: uuid, business_identifier: str):
+    def find_user_authorization_by_business_number(cls, business_identifier: str, keycloak_guid: uuid = None):
         """Return authorization view object."""
-        return cls.query.filter_by(keycloak_guid=keycloak_guid, business_identifier=business_identifier).one_or_none()
+        auth = None
+        if keycloak_guid and business_identifier:
+            auth = cls.query.filter_by(keycloak_guid=keycloak_guid,
+                                       business_identifier=business_identifier).one_or_none()
+        if not keycloak_guid and business_identifier:
+            auth = cls.query.filter_by(business_identifier=business_identifier).first()
+
+        return auth
 
     @classmethod
     def find_user_authorization_by_business_number_and_corp_type(cls, business_identifier: str, corp_type: str):

--- a/auth-api/src/auth_api/services/authorization.py
+++ b/auth-api/src/auth_api/services/authorization.py
@@ -40,13 +40,13 @@ class Authorization:
         auth_response = {}
         auth = None
         token_roles = token_info.get('realm_access').get('roles')
-        if 'staff' in token_roles:
-            if 'edit' in token_roles:
-                if expanded:
-                    # Query Authorization view by business identifier
-                    auth = AuthorizationView.find_user_authorization_by_business_number(business_identifier)
-                    auth_response = Authorization(auth).as_dict(expanded)
-                auth_response['roles'] = ['edit', 'view']
+
+        if 'staff' in token_roles and 'edit' in token_roles:
+            if expanded:
+                # Query Authorization view by business identifier
+                auth = AuthorizationView.find_user_authorization_by_business_number(business_identifier)
+                auth_response = Authorization(auth).as_dict(expanded)
+            auth_response['roles'] = ['edit', 'view']
 
         elif Role.SYSTEM.value in token_roles:
             # a service account in keycloak should have corp_type claim setup.

--- a/auth-api/tests/unit/models/views/test_authorization.py
+++ b/auth-api/tests/unit/models/views/test_authorization.py
@@ -30,8 +30,8 @@ def test_find_user_authorization_by_business_number(session):  # pylint:disable=
     membership = factory_membership_model(user.id, org.id)
     entity = factory_entity_model()
     factory_affiliation_model(entity.id, org.id)
-    authorization = Authorization.find_user_authorization_by_business_number(str(user.keycloak_guid),
-                                                                             entity.business_identifier)
+    authorization = Authorization.find_user_authorization_by_business_number(entity.business_identifier,
+                                                                             str(user.keycloak_guid))
 
     assert authorization is not None
     assert authorization.org_membership == membership.membership_type_code
@@ -164,12 +164,12 @@ def test_find_invalid_user_authorization_by_business_number(session):  # pylint:
     factory_membership_model(user.id, org.id)
     entity = factory_entity_model()
     factory_affiliation_model(entity.id, org.id)
-    authorization = Authorization.find_user_authorization_by_business_number(str(uuid.uuid4()),
-                                                                             entity.business_identifier)
+    authorization = Authorization.find_user_authorization_by_business_number(entity.business_identifier,
+                                                                             str(uuid.uuid4()))
     assert authorization is None
 
     # Test with invalid business identifier
-    authorization = Authorization.find_user_authorization_by_business_number(str(uuid.uuid4()), '')
+    authorization = Authorization.find_user_authorization_by_business_number('', str(uuid.uuid4()))
     assert authorization is None
 
 

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -115,7 +115,8 @@ class TestJwtClaims(dict, Enum):
         'preferred_username': 'testuser',
         'realm_access': {
             'roles': [
-                'staff'
+                'staff',
+                'edit'
             ]
         }
     }
@@ -128,7 +129,9 @@ class TestJwtClaims(dict, Enum):
         'preferred_username': 'testuser',
         'realm_access': {
             'roles': [
-                'staff', 'staff_admin'
+                'staff',
+                'staff_admin',
+                'edit'
             ]
         },
         'roles': [

--- a/docs/docs/api_contract/auth-api-1.0.0.yaml
+++ b/docs/docs/api_contract/auth-api-1.0.0.yaml
@@ -3374,9 +3374,20 @@ paths:
               examples:
                 example1:
                   value:
+                    orgMembership: OWNER
                     roles:
                       - search
                       - edit
+                    business:
+                      folioNumber: MOCK1234
+                      name: Mock Business
+                    account:
+                      id: '1234'
+                      name: Mock Account
+                      paymentPreference:
+                        methodOfPayment: CC
+                        bcOnlineUserId: PB25020
+                        bcOnlineAccountId: ''
         default:
           description: unexpected error
           content:


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/3088

*Description of changes:*
-Adding staff user auth to return expanded details


*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
