### PR TITLE
Fix for missing reset button and blank org name

### DIFF
--- a/auth-web/src/components/auth/AccountInfo.vue
+++ b/auth-web/src/components/auth/AccountInfo.vue
@@ -24,7 +24,7 @@
           @key-down="keyDown()"
           @address-update="updateAddress"
           v-if="isPremiumAccount && currentOrgAddress"
-          :disabled="!canChangeAddress"
+          :disabled="!canChangeAddress()"
         >
         </BaseAddress>
       </div>
@@ -126,10 +126,8 @@ export default class AccountInfo extends Mixins(AccountChangeMixin) {
   private canChangeAddress (): boolean {
     if (this.isPremiumAccount) {
       const premiumOwner =
-        this.currentMembership?.membershipTypeCode === MembershipType.Owner
-      // org name is read only ;the only thing which they can change is address
-      // detect any change in address
-      return true
+        this.currentMembership?.membershipTypeCode === MembershipType.Owner || this.currentMembership?.membershipTypeCode === MembershipType.Admin
+      return premiumOwner
     }
     return false
   }

--- a/auth-web/src/router.ts
+++ b/auth-web/src/router.ts
@@ -96,7 +96,7 @@ export function getRoutes (): RouteConfig[] {
     },
     { path: '/setup-account', name: 'setupaccount', component: AccountSetupView, props: true, meta: { requiresAuth: true, requiresProfile: true } },
     { path: '/setup-account-success', name: 'setup-account-success', component: AccountCreationSuccessView, meta: { requiresAuth: true, requiresProfile: true } },
-    { path: '/userprofile/:token?', name: 'userprofile', component: UserProfileView, props: true, meta: { requiresAuth: true } },
+    { path: '/userprofile/:token?', name: 'userprofile', component: UserProfileView, props: true, meta: { requiresAuth: true, requiresProfile: true } },
     { path: '/createaccount', name: 'createaccount', component: CreateAccountView, meta: { requiresAuth: false, requiresProfile: false }, props: true },
     { path: '/duplicateteam', name: 'duplicateteam', component: DuplicateTeamWarningView, meta: { requiresAuth: true } },
     { path: '/validatetoken/:token', name: 'validatetoken', component: AcceptInviteLandingView, props: true, meta: { requiresAuth: false, disabledRoles: [Role.Staff] } },


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/2543
https://github.com/bcgov/entity/issues/3605

- Another fix for user profile being accessible before TOS


*Description of changes:*

Added a reset button [was in UXPIN , i missed it]
added org sync to the mounted

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
