### PR TITLE
3875 out of province dialog

### DIFF
--- a/auth-web/src/components/auth/OutOfProvinceDialog.vue
+++ b/auth-web/src/components/auth/OutOfProvinceDialog.vue
@@ -1,0 +1,47 @@
+<template>
+  <v-card>
+    <v-card-title>Create a BC Registries Account</v-card-title>
+    <v-card-text>
+      <p class="mb-1">Are you a resident of British Columbia?</p>
+    </v-card-text>
+    <v-radio-group class="ml-5" v-model="selection">
+      <v-radio label="Yes" value="yes"></v-radio>
+      <v-radio label="No" value="no"></v-radio>
+    </v-radio-group>
+    <v-card-actions>
+      <v-spacer></v-spacer>
+      <v-btn :disabled="!selection" large color="primary" @click="next()">Next<v-icon left class="ml-3 mr-2">mdi-arrow-right</v-icon></v-btn>
+      <v-btn large @click="cancel()">Cancel</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+@Component({
+  name: 'OutOfProvinceDialog'
+})
+export default class OutOfProvinceDialog extends Vue {
+  @Prop({ default: false }) signedIn
+  private selection = ''
+
+  private next () {
+    if (this.selection === 'yes') {
+      if (this.signedIn) {
+        this.$emit('bc-signed-in')
+      } else {
+        this.$emit('bc-not-signed-in')
+      }
+    } else {
+      this.$emit('oop')
+    }
+  }
+
+  private cancel () {
+    this.$emit('close')
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/auth-web/src/router.ts
+++ b/auth-web/src/router.ts
@@ -24,6 +24,7 @@ import KeyCloakService from 'sbc-common-components/src/services/keycloak.service
 import LaunchDarklyService from 'sbc-common-components/src/services/launchdarkly.services'
 import LeaveTeamLandingView from '@/views/auth/LeaveTeamLandingView.vue'
 import MaintainBusinessView from '@/views/auth/MaintainBusinessView.vue'
+import OutOfProvinceAccount from '@/views/auth/OutOfProvinceAccount.vue'
 import PageNotFound from '@/views/auth/PageNotFound.vue'
 import PaymentReturnView from '@/views/pay/PaymentReturnView.vue'
 import PaymentView from '@/views/pay/PaymentView.vue'
@@ -141,6 +142,7 @@ export function getRoutes (): RouteConfig[] {
     },
     { path: '/change-account', name: 'changeaccount', component: AccountChangeView, props: true, meta: { requiresAuth: true, requiresProfile: true } },
     { path: '/setup-account', name: 'setupaccount', component: AccountSetupView, props: true, meta: { requiresAuth: true, requiresProfile: true } },
+    { path: '/setup-account-oop', name: 'setupaccount-oop', component: OutOfProvinceAccount, props: true, meta: { requiresAuth: false, requiresProfile: false } },
     { path: '/change-account-success', name: 'change-account-success', component: AccountChangeSuccessView, meta: { requiresAuth: true, requiresProfile: true } },
     { path: '/setup-account-success', name: 'setup-account-success', component: AccountCreationSuccessView, meta: { requiresAuth: true, requiresProfile: true } },
     { path: '/userprofile/:token?', name: 'userprofile', component: UserProfileView, props: true, meta: { requiresAuth: true, requiresProfile: true } },

--- a/auth-web/src/views/auth/HomeView.vue
+++ b/auth-web/src/views/auth/HomeView.vue
@@ -29,7 +29,7 @@
               <v-btn large outlined color="#ffffff"
                 class="cta-btn"
                 v-if="!isDirSearchUser"
-                @click="createAccount()">
+                @click="oopDialog = true">
                 Create a new BC Registries Account
               </v-btn>
             </div>
@@ -37,7 +37,7 @@
             <!-- Non-authenticated -->
             <v-btn large color="#fcba19" class="cta-btn"
               v-if="!userProfile"
-              @click="accountDialog = true">
+              @click="oopDialog = true">
               Create a BC Registries Account
             </v-btn>
           </div>
@@ -50,6 +50,17 @@
               </template>
             </LoginBCSC>
           </v-dialog>
+
+          <v-dialog v-model="oopDialog" max-width="640">
+            <OutOfProvinceDialog
+              @close="oopDialog = false"
+              @oop = "goToOutOfProvince()"
+              @bc-not-signed-in = "oopDialog = false; accountDialog = true"
+              @bc-signed-in = "createAccount()"
+              :signed-in = "!!userProfile"
+            />
+          </v-dialog>
+
         </v-container>
       </header>
       <div class="how-to-container">
@@ -235,13 +246,15 @@ import { AccountSettings } from '@/models/account-settings'
 import ConfigHelper from '@/util/config-helper'
 import { KCUserProfile } from 'sbc-common-components/src/models/KCUserProfile'
 import LoginBCSC from '@/components/auth/LoginBCSC.vue'
+import OutOfProvinceDialog from '@/components/auth/OutOfProvinceDialog.vue'
 import { User } from '@/models/user'
 import { VueConstructor } from 'vue'
 
 @Component({
   name: 'Home',
   components: {
-    LoginBCSC
+    LoginBCSC,
+    OutOfProvinceDialog
   },
   computed: {
     ...mapState('user', ['userProfile', 'currentUser']),
@@ -260,6 +273,7 @@ export default class HomeView extends Vue {
   private readonly currentUser!: KCUserProfile
   private noPasscodeDialog = false
   private accountDialog = false
+  private oopDialog = false
   private isDirSearchUser: boolean = false
   private isStaffUser: boolean = false
   private readonly resetCurrentOrganisation!: () => void
@@ -283,6 +297,10 @@ export default class HomeView extends Vue {
 
   private login () {
     this.$router.push(`/signin/bcsc/${Pages.CREATE_ACCOUNT}`)
+  }
+
+  private goToOutOfProvince () {
+    this.$router.push(`/setup-account-oop`)
   }
 
   mounted () {

--- a/auth-web/src/views/auth/OutOfProvinceAccount.vue
+++ b/auth-web/src/views/auth/OutOfProvinceAccount.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>TODO: Out of province instructions go here</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({})
+</script>
+
+<style lang="scss" scoped>
+
+</style>


### PR DESCRIPTION
*Issue #:* 3875
https://github.com/bcgov/entity/issues/3875

*Description of changes:*

Add intercept to `Create Account` button on home page view.  Shows dialog that prompts for selection of out of province flow.

Includes route and stub view for Out of Province instructions view.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
