### PR TITLE
4176: Changes to add org contact on search endpoint

### DIFF
--- a/auth-api/config.py
+++ b/auth-api/config.py
@@ -276,6 +276,8 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     MINIO_BUCKET_ACCOUNTS = 'accounts'
     MINIO_SECURE = False
 
+    STAFF_ADMIN_EMAIL = 'test@test.com'
+
 
 class ProdConfig(_Config):  # pylint: disable=too-few-public-methods
     """Production environment configuration."""

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -92,12 +92,12 @@ class Affiliation:
         # NR Numbers
         nr_numbers = nr_number_name_dict.keys()
 
-        new_data: list = []
+        filtered_affiliations: list = []
         for entity in data:
             if entity['corpType']['code'] == CorpType.NR.value:
                 # If there is a TMP affiliation present for the NR, do not show NR
                 if not entity['businessIdentifier'] in tmp_business_list:
-                    new_data.append(entity)
+                    filtered_affiliations.append(entity)
 
             elif entity['corpType']['code'] == CorpType.TMP.value:
 
@@ -110,12 +110,12 @@ class Affiliation:
                     if entity['name'] in nr_numbers:
                         entity['name'] = nr_number_name_dict[entity['name']]
 
-                    new_data.append(entity)
+                    filtered_affiliations.append(entity)
             else:
-                new_data.append(entity)
+                filtered_affiliations.append(entity)
 
         current_app.logger.debug('>find_affiliations_by_org_id')
-        return new_data
+        return filtered_affiliations
 
     @staticmethod
     def create_affiliation(org_id, business_identifier, pass_code=None, token_info: Dict = None):

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -28,7 +28,6 @@ from auth_api.services.org import Org as OrgService
 from auth_api.utils.enums import CorpType, NRNameStatus, NRStatus
 from auth_api.utils.passcode import validate_passcode
 from auth_api.utils.roles import ALL_ALLOWED_ROLES, CLIENT_AUTH_ROLES, STAFF
-
 from .rest_service import RestService
 
 
@@ -89,17 +88,34 @@ class Affiliation:
                                for d in data if d['corpType']['code'] == CorpType.NR.value}
         # Create a list of all temporary business names
         tmp_business_list = [d['name'] for d in data if d['corpType']['code'] == CorpType.TMP.value]
-        # Filter all affiliations with business identifier in tmp_business_list and tis Name Request
-        data = list(filter(lambda aff: (not (aff['corpType']['code'] == CorpType.NR.value and aff['businessIdentifier']
-                                             in tmp_business_list)), data))
-        # Replace the name of temporary business registration with NR Name
+
+        # NR Numbers
         nr_numbers = nr_number_name_dict.keys()
-        for affiliation in data:
-            if affiliation['corpType']['code'] == CorpType.TMP.value and affiliation['name'] in nr_numbers:
-                affiliation['name'] = nr_number_name_dict[affiliation['name']]
+
+        new_data: list = []
+        for entity in data:
+            if entity['corpType']['code'] == CorpType.NR.value:
+                # If there is a TMP affiliation present for the NR, do not show NR
+                if not entity['businessIdentifier'] in tmp_business_list:
+                    new_data.append(entity)
+
+            elif entity['corpType']['code'] == CorpType.TMP.value:
+
+                # If affiliation is not for a named company IA, and not a Numbered company
+                # (name and businessIdentifier same)
+                # --> Its a Temp affiliation with incorporation complete.
+                # In this case, a TMP affiliation will be there but the name will be BC...
+                if entity['name'] in nr_numbers or entity['name'] == entity['businessIdentifier']:
+                    # If temp affiliation is for an NR, change the name to NR's name
+                    if entity['name'] in nr_numbers:
+                        entity['name'] = nr_number_name_dict[entity['name']]
+
+                    new_data.append(entity)
+            else:
+                new_data.append(entity)
 
         current_app.logger.debug('>find_affiliations_by_org_id')
-        return data
+        return new_data
 
     @staticmethod
     def create_affiliation(org_id, business_identifier, pass_code=None, token_info: Dict = None):

--- a/auth-api/src/auth_api/services/notification.py
+++ b/auth-api/src/auth_api/services/notification.py
@@ -30,6 +30,7 @@ def send_email(subject: str, sender: str, recipients: str, html_body: str):  # p
             'body': html_body
         }
     }
+
     notify_response = RestService.post(notify_url, data=notify_body)
     current_app.logger.info('send_email notify_response')
     if notify_response:

--- a/auth-api/tests/unit/services/test_affidavit.py
+++ b/auth-api/tests/unit/services/test_affidavit.py
@@ -23,7 +23,7 @@ from auth_api.services import Org as OrgService
 from auth_api.utils.enums import AffidavitStatus, LoginSource, OrgStatus
 
 from tests.utilities.factory_scenarios import TestJwtClaims, TestAffidavit, TestOrgInfo
-from tests.utilities.factory_utils import factory_user_model
+from tests.utilities.factory_utils import factory_user_model, factory_user_model_with_contact
 
 
 def test_create_affidavit(session, keycloak_mock):  # pylint:disable=unused-argument
@@ -52,7 +52,7 @@ def test_create_affidavit_duplicate(session, keycloak_mock):  # pylint:disable=u
 
 def test_approve_org(session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an Affidavit can be approved."""
-    user = factory_user_model()
+    user = factory_user_model_with_contact()
     token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.BCEID.value)
 
     affidavit_info = TestAffidavit.get_test_affidavit_with_contact()
@@ -70,7 +70,7 @@ def test_approve_org(session, keycloak_mock):  # pylint:disable=unused-argument
 
 def test_reject_org(session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an Affidavit can be rejected."""
-    user = factory_user_model()
+    user = factory_user_model_with_contact()
     token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.BCEID.value)
 
     affidavit_info = TestAffidavit.get_test_affidavit_with_contact()

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -23,7 +23,7 @@ from tests.utilities.factory_scenarios import (
     TestOrgProductsInfo, TestOrgTypeInfo, TestUserInfo)
 from tests.utilities.factory_utils import (
     factory_contact_model, factory_entity_model, factory_entity_service, factory_invitation, factory_membership_model,
-    factory_org_model, factory_org_service, factory_user_model)
+    factory_org_model, factory_org_service, factory_user_model, factory_user_model_with_contact)
 
 import auth_api.services.notification as notification
 from auth_api.exceptions import BusinessException
@@ -475,7 +475,7 @@ def test_create_org_with_a_linked_bcol_details(session, keycloak_mock):  # pylin
 
 def test_create_org_by_bceid_user(session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
-    user = factory_user_model()
+    user = factory_user_model_with_contact()
     token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.BCEID.value)
 
     with patch.object(OrgService, 'send_staff_review_account_reminder', return_value=None) as mock_notify:
@@ -490,7 +490,7 @@ def test_create_org_by_bceid_user(session, keycloak_mock):  # pylint:disable=unu
 
 def test_create_org_by_in_province_bceid_user(session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
-    user = factory_user_model()
+    user = factory_user_model_with_contact()
     token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.BCEID.value)
 
     with patch.object(OrgService, 'send_staff_review_account_reminder', return_value=None) as mock_notify:
@@ -505,7 +505,7 @@ def test_create_org_by_in_province_bceid_user(session, keycloak_mock):  # pylint
 
 def test_create_org_invalid_access_type_user(session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an Org cannot be created by providing wrong access type."""
-    user = factory_user_model()
+    user = factory_user_model_with_contact()
     token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.BCEID.value)
     with pytest.raises(BusinessException) as exception:
         OrgService.create_org(TestOrgInfo.org_regular, user_id=user.id, token_info=token_info)
@@ -519,7 +519,7 @@ def test_create_org_by_verified_bceid_user(session, keycloak_mock):  # pylint:di
     # 2. Create org
     # 3. Approve Org, which will mark the affidavit as approved
     # 4. Same user create new org, which should be ACTIVE.
-    user = factory_user_model()
+    user = factory_user_model_with_contact()
     token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.BCEID.value)
     affidavit_info = TestAffidavit.get_test_affidavit_with_contact()
     AffidavitService.create_affidavit(token_info=token_info, affidavit_info=affidavit_info)
@@ -546,7 +546,7 @@ def test_create_org_by_rejected_bceid_user(session, keycloak_mock):  # pylint:di
     # 2. Create org
     # 3. Reject Org, which will mark the affidavit as rejected
     # 4. Same user create new org, which should be PENDING_AFFIDAVIT_REVIEW.
-    user = factory_user_model()
+    user = factory_user_model_with_contact()
     token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.BCEID.value)
     affidavit_info = TestAffidavit.get_test_affidavit_with_contact()
     AffidavitService.create_affidavit(token_info=token_info, affidavit_info=affidavit_info)
@@ -570,7 +570,7 @@ def test_send_staff_review_account_reminder_exception(session,
                                                       notify_org_mock,
                                                       keycloak_mock):  # pylint:disable=unused-argument
     """Send a reminder with exception."""
-    user = factory_user_model(TestUserInfo.user_test)
+    user = factory_user_model_with_contact(TestUserInfo.user_test)
     org = OrgService.create_org(TestOrgInfo.org1, user_id=user.id)
     org_dictionary = org.as_dict()
 

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -482,6 +482,18 @@ class TestEntityInfo(dict, Enum):
         'corpTypeCode': 'TMP'
     }
 
+    temp_business_incoporated = {
+        'businessIdentifier': 'QWERTYUIO',
+        'name': 'BC1234567890',
+        'corpTypeCode': 'TMP'
+    }
+
+    business_incoporated = {
+        'businessIdentifier': 'BC1234567890',
+        'name': 'My New Incorporated Company',
+        'corpTypeCode': 'BC'
+    }
+
 
 class TestAffliationInfo(dict, Enum):
     """Test scenarios of affliation."""

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -81,6 +81,7 @@ class TestJwtClaims(dict, Enum):
                 'edit'
             ]
         },
+        'email': 'test@test.com',
         'loginSource': LoginSource.BCEID.value
     }
 

--- a/auth-api/tests/utilities/factory_utils.py
+++ b/auth-api/tests/utilities/factory_utils.py
@@ -24,6 +24,7 @@ from tests.utilities.factory_scenarios import (
 from auth_api.models import AccountPaymentSettings as AccountPaymentModel
 from auth_api.models import Affiliation as AffiliationModel
 from auth_api.models import Contact as ContactModel
+from auth_api.models import ContactLink as ContactLinkModel
 from auth_api.models import Documents as DocumentsModel
 from auth_api.models import Entity as EntityModel
 from auth_api.models import Org as OrgModel
@@ -68,10 +69,34 @@ def factory_user_model(user_info: dict = TestUserInfo.user1):
                      lastname=user_info['lastname'],
                      roles=user_info['roles'],
                      keycloak_guid=user_info.get('keycloak_guid', None),
-                     type=user_info.get('access_type', None)
+                     type=user_info.get('access_type', None),
+                     email='test@test.com'
                      )
 
     user.save()
+    return user
+
+
+def factory_user_model_with_contact(user_info: dict = TestUserInfo.user1):
+    """Produce a user model."""
+    user = UserModel(username=user_info['username'],
+                     firstname=user_info['firstname'],
+                     lastname=user_info['lastname'],
+                     roles=user_info['roles'],
+                     keycloak_guid=user_info.get('keycloak_guid', None),
+                     type=user_info.get('access_type', None),
+                     email='test@test.com'
+                     )
+
+    user.save()
+
+    contact = factory_contact_model()
+    contact.save()
+    contact_link = ContactLinkModel()
+    contact_link.contact = contact
+    contact_link.user = user
+    contact_link.save()
+
     return user
 
 

--- a/keycloak/namex_config.json
+++ b/keycloak/namex_config.json
@@ -1,0 +1,323 @@
+{
+  "roles": {
+    "realm": [
+      {
+        "name": "names_editor",
+        "description": "Can edit all the fields of a name request, but cannot Approve or Reject names or the request itself.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "fcf0kpqr",
+        "attributes": {}
+      },
+      {
+        "name": "names_viewer",
+        "description": "Can view the detail of a names request in the names service",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "fcf0kpqr",
+        "attributes": {}
+      },
+      {
+        "name": "names_approver",
+        "description": "Can Approve, Reject a name in the names service",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "fcf0kpqr",
+        "attributes": {}
+      },
+      {
+        "name": "names_manager",
+        "description": "Can perform managerial tasks on the Names Examination application.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "fcf0kpqr",
+        "attributes": {}
+      },
+      {
+        "name": "idir",
+        "description": "IDIR Users",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "fcf0kpqr",
+        "attributes": {}
+      }
+    ]
+  },
+  "groups": [
+    {
+      "name": "NameX_Examiner",
+      "path": "/NameX_Examiner",
+      "attributes": {},
+      "realmRoles": [
+        "names_approver",
+        "names_editor",
+        "names_manager",
+        "names_viewer"
+      ],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "name": "NameX_Manager",
+      "path": "/NameX_Manager",
+      "attributes": {},
+      "realmRoles": [
+        "names_approver",
+        "names_editor",
+        "names_manager",
+        "names_viewer"
+      ],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "name": "NameX_OfficeSupport",
+      "path": "/NameX_OfficeSupport",
+      "attributes": {},
+      "realmRoles": [
+        "names_editor",
+        "names_viewer"
+      ],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "name": "NameX_Viewer",
+      "path": "/NameX_Viewer",
+      "attributes": {},
+      "realmRoles": [
+        "names_viewer"
+      ],
+      "clientRoles": {},
+      "subGroups": []
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "name-requests-web",
+      "rootUrl": "https://namerequest-test.pathfinder.gov.bc.ca/namerequest/",
+      "adminUrl": "/",
+      "baseUrl": "/*",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "https://namerequest-test.pathfinder.gov.bc.ca/namerequest/*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "name": "aud-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "name-requests-web",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "firstname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "displayName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "access_type",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "access_type",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "accessType",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        },
+        {
+          "name": "Source Mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "source",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "loginSource",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "idp_userid",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "idp_userid",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "idp_userid",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "preferred_username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "lastname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "roles"
+      ],
+      "optionalClientScopes": [
+        "offline_access"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/4176

*Description of changes:*
- 4176: Changes to add org contact on search endpoint
- Changes to filter out the temporary affiliation if the entity is already incorporated

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
