### PR TITLE
Added bcolAccountId filter to the org search (#837)

### DIFF
--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -82,9 +82,10 @@ class Orgs(Resource):
         name = request.args.get('name', None)
         status = request.args.get('status', None)
         access_type = request.args.get('access_type', None)
+        bcol_account_id = request.args.get('bcolAccountId', None)
         try:
             response, status = OrgService.search_orgs(business_identifier=business_identifier, access_type=access_type,
-                                                      name=name, status=status), \
+                                                      name=name, status=status, bcol_account_id=bcol_account_id), \
                                http_status.HTTP_200_OK
 
             # If public user is searching , return 200 with empty results if orgs exist

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -452,7 +452,7 @@ class Org:  # pylint: disable=too-many-public-methods
                 orgs['orgs'].append(Org(OrgModel.find_by_org_id(affiliation.org_id)).as_dict())
         else:
             org_models = OrgModel.search_org(kwargs.get('access_type', None), kwargs.get('name', None),
-                                             kwargs.get('status', None))
+                                             kwargs.get('status', None), kwargs.get('bcol_account_id', None))
             for org in org_models:
                 org_dict = Org(org).as_dict()
                 org_dict['contacts'] = []

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -1069,6 +1069,26 @@ def test_add_bcol_linked_org(client, jwt, session, keycloak_mock):  # pylint:dis
     assert rv.json.get('orgType') == OrgType.PREMIUM.value
     assert rv.json.get('name') == TestOrgInfo.bcol_linked()['name']
 
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_role)
+
+    org_search_response = client.get(f"/api/v1/orgs?name={TestOrgInfo.bcol_linked()['name']}",
+                                     headers=headers, content_type='application/json')
+
+    assert len(org_search_response.json.get('orgs')) == 1
+    assert org_search_response.status_code == http_status.HTTP_200_OK
+    orgs = json.loads(org_search_response.data)
+    assert orgs.get('orgs')[0].get('name') == TestOrgInfo.bcol_linked()['name']
+    account_id = orgs.get('orgs')[0].get('payment_settings')[0].get('bcolAccountId')
+
+    # do a search with bcol account id and name
+    org_search_response = client.get(
+        f"/api/v1/orgs?name={TestOrgInfo.bcol_linked()['name']}&bcolAccountId={account_id}",
+        headers=headers, content_type='application/json')
+    orgs = json.loads(org_search_response.data)
+    assert orgs.get('orgs')[0].get('name') == TestOrgInfo.bcol_linked()['name']
+    new_account_id = orgs.get('orgs')[0].get('payment_settings')[0].get('bcolAccountId')
+    assert account_id == new_account_id
+
 
 def test_add_bcol_linked_org_failure_mailing_address(client, jwt, session,
                                                      keycloak_mock):  # pylint:disable=unused-argument


### PR DESCRIPTION
* Added bcolAccountId filter to the org search


*Description of changes:*

https://github.com/bcgov/entity/issues/4187

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
