### PR TITLE
set the corp type as NR

### DIFF
--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -226,7 +226,7 @@ class Affiliation:
                 entity = EntityService.save_entity({
                     'businessIdentifier': business_identifier,
                     'name': name,
-                    'corpTypeCode': corp_type_code,
+                    'corpTypeCode': CorpType.NR.value,
                     'passCodeClaimed': True
                 })
             # Create an affiliation with org


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/4160

*Description of changes:*
The previous commit set the corp type to the actual type of the NR (eg CR), but the API code doesn't support it. It needs to be of type "NR". This caused a 500 error as the NR's actual type could not be inserted (as it is not a valid type in the code table).

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [x] No lint errors
- [ ] ~~No test case failures and proper coverage for all modules/classes~~ no tests for this change
- [ ] ~~Updated the deployment configs for new environment variable(s)~~ no change needed
- [ ] ~~Updated the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests~~ no tests for this change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).