### PR TITLE
Fixed Routes for old invitations ; fixed reset password and adding members in anonymous account by staff

### DIFF
--- a/auth-api/src/auth_api/resources/bcol_profiles.py
+++ b/auth-api/src/auth_api/resources/bcol_profiles.py
@@ -18,6 +18,7 @@ from flask_restplus import Namespace, Resource, cors
 
 from auth_api.exceptions import BusinessException
 from auth_api.jwt_wrapper import JWTWrapper
+from auth_api.utils.roles import Role
 from auth_api.services.org import Org
 from auth_api.tracer import Tracer
 from auth_api.utils.util import cors_preflight
@@ -35,7 +36,7 @@ class BcOnlineProfiles(Resource):
     """Resource for validating BC Online account."""
 
     @staticmethod
-    @_JWT.requires_auth
+    @_JWT.has_one_of_roles([Role.STAFF_MANAGE_ACCOUNTS.value, Role.PUBLIC_USER.value])
     @TRACER.trace()
     @cors.crossdomain(origin='*')
     def post():

--- a/auth-api/src/auth_api/services/user.py
+++ b/auth-api/src/auth_api/services/user.py
@@ -159,7 +159,7 @@ class User:  # pylint: disable=too-many-instance-attributes
             if len(memberships) > 1 or memberships[0].get('membershipType') not in [ADMIN, COORDINATOR]:
                 raise BusinessException(Error.INVALID_USER_CREDENTIALS, None)
         else:
-            check_auth(org_id=org_id, token_info=token_info, one_of_roles=(COORDINATOR, ADMIN))
+            check_auth(org_id=org_id, token_info=token_info, one_of_roles=(COORDINATOR, ADMIN, STAFF))
         # check if anonymous org ;these actions cannot be performed on normal orgs
         org = OrgModel.find_by_org_id(org_id)
         if not org or org.access_type != AccessType.ANONYMOUS.value:

--- a/auth-web/src/components/auth/MemberDataTable.vue
+++ b/auth-web/src/components/auth/MemberDataTable.vue
@@ -1,7 +1,7 @@
 <template>
   <v-data-table
     v-if="roleInfos"
-    mobile-breakpoint="1024"
+    :mobile-breakpoint="1024"
     :headers="headerMembers"
     :items="indexedOrgMembers"
     :items-per-page="5"

--- a/auth-web/src/components/auth/TeamManagement.vue
+++ b/auth-web/src/components/auth/TeamManagement.vue
@@ -1,6 +1,5 @@
 <template>
   <v-container>
-    ------{{isAnonymousAccount()}}
     <UserManagement
       v-if="!isAnonymousAccount()"
      ></UserManagement>
@@ -11,17 +10,12 @@
 </template>
 
 <script lang="ts">
-import { AccessType, Account, Role } from '@/util/constants'
-import { Component, Mixins, Prop, Vue } from 'vue-property-decorator'
-import { Member, MembershipStatus, MembershipType, Organization } from '@/models/Organization'
-import { mapActions, mapState } from 'vuex'
+import { AccessType, Role } from '@/util/constants'
+import { Component, Mixins, Prop } from 'vue-property-decorator'
 import AnonymousUserManagement from '@/components/auth/AnonymousUserManagement.vue'
-import { Event } from '@/models/event'
-import { KCUserProfile } from 'sbc-common-components/src/models/KCUserProfile'
 import NextPageMixin from '@/components/auth/mixins/NextPageMixin.vue'
-import OrgModule from '@/store/modules/org'
 import UserManagement from '@/components/auth/UserManagement.vue'
-import { getModule } from 'vuex-module-decorators'
+import { mapState } from 'vuex'
 
 @Component({
   components: {
@@ -29,7 +23,6 @@ import { getModule } from 'vuex-module-decorators'
     AnonymousUserManagement
   },
   computed: {
-    ...mapState('user', ['currentUser']),
     ...mapState('org', [
       'currentMembership',
       'currentOrganization'
@@ -41,11 +34,10 @@ import { getModule } from 'vuex-module-decorators'
 })
 export default class TeamManagement extends Mixins(NextPageMixin) {
   @Prop({ default: '' }) private orgId: string;
-  readonly currentUser!: KCUserProfile
 
   private async mounted () {
     // redirect to dir search/team management according to dir search user role change
-    if (this.isAnonymousAccount()) {
+    if (this.isAnonymousAccount() && !this.currentUser.roles.includes(Role.Staff)) {
       this.redirectTo(this.getNextPageUrl())
     }
   }

--- a/auth-web/src/components/auth/TeamManagement.vue
+++ b/auth-web/src/components/auth/TeamManagement.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container>
+    ------{{isAnonymousAccount()}}
     <UserManagement
       v-if="!isAnonymousAccount()"
      ></UserManagement>
@@ -50,8 +51,7 @@ export default class TeamManagement extends Mixins(NextPageMixin) {
   }
   private isAnonymousAccount (): boolean {
     return this.currentOrganization &&
-            this.currentOrganization.accessType === AccessType.ANONYMOUS &&
-            !this.currentUser.roles.includes(Role.Staff)
+            this.currentOrganization.accessType === AccessType.ANONYMOUS
   }
 }
 </script>

--- a/auth-web/src/routes/router.ts
+++ b/auth-web/src/routes/router.ts
@@ -254,7 +254,7 @@ export function getRoutes (): RouteConfig[] {
       // to handle old invitation; removable this after a month of this release
       path: '/:orgName/dirsearch/validatetoken/:token',
       name: 'createuserprofile',
-      redirect: '/undefined/BCROS/:token'
+      redirect: '/:orgName/validatetoken/BCROS/:token'
     },
     {
       path: '/:orgName/validatetoken/:loginSource/:token',


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/4454

*Description of changes:*

- password reset was not working since wrong view was rendering.This happened because of a faulty check by which accounts are treated like normal accounts for staff.Fixed that check

- member adding by staff was failing bcoz of the permission issues.


*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
