### PR TITLE
Add delete user, assign role function in Keycloak service and add tester role endpoint in Reset api.

### DIFF
--- a/auth-api/src/auth_api/resources/reset.py
+++ b/auth-api/src/auth_api/resources/reset.py
@@ -19,6 +19,7 @@ from flask_restplus import Namespace, Resource, cors
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
 from auth_api.jwt_wrapper import JWTWrapper
+from auth_api.services.keycloak import KeycloakService
 from auth_api.services import ResetTestData as ResetService
 from auth_api.tracer import Tracer
 from auth_api.utils.roles import Role
@@ -30,8 +31,8 @@ TRACER = Tracer.get_instance()
 _JWT = JWTWrapper.get_instance()
 
 
-@cors_preflight('POST,OPTIONS')
-@API.route('', methods=['POST', 'OPTIONS'])
+@cors_preflight('POST, PUT, OPTIONS')
+@API.route('', methods=['POST', 'PUT', 'OPTIONS'])
 class Reset(Resource):
     """Cleanup test data by the provided token."""
 
@@ -46,6 +47,21 @@ class Reset(Resource):
 
         try:
             ResetService.reset(token)
+            response, status = '', http_status.HTTP_204_NO_CONTENT
+        except BusinessException as exception:
+            response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
+        return response, status
+
+    @staticmethod
+    @TRACER.trace()
+    @cors.crossdomain(origin='*')
+    @_JWT.requires_auth
+    def put():
+        """Add tester role to the user during integration test."""
+        token = g.jwt_oidc_token_info
+
+        try:
+            KeycloakService.assign_realm_role_to_user(token.get('sub'), Role.TESTER.value)
             response, status = '', http_status.HTTP_204_NO_CONTENT
         except BusinessException as exception:
             response, status = {'code': exception.code, 'message': exception.message}, exception.status_code

--- a/auth-api/src/auth_api/services/keycloak.py
+++ b/auth-api/src/auth_api/services/keycloak.py
@@ -15,6 +15,7 @@
 
 from typing import Dict
 
+import json
 import requests
 from flask import current_app, g
 
@@ -203,6 +204,23 @@ class KeycloakService:
         KeycloakService._remove_user_from_group(keycloak_guid, GROUP_ACCOUNT_HOLDERS)
 
     @staticmethod
+    def delete_user(keycloak_guid: str = None):
+        """Delete user from Keycloak by username."""
+        if not keycloak_guid:
+            keycloak_guid: Dict = KeycloakService._get_token_info().get('sub')
+
+        KeycloakService._delete_user(keycloak_guid)
+
+    @staticmethod
+    def assign_realm_role_to_user(keycloak_guid: str = None, role: str = None):
+        """Remove one time password setting for bceid user from the keycloak."""
+        if not keycloak_guid:
+            keycloak_guid: Dict = KeycloakService._get_token_info().get('sub')
+
+        if keycloak_guid and role:
+            KeycloakService._assign_realm_role(keycloak_guid, role)
+
+    @staticmethod
     def _add_user_to_group(user_id: str, group_name: str):
         """Add user to the keycloak group."""
         config = current_app.config
@@ -277,3 +295,46 @@ class KeycloakService:
     @staticmethod
     def _get_token_info():
         return g.jwt_oidc_token_info
+
+    @staticmethod
+    def _delete_user(user_id: str):
+        """Remove user from the keycloak."""
+        config = current_app.config
+        base_url = config.get('KEYCLOAK_BASE_URL')
+        realm = config.get('KEYCLOAK_REALMNAME')
+        # Create an admin token
+        admin_token = KeycloakService._get_admin_token()
+
+        headers = {
+            'Content-Type': ContentType.JSON.value,
+            'Authorization': f'Bearer {admin_token}'
+        }
+        delete_user_url = f'{base_url}/auth/admin/realms/{realm}/users/{user_id}'
+        response = requests.delete(delete_user_url, headers=headers)
+        response.raise_for_status()
+
+    @staticmethod
+    def _assign_realm_role(user_id: str, role: str):
+        """Remove one time password setting for bceid user from the keycloak."""
+        config = current_app.config
+        base_url = config.get('KEYCLOAK_BASE_URL')
+        realm = config.get('KEYCLOAK_REALMNAME')
+        # Create an admin token
+        admin_token = KeycloakService._get_admin_token()
+
+        headers = {
+            'Content-Type': ContentType.JSON.value,
+            'Authorization': f'Bearer {admin_token}'
+        }
+
+        get_role_url = f'{base_url}/auth/admin/realms/{realm}/roles/{role}'
+        response = requests.get(get_role_url, headers=headers)
+        input_data = json.dumps([
+            {
+                'id': response.json().get('id'),
+                'name': role
+            }
+        ])
+        assign_role_url = f'{base_url}/auth/admin/realms/{realm}/users/{user_id}/role-mappings/realm'
+        response = requests.post(assign_role_url, headers=headers, data=input_data)
+        response.raise_for_status()

--- a/auth-api/src/auth_api/services/keycloak.py
+++ b/auth-api/src/auth_api/services/keycloak.py
@@ -205,7 +205,7 @@ class KeycloakService:
 
     @staticmethod
     def delete_user(keycloak_guid: str = None):
-        """Delete user from Keycloak by username."""
+        """Delete user from Keycloak. Only for reseting BCeID user purpose."""
         if not keycloak_guid:
             keycloak_guid: Dict = KeycloakService._get_token_info().get('sub')
 
@@ -213,7 +213,7 @@ class KeycloakService:
 
     @staticmethod
     def assign_realm_role_to_user(keycloak_guid: str = None, role: str = None):
-        """Remove one time password setting for bceid user from the keycloak."""
+        """Assign a role to user from the keycloak. Only for reseting BCeID user purpose."""
         if not keycloak_guid:
             keycloak_guid: Dict = KeycloakService._get_token_info().get('sub')
 
@@ -298,7 +298,7 @@ class KeycloakService:
 
     @staticmethod
     def _delete_user(user_id: str):
-        """Remove user from the keycloak."""
+        """Remove user from the keycloak. Only for reseting BCeID user purpose."""
         config = current_app.config
         base_url = config.get('KEYCLOAK_BASE_URL')
         realm = config.get('KEYCLOAK_REALMNAME')
@@ -315,7 +315,7 @@ class KeycloakService:
 
     @staticmethod
     def _assign_realm_role(user_id: str, role: str):
-        """Remove one time password setting for bceid user from the keycloak."""
+        """Assign a role to user from the keycloak. Only for reseting BCeID user purpose."""
         config = current_app.config
         base_url = config.get('KEYCLOAK_BASE_URL')
         realm = config.get('KEYCLOAK_REALMNAME')

--- a/auth-api/src/auth_api/services/reset.py
+++ b/auth-api/src/auth_api/services/reset.py
@@ -16,6 +16,8 @@ from typing import Dict
 
 from auth_api.models import User as UserModel
 from auth_api.models import db
+from auth_api.services.keycloak import KeycloakService
+from auth_api.utils.enums import LoginSource
 from auth_api.utils.roles import Role
 
 
@@ -45,3 +47,9 @@ class ResetTestData:  # pylint:disable=too-few-public-methods
                     user.modified_by = None
                     user.modified_by_id = None
                     user.reset()
+
+                # delete the user in keycloak if from BCEID
+                login_source = token_info.get('loginSource', None)
+
+                if login_source == LoginSource.BCEID.value:
+                    KeycloakService.delete_user(token_info.get('sub'))

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -153,6 +153,7 @@ class IdpHint(Enum):
     """IdpHint for user login."""
 
     BCROS = 'bcros'
+    BCEID = 'bceid'
 
 
 class InvitationStatus(Enum):

--- a/auth-api/tests/docker/setup/demo-realm.json
+++ b/auth-api/tests/docker/setup/demo-realm.json
@@ -856,7 +856,8 @@
           "query-groups",
           "query-users",
           "view-authorization",
-          "view-users"
+          "view-users",
+          "view-realm"
         ],
         "account": [
           "view-profile",

--- a/auth-api/tests/unit/api/test_reset.py
+++ b/auth-api/tests/unit/api/test_reset.py
@@ -19,13 +19,14 @@ Test-Suite to ensure that the /tester/reset endpoint is working as expected.
 import json
 from unittest.mock import patch
 
-from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo
+from tests.utilities.factory_scenarios import KeycloakScenario, TestJwtClaims, TestOrgInfo
 from tests.utilities.factory_utils import factory_auth_header
 
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
 from auth_api.services import ResetTestData as ResetDataService
+from auth_api.services.keycloak import KeycloakService
 
 
 def test_reset(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -55,4 +56,26 @@ def test_reset_returns_exception(client, jwt, session):  # pylint:disable=unused
     with patch.object(ResetDataService, 'reset', side_effect=BusinessException(Error.UNDEFINED_ERROR, None)):
         headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.tester_role)
         rv = client.post('/test/reset', headers=headers, content_type='application/json')
+        assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
+
+
+def test_add_role(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
+    """Assert the endpoint can reset the test data."""
+    request = KeycloakScenario.create_user_request()
+    keycloak_service = KeycloakService()
+    keycloak_service.add_user(request, return_if_exists=True)
+    user = keycloak_service.get_user_by_username(request.user_name)
+    user_id = user.id
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.get_test_real_user(user_id))
+    rv = client.put('/test/reset', headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_204_NO_CONTENT
+
+
+def test_add_role_returns_exception(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that the code type can not be fetched and with expcetion."""
+    with patch.object(KeycloakService,
+                      'assign_realm_role_to_user',
+                      side_effect=BusinessException(Error.UNDEFINED_ERROR, None)):
+        headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.tester_role)
+        rv = client.put('/test/reset', headers=headers, content_type='application/json')
         assert rv.status_code == http_status.HTTP_400_BAD_REQUEST

--- a/auth-api/tests/unit/services/test_keycloak.py
+++ b/auth-api/tests/unit/services/test_keycloak.py
@@ -226,3 +226,24 @@ def test_remove_from_account_holders_group(session):
     for group in user_groups:
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS not in groups
+
+
+def test_delete_user(session):
+    """Assert that the user get deleted in keycloak."""
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
+    user_id = user.id
+    KEYCLOAK_SERVICE.delete_user(user_id)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
+    assert user is None
+
+
+def test_assign_role(session):
+    """Assert that the otp credential type for user get deleted in keycloak."""
+    request = KeycloakScenario.create_user_request()
+    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
+    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
+    user_id = user.id
+    KEYCLOAK_SERVICE.assign_realm_role_to_user(user_id, 'tester')
+    assert True

--- a/auth-api/tests/unit/services/test_reset.py
+++ b/auth-api/tests/unit/services/test_reset.py
@@ -18,7 +18,7 @@ Test-Suite to ensure that the reset data Service is working as expected.
 """
 
 import pytest
-from tests.utilities.factory_scenarios import TestEntityInfo, TestJwtClaims, TestUserInfo
+from tests.utilities.factory_scenarios import KeycloakScenario, TestEntityInfo, TestJwtClaims, TestUserInfo
 from tests.utilities.factory_utils import (
     factory_entity_model, factory_membership_model, factory_org_model, factory_user_model)
 
@@ -29,6 +29,7 @@ from auth_api.services import Org as OrgService
 from auth_api.services import ResetTestData as ResetDataService
 from auth_api.services import User as UserService
 from auth_api.services.entity import Entity as EntityService
+from auth_api.services.keycloak import KeycloakService
 
 
 def test_reset(session, auth_mock):  # pylint: disable=unused-argument
@@ -77,3 +78,49 @@ def test_reset_user_without_tester_role(session, auth_mock):  # pylint: disable=
 
     found_org = OrgService.find_by_org_id(org.id)
     assert found_org is not None
+
+
+def test_reset_bceid_user(session, auth_mock):  # pylint: disable=unused-argument
+    """Assert that reset data from a bceid user."""
+    keycloak_service = KeycloakService()
+    request = KeycloakScenario.create_user_by_user_info(TestJwtClaims.tester_bceid_role)
+    keycloak_service.add_user(request, return_if_exists=True)
+    user = keycloak_service.get_user_by_username(request.user_name)
+    assert user is not None
+    user_id = user.id
+    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token['keycloak_guid'] = user_id
+    user = factory_user_model(user_info=user_with_token)
+    org = factory_org_model(user_id=user.id)
+
+    response = ResetDataService.reset(TestJwtClaims.get_test_user(user_id, 'BCEID'))
+    assert response is None
+
+    found_org = OrgService.find_by_org_id(org.id)
+    assert found_org is None
+
+    user = keycloak_service.get_user_by_username(request.user_name)
+    assert user is None
+
+
+def test_reset_non_bceid_user(session, auth_mock):  # pylint: disable=unused-argument
+    """Assert that reset data from a bceid user."""
+    keycloak_service = KeycloakService()
+    request = KeycloakScenario.create_user_by_user_info(TestJwtClaims.tester_role)
+    keycloak_service.add_user(request, return_if_exists=True)
+    user = keycloak_service.get_user_by_username(request.user_name)
+    assert user is not None
+    user_id = user.id
+    user_with_token = TestUserInfo.user_tester
+    user_with_token['keycloak_guid'] = user_id
+    user = factory_user_model(user_info=user_with_token)
+    org = factory_org_model(user_id=user.id)
+
+    response = ResetDataService.reset(TestJwtClaims.get_test_user(user_id, 'BCSC'))
+    assert response is None
+
+    found_org = OrgService.find_by_org_id(org.id)
+    assert found_org is None
+
+    user = keycloak_service.get_user_by_username(request.user_name)
+    assert user is not None

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -288,6 +288,7 @@ class TestJwtClaims(dict, Enum):
         'firstname': fake.first_name(),
         'lastname': fake.last_name(),
         'preferred_username': fake.user_name(),
+        'loginSource': 'BCSC',
         'realm_access': {
             'roles': [
                 'tester'
@@ -309,6 +310,21 @@ class TestJwtClaims(dict, Enum):
             ]
         },
         'product_code': 'DIR_SEARCH'
+    }
+
+    tester_bceid_role = {
+        'iss': CONFIG.JWT_OIDC_TEST_ISSUER,
+        'sub': 'f7a4a1d3-73a8-4cbc-a40f-bb1145302064',
+        'firstname': fake.first_name(),
+        'lastname': fake.last_name(),
+        'preferred_username': fake.user_name(),
+        'user_name': fake.user_name(),
+        'loginSource': 'BCEID',
+        'realm_access': {
+            'roles': [
+                'tester'
+            ]
+        }
     }
 
     @staticmethod
@@ -340,10 +356,10 @@ class TestJwtClaims(dict, Enum):
             'username': 'CP1234567',
             'realm_access': {
                 'roles': [
-                    'edit', 'uma_authorization', 'staff'
+                    'edit', 'uma_authorization', 'staff', 'tester'
                 ]
             },
-            'roles': ['edit', 'uma_authorization', 'staff'],
+            'roles': ['edit', 'uma_authorization', 'staff', 'tester'],
             'loginSource': source
         }
 
@@ -646,6 +662,14 @@ class TestUserInfo(dict, Enum):
         'keycloak_guid': uuid.uuid4(),
         'access_type': 'ANONYMOUS',
     }
+    user_bceid_tester = {
+        'username': f'{fake.user_name()}@{IdpHint.BCEID.value}',
+        'firstname': fake.first_name(),
+        'lastname': fake.last_name(),
+        'roles': '{edit, uma_authorization, tester}',
+        'keycloak_guid': uuid.uuid4(),
+        'access_type': 'BCEID',
+    }
 
     @staticmethod
     def get_user_with_kc_guid(kc_guid: str):
@@ -673,6 +697,18 @@ class KeycloakScenario:
         create_user_request.last_name = 'test_last'
         create_user_request.email = f'{user_name}@gov.bc.ca'
         create_user_request.attributes = {'corp_type': 'CP', 'source': 'BCSC'}
+        create_user_request.enabled = True
+        return create_user_request
+
+    @staticmethod
+    def create_user_by_user_info(user_info: dict):
+        """Return create user request."""
+        create_user_request = KeycloakUser()
+        create_user_request.user_name = user_info['preferred_username']
+        create_user_request.password = 'Test@123'
+        create_user_request.first_name = user_info['firstname']
+        create_user_request.last_name = user_info['lastname']
+        create_user_request.attributes = {'source': user_info['loginSource']}
         create_user_request.enabled = True
         return create_user_request
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
The BCeID user has otp setting in the keycloak. Currently, there is no way to reset the otp setting through keycloak api. During teardown stage of integration testing, it will call reset api to delete the test user. And, it will add the tester role into test user during setup stage. 

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
