### PR TITLE
Rollback the keycloak service delete user and assign role function.

### DIFF
--- a/auth-api/src/auth_api/resources/reset.py
+++ b/auth-api/src/auth_api/resources/reset.py
@@ -19,7 +19,6 @@ from flask_restplus import Namespace, Resource, cors
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
 from auth_api.jwt_wrapper import JWTWrapper
-from auth_api.services.keycloak import KeycloakService
 from auth_api.services import ResetTestData as ResetService
 from auth_api.tracer import Tracer
 from auth_api.utils.roles import Role
@@ -47,21 +46,6 @@ class Reset(Resource):
 
         try:
             ResetService.reset(token)
-            response, status = '', http_status.HTTP_204_NO_CONTENT
-        except BusinessException as exception:
-            response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
-        return response, status
-
-    @staticmethod
-    @TRACER.trace()
-    @cors.crossdomain(origin='*')
-    @_JWT.requires_auth
-    def put():
-        """Add tester role to the user during integration test."""
-        token = g.jwt_oidc_token_info
-
-        try:
-            KeycloakService.assign_realm_role_to_user(token.get('sub'), Role.TESTER.value)
             response, status = '', http_status.HTTP_204_NO_CONTENT
         except BusinessException as exception:
             response, status = {'code': exception.code, 'message': exception.message}, exception.status_code

--- a/auth-api/src/auth_api/services/reset.py
+++ b/auth-api/src/auth_api/services/reset.py
@@ -16,8 +16,6 @@ from typing import Dict
 
 from auth_api.models import User as UserModel
 from auth_api.models import db
-from auth_api.services.keycloak import KeycloakService
-from auth_api.utils.enums import LoginSource
 from auth_api.utils.roles import Role
 
 
@@ -47,9 +45,3 @@ class ResetTestData:  # pylint:disable=too-few-public-methods
                     user.modified_by = None
                     user.modified_by_id = None
                     user.reset()
-
-                # delete the user in keycloak if from BCEID
-                login_source = token_info.get('loginSource', None)
-
-                if login_source == LoginSource.BCEID.value:
-                    KeycloakService.delete_user(token_info.get('sub'))

--- a/auth-api/tests/unit/api/test_reset.py
+++ b/auth-api/tests/unit/api/test_reset.py
@@ -19,14 +19,13 @@ Test-Suite to ensure that the /tester/reset endpoint is working as expected.
 import json
 from unittest.mock import patch
 
-from tests.utilities.factory_scenarios import KeycloakScenario, TestJwtClaims, TestOrgInfo
+from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo
 from tests.utilities.factory_utils import factory_auth_header
 
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
 from auth_api.services import ResetTestData as ResetDataService
-from auth_api.services.keycloak import KeycloakService
 
 
 def test_reset(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -56,26 +55,4 @@ def test_reset_returns_exception(client, jwt, session):  # pylint:disable=unused
     with patch.object(ResetDataService, 'reset', side_effect=BusinessException(Error.UNDEFINED_ERROR, None)):
         headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.tester_role)
         rv = client.post('/test/reset', headers=headers, content_type='application/json')
-        assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
-
-
-def test_add_role(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
-    """Assert the endpoint can reset the test data."""
-    request = KeycloakScenario.create_user_request()
-    keycloak_service = KeycloakService()
-    keycloak_service.add_user(request, return_if_exists=True)
-    user = keycloak_service.get_user_by_username(request.user_name)
-    user_id = user.id
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.get_test_real_user(user_id))
-    rv = client.put('/test/reset', headers=headers, content_type='application/json')
-    assert rv.status_code == http_status.HTTP_204_NO_CONTENT
-
-
-def test_add_role_returns_exception(client, jwt, session):  # pylint:disable=unused-argument
-    """Assert that the code type can not be fetched and with expcetion."""
-    with patch.object(KeycloakService,
-                      'assign_realm_role_to_user',
-                      side_effect=BusinessException(Error.UNDEFINED_ERROR, None)):
-        headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.tester_role)
-        rv = client.put('/test/reset', headers=headers, content_type='application/json')
         assert rv.status_code == http_status.HTTP_400_BAD_REQUEST

--- a/auth-api/tests/unit/services/test_keycloak.py
+++ b/auth-api/tests/unit/services/test_keycloak.py
@@ -226,24 +226,3 @@ def test_remove_from_account_holders_group(session):
     for group in user_groups:
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS not in groups
-
-
-def test_delete_user(session):
-    """Assert that the user get deleted in keycloak."""
-    request = KeycloakScenario.create_user_request()
-    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
-    user_id = user.id
-    KEYCLOAK_SERVICE.delete_user(user_id)
-    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
-    assert user is None
-
-
-def test_assign_role(session):
-    """Assert that the otp credential type for user get deleted in keycloak."""
-    request = KeycloakScenario.create_user_request()
-    KEYCLOAK_SERVICE.add_user(request, return_if_exists=True)
-    user = KEYCLOAK_SERVICE.get_user_by_username(request.user_name)
-    user_id = user.id
-    KEYCLOAK_SERVICE.assign_realm_role_to_user(user_id, 'tester')
-    assert True

--- a/auth-api/tests/unit/services/test_reset.py
+++ b/auth-api/tests/unit/services/test_reset.py
@@ -18,7 +18,7 @@ Test-Suite to ensure that the reset data Service is working as expected.
 """
 
 import pytest
-from tests.utilities.factory_scenarios import KeycloakScenario, TestEntityInfo, TestJwtClaims, TestUserInfo
+from tests.utilities.factory_scenarios import TestEntityInfo, TestJwtClaims, TestUserInfo
 from tests.utilities.factory_utils import (
     factory_entity_model, factory_membership_model, factory_org_model, factory_user_model)
 
@@ -29,7 +29,6 @@ from auth_api.services import Org as OrgService
 from auth_api.services import ResetTestData as ResetDataService
 from auth_api.services import User as UserService
 from auth_api.services.entity import Entity as EntityService
-from auth_api.services.keycloak import KeycloakService
 
 
 def test_reset(session, auth_mock):  # pylint: disable=unused-argument
@@ -78,49 +77,3 @@ def test_reset_user_without_tester_role(session, auth_mock):  # pylint: disable=
 
     found_org = OrgService.find_by_org_id(org.id)
     assert found_org is not None
-
-
-def test_reset_bceid_user(session, auth_mock):  # pylint: disable=unused-argument
-    """Assert that reset data from a bceid user."""
-    keycloak_service = KeycloakService()
-    request = KeycloakScenario.create_user_by_user_info(TestJwtClaims.tester_bceid_role)
-    keycloak_service.add_user(request, return_if_exists=True)
-    user = keycloak_service.get_user_by_username(request.user_name)
-    assert user is not None
-    user_id = user.id
-    user_with_token = TestUserInfo.user_bceid_tester
-    user_with_token['keycloak_guid'] = user_id
-    user = factory_user_model(user_info=user_with_token)
-    org = factory_org_model(user_id=user.id)
-
-    response = ResetDataService.reset(TestJwtClaims.get_test_user(user_id, 'BCEID'))
-    assert response is None
-
-    found_org = OrgService.find_by_org_id(org.id)
-    assert found_org is None
-
-    user = keycloak_service.get_user_by_username(request.user_name)
-    assert user is None
-
-
-def test_reset_non_bceid_user(session, auth_mock):  # pylint: disable=unused-argument
-    """Assert that reset data from a bceid user."""
-    keycloak_service = KeycloakService()
-    request = KeycloakScenario.create_user_by_user_info(TestJwtClaims.tester_role)
-    keycloak_service.add_user(request, return_if_exists=True)
-    user = keycloak_service.get_user_by_username(request.user_name)
-    assert user is not None
-    user_id = user.id
-    user_with_token = TestUserInfo.user_tester
-    user_with_token['keycloak_guid'] = user_id
-    user = factory_user_model(user_info=user_with_token)
-    org = factory_org_model(user_id=user.id)
-
-    response = ResetDataService.reset(TestJwtClaims.get_test_user(user_id, 'BCSC'))
-    assert response is None
-
-    found_org = OrgService.find_by_org_id(org.id)
-    assert found_org is None
-
-    user = keycloak_service.get_user_by_username(request.user_name)
-    assert user is not None


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
Found a issuer that delete user api will reset the roles of service account. 

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
