### PR TITLE
BC/Non-BC resident screen appears twice#4535

### DIFF
--- a/auth-web/src/components/auth/mixins/NextPageMixin.vue
+++ b/auth-web/src/components/auth/mixins/NextPageMixin.vue
@@ -93,10 +93,13 @@ export default class NextPageMixin extends Vue {
           ConfigHelper.removeFromSession(SessionStorageKeys.InvitationToken)
         } else if (!this.userProfile?.userTerms?.isTermsOfUseAccepted) {
           bceidNextStep = Pages.USER_PROFILE_TERMS
-        } else if (!this.userProfile?.userTerms?.isTermsOfUseAccepted) {
-          bceidNextStep = Pages.USER_PROFILE_TERMS
         } else if (!this.currentOrganization && !this.currentMembership) {
-          bceidNextStep = Pages.CHOOSE_AUTH_METHOD
+          let isExtraProv = ConfigHelper.getFromSession(SessionStorageKeys.ExtraProvincialUser)
+          if (isExtraProv) {
+            bceidNextStep = Pages.CREATE_NON_BCSC_ACCOUNT
+          } else {
+            bceidNextStep = Pages.CHOOSE_AUTH_METHOD
+          }
         } else if (this.currentOrganization && this.currentOrganization.statusCode === OrgStatus.PendingAffidavitReview) {
           bceidNextStep = `${Pages.PENDING_APPROVAL}/${this.currentAccountSettings?.label}/true`
         } else if (this.currentOrganization && this.currentMembership.membershipStatus === MembershipStatus.Active) {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/4535

*Description of changes:*
- BC/Non-BC resident screen appears twice#4535

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
