### PR TITLE
4660 - align session storage constant w/ entities

### DIFF
--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -2,7 +2,7 @@
 export enum SessionStorageKeys {
     KeyCloakToken = 'KEYCLOAK_TOKEN',
     ApiConfigKey = 'AUTH_API_CONFIG',
-    BusinessIdentifierKey = 'BUSINESS_IDENTIFIER',
+    BusinessIdentifierKey = 'BUSINESS_ID',
     CurrentAccount = 'CURRENT_ACCOUNT',
     LaunchDarklyFlags = 'LD_FLAGS',
     ExtraProvincialUser = 'EXTRAPROVINCIAL_USER',


### PR DESCRIPTION
*Issue #:* 4660
https://github.com/bcgov/entity/issues/4660

*Description of changes:*

The bug in Issue 4660 is being caused by a mismatched session storage key (BUSINESS_ID in Entities, BUSINESS_IDENTIFIER in Relationships).  This PR renames the session storage key constant to BUSINESS_ID to be consistent with the convention used in Entities.  

This change should also correct a similar issue described in #4328, but will confirm once deployed to development.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
