### PR TITLE
director search account should only be accessible to Admins

### DIFF
--- a/auth-api/requirements.txt
+++ b/auth-api/requirements.txt
@@ -13,7 +13,7 @@ SQLAlchemy==1.3.19
 Werkzeug==0.16.1
 alembic==1.4.2
 aniso8601==8.0.0
-attrs==20.1.0
+attrs==20.2.0
 bcrypt==3.2.0
 blinker==1.4
 certifi==2020.6.20
@@ -27,7 +27,6 @@ flask-marshmallow==0.11.0
 flask-restplus==0.13.0
 gunicorn==20.0.4
 idna==2.10
-importlib-metadata==1.7.0
 itsdangerous==1.1.0
 jaeger-client==4.3.0
 jsonschema==3.2.0
@@ -35,7 +34,7 @@ marshmallow-sqlalchemy==0.23.1
 marshmallow==3.0.0rc7
 minio==6.0.0
 opentracing==2.3.0
-psycopg2-binary==2.8.5
+psycopg2-binary==2.8.6
 pyasn1==0.4.8
 pycparser==2.20
 pyhumps==1.6.1
@@ -47,11 +46,10 @@ python-jose==3.2.0
 pytz==2020.1
 requests==2.24.0
 rsa==4.6
-sentry-sdk==0.17.0
+sentry-sdk==0.17.3
 six==1.15.0
 threadloop==1.0.2
 thrift==0.13.0
 tornado==6.0.4
 urllib3==1.25.10
-zipp==3.1.0
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components-2.0.0&subdirectory=python

--- a/auth-api/src/auth_api/models/org.py
+++ b/auth-api/src/auth_api/models/org.py
@@ -95,7 +95,7 @@ class Org(VersionedModel):  # pylint: disable=too-few-public-methods,too-many-in
             .options(contains_eager('contacts').contains_eager('contact'))
 
         if access_type:
-            query = query.filter(Org.access_type.in_(access_type.split(',')))
+            query = query.filter(Org.access_type.in_(access_type))
         if name:
             query = query.filter(Org.name.ilike(f'%{name}%'))
         if status:

--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -87,13 +87,14 @@ class Orgs(Resource):
         limit = request.args.get('limit', 10)
 
         try:
+            token = g.jwt_oidc_token_info
             response, status = OrgService.search_orgs(business_identifier=business_identifier, access_type=access_type,
                                                       name=name, status=status, bcol_account_id=bcol_account_id,
-                                                      page=page, limit=limit), http_status.HTTP_200_OK
+                                                      page=page, limit=limit, token=token), http_status.HTTP_200_OK
 
             # If public user is searching , return 200 with empty results if orgs exist
             # Else return 204
-            token = g.jwt_oidc_token_info
+
             is_public_user = Role.PUBLIC_USER.value in token.get('realm_access').get('roles')
             if is_public_user:  # public user cant get the details in search.Gets only status of orgs
                 if response and response.get('orgs'):

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -558,6 +558,7 @@ class Org:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def filter_access_type(access_type_str, roles, token_info):
+        """Find Access Type."""
         is_staff_admin = token_info and Role.STAFF_CREATE_ACCOUNTS.value in roles or \
                          Role.STAFF_MANAGE_ACCOUNTS in roles
         access_type = [] if not access_type_str else access_type_str.split(',')

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -513,12 +513,9 @@ class Org:  # pylint: disable=too-many-public-methods
             limit: int = int(kwargs.get('limit'))
             status: str = kwargs.get('status', None)
             name: str = kwargs.get('name', None)
-            access_type_str = kwargs.get('access_type', None)
-            token_info = kwargs.get('token', None)
-            roles = token_info.get('realm_access').get('roles')
             # https://github.com/bcgov/entity/issues/4786
-            access_type, is_staff_admin = Org.filter_access_type(access_type_str, roles, token_info)
-
+            access_type, is_staff_admin = Org.refine_access_type(kwargs.get('access_type', None),
+                                                                 kwargs.get('token', None))
             search_args = (access_type,
                            name,
                            status,
@@ -557,8 +554,10 @@ class Org:  # pylint: disable=too-many-public-methods
         return orgs
 
     @staticmethod
-    def filter_access_type(access_type_str, roles, token_info):
+    def refine_access_type(access_type_str, token_info):
         """Find Access Type."""
+        roles = token_info.get('realm_access').get('roles')
+
         is_staff_admin = token_info and Role.STAFF_CREATE_ACCOUNTS.value in roles or \
             Role.STAFF_MANAGE_ACCOUNTS in roles
         access_type = [] if not access_type_str else access_type_str.split(',')

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -560,7 +560,7 @@ class Org:  # pylint: disable=too-many-public-methods
     def filter_access_type(access_type_str, roles, token_info):
         """Find Access Type."""
         is_staff_admin = token_info and Role.STAFF_CREATE_ACCOUNTS.value in roles or \
-                         Role.STAFF_MANAGE_ACCOUNTS in roles
+            Role.STAFF_MANAGE_ACCOUNTS in roles
         access_type = [] if not access_type_str else access_type_str.split(',')
         if not is_staff_admin:
             if len(access_type) < 1:


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/4786

*Description of changes:*

the requirement says VIEWER staff should not be able to see director search related accounts ;It should only be visible to ADMINS. The api has been changed to take care of this behaviour. 

- filtered director search if request comes from non-admin

- blocked accessing pending invitations if its non-admin

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
