### PR TITLE
adding the missed redirection for 'staff' route

### DIFF
--- a/auth-web/src/routes/router.ts
+++ b/auth-web/src/routes/router.ts
@@ -392,6 +392,11 @@ export function getRoutes (): RouteConfig[] {
       ]
     },
     {
+      path: Pages.STAFF,
+      name: 'staff',
+      redirect: Pages.STAFF_DASHBOARD
+    },
+    {
       path: Pages.STAFF_DASHBOARD_OLD,
       name: 'searchbusiness',
       redirect: Pages.STAFF_DASHBOARD

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -51,6 +51,7 @@ export enum Pages {
     STAFF_DASHBOARD_OLD= '/searchbusiness',
     STAFF_SETUP_ACCOUNT = 'staff-setup-account',
     CONFIRM_TOKEN = 'confirmtoken',
+    STAFF = '/staff',
     STAFF_DASHBOARD = '/staff/dashboard',
     STAFF_DASHBOARD_ACTIVE = '/staff/dashboard/active',
     STAFF_DASHBOARD_REVIEW = '/staff/dashboard/review',


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/4626

*Description of changes:*

/staff should automatically redirect to /staff/dashboard

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
