### PR TITLE
4238 fix cancel button

### DIFF
--- a/auth-web/src/components/auth/UserProfileForm.vue
+++ b/auth-web/src/components/auth/UserProfileForm.vue
@@ -457,7 +457,15 @@ export default class UserProfileForm extends Mixins(NextPageMixin, Steppable) {
       if (this.isStepperView) {
         this.$router.push('/')
       } else {
-        window.history.back()
+        this.navigateBack()
+      }
+    }
+
+    private navigateBack (): void {
+      if (this.currentOrganization) {
+        this.$router.push(`/account/${this.currentOrganization.id}`)
+      } else {
+        this.$router.push('/home')
       }
     }
 


### PR DESCRIPTION
*Issue #:* 4238
https://github.com/bcgov/entity/issues/4238

*Description of changes:*

This PR fixes an issue where the Cancel button on the Edit Profile form was not functioning.  Prior to the fix the cancel button would resolve to using `window.history.back()` to return to the previous page.  In a SPA, this won't always work if you are coming from a different application (in this case IA dashboard) or if there is a redirect on load of the view.  For now, I've changed it to behave the same as if the View level back arrow was pressed (returns to the Manage Business dashboard if an account is selected, or Home otherwise).  If the desired behaviour is to return to the IA dashboard then this will require additional changes on that application as well (a query parameter would need to be passed to the Edit Profile view and handled).  For now, this PR fixes the non-functional Cancel button.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
