### PR TITLE
4772 add view for PAD tos + dialog

### DIFF
--- a/auth-web/src/components/auth/PAD/PADAgreementDialog.vue
+++ b/auth-web/src/components/auth/PAD/PADAgreementDialog.vue
@@ -1,0 +1,178 @@
+<template>
+  <v-row>
+    <v-col sm="12">
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on }">
+          <v-checkbox
+            v-on:change="emitStatus()"
+            v-on="on"
+            class="terms-checkbox"
+            color="default"
+            v-model="termsAccepted"
+            required
+            :disabled="termsAccepted || !canCheckTerms"
+          >
+            <template v-slot:label>
+              <div class="terms-checkbox-label" v-on="on">
+                <span>I have read and agreed to the</span>
+                <v-btn
+                  text
+                  link
+                  color="primary"
+                  class="pr-1 pl-1"
+                  @click.stop="openDialog()"
+                  data-test="terms-of-use-checkbox"
+                >Terms of Use</v-btn>
+              </div>
+            </template>
+          </v-checkbox>
+        </template>
+        <span>{{tooltipTxt}}</span>
+      </v-tooltip>
+      <v-dialog scrollable width="1024" v-model="termsDialog" :persistent="true">
+        <v-card>
+          <v-card-title>Terms of Use</v-card-title>
+          <v-card-text id="scroll-target" data-test="scroll-area">
+            <div v-scroll:#scroll-target="onScroll" style="height: 2000px;">
+              <PADTermsOfUse
+                :content="content"
+              ></PADTermsOfUse>
+            </div>
+          </v-card-text>
+          <v-card-actions>
+            <v-btn
+              large
+              depressed
+              color="primary"
+              class="agree-btn"
+              :disabled="!atBottom"
+              @click="termsDialog = false; termsAccepted = true; emitStatus()"
+              data-test="accept-button"
+            >
+              <span>Agree to Terms</span>
+            </v-btn>
+            <v-btn
+              large
+              depressed
+              color="primary"
+              class="agree-btn"
+              @click="termsDialog = false"
+              data-test="close-button"
+            >
+              <span>Close</span>
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts">
+import { Component, Emit, Prop, Vue, Watch } from 'vue-property-decorator'
+import PADTermsOfUse from '@/components/auth/PAD/PADTermsOfUse.vue'
+import { User } from '@/models/user'
+import documentService from '@/services/document.services.ts'
+import { getModule } from 'vuex-module-decorators'
+import { mapState } from 'vuex'
+
+@Component({
+  components: {
+    PADTermsOfUse
+  },
+  computed: {
+    ...mapState('user', ['userProfile'])
+  }
+})
+export default class PADAgreementDialog extends Vue {
+  private readonly userProfile!: User
+  private termsDialog = false
+  private termsAccepted = false
+  private content: string = ''
+  private version: string = ''
+  private canCheckTerms: boolean = false
+  private atBottom = false
+
+  async mounted () {
+    const response = await documentService.getTermsOfService('termsofuse')
+    this.content = response.data.content
+    this.version = response.data.versionId
+  }
+
+  get tooltipTxt () {
+    return 'Please read and agree to the Terms Of Use'
+  }
+
+  @Watch('version')
+  onDocVersionChanged (val: string, oldVal: string) {
+    if (val === this.userProfile.userTerms.termsOfUseAcceptedVersion) {
+      this.termsAccepted = true
+      this.canCheckTerms = true
+      this.emitStatus()
+    }
+  }
+
+  private openDialog () {
+    this.termsDialog = true
+  }
+
+  private onScroll (e) {
+    this.atBottom = (e.target.scrollHeight - e.target.scrollTop) <= (e.target.offsetHeight + 25)
+  }
+
+  @Emit('terms-updated')
+  private emitStatus () {
+    return {
+      termsVersion: this.version,
+      isTermsAccepted: this.termsAccepted
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '$assets/scss/theme.scss';
+
+// Tighten up some of the spacing between rows
+[class^='col'] {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.terms-checkbox {
+  pointer-events: auto !important;
+}
+
+.form__btns {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.terms-checkbox-label {
+  display: flex;
+  align-items: center;
+  margin-top: -0.1rem;
+
+  .v-btn {
+    height: auto !important;
+    margin-left: 0.1rem;
+    padding: 0;
+    text-decoration: underline;
+    font-size: 1rem;
+  }
+}
+
+.v-card__actions {
+  justify-content: center;
+
+  .v-btn {
+    width: 10rem;
+  }
+}
+
+.terms-container ::v-deep {
+  article {
+    background: $gray1;
+  }
+}
+</style>

--- a/auth-web/src/components/auth/PAD/PADTermsOfUse.vue
+++ b/auth-web/src/components/auth/PAD/PADTermsOfUse.vue
@@ -1,0 +1,127 @@
+<template>
+  <div>
+    <v-fade-transition>
+      <div class="loading-container" v-if="!termsContent">
+        <v-progress-circular
+          size="50"
+          width="5"
+          color="primary"
+          :indeterminate="termsContent"
+        />
+      </div>
+    </v-fade-transition>
+    <div v-html="termsContent" class="terms-container"></div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+import { mapMutations, mapState } from 'vuex'
+import { TermsOfUseDocument } from '@/models/TermsOfUseDocument'
+import { User } from '@/models/user'
+import documentService from '@/services/document.services.ts'
+
+@Component({
+  computed: {
+    ...mapState('user', ['termsOfUse'])
+  },
+  methods: {
+    ...mapMutations('user', ['setTermsOfUse'])
+  }
+})
+export default class PADTermsOfUse extends Vue {
+  private readonly setTermsOfUse!: (terms: TermsOfUseDocument) => void
+  private termsContent = ''
+  protected readonly userProfile!: User
+
+  @Prop({ default: '' }) private content: string
+
+  async mounted () {
+    if (!this.content) {
+      const response = await documentService.getTermsOfService('termsofuse')
+      if (response.data) {
+        this.termsContent = response.data.content
+        this.setTermsOfUse(response.data)
+        const hasLatestTermsAccepted = this.hasAcceptedLatestTos(
+          response.data.versionId
+        )
+        if (!hasLatestTermsAccepted) {
+          this.$emit('update_version')
+        }
+      }
+    } else {
+      this.termsContent = this.content
+    }
+  }
+
+  private hasAcceptedLatestTos (latestVersionId: string) {
+    /*
+    version id comes with a string prefix like d1 , d2... strip that , convert to number for comparison
+    Or else 'd1' will be,l 'd2' . But 'd2' wont be less than ' d10 '!!!  '
+    */
+
+    // TODO: check the appropriate field on the account to see if current version has been accepted
+    return false
+    // if (!this.userProfile.userTerms?.termsOfUseAcceptedVersion) {
+    //   return true
+    // }
+    // const currentlyAcceptedTermsVersion = Number(
+    //   // this.userProfile.userTerms.termsOfUseAcceptedVersion.replace(/\D/g, '')
+    // )
+    // const latestVersionNumber = Number(latestVersionId.replace(/\D/g, ''))
+
+    // return (
+    //   this.userProfile.userTerms.isTermsOfUseAccepted &&
+    //   currentlyAcceptedTermsVersion > latestVersionNumber
+    // )
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '$assets/scss/theme.scss';
+
+// Terms and Conditions Container
+$indent-width: 3rem;
+
+.terms-container ::v-deep {
+  section {
+    margin-top: 2rem;
+  }
+
+  section header {
+    margin-bottom: 1rem;
+    color: $gray9;
+    letter-spacing: -0.02rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+  }
+
+  section header > span {
+    display: inline-block;
+    width: $indent-width;
+  }
+
+  header + div {
+    margin-left: 3.25rem;
+  }
+
+  section div > p {
+    padding-left: $indent-width;
+  }
+
+  p {
+    position: relative;
+  }
+
+  p + div {
+    margin-left: $indent-width;
+  }
+
+  p > span {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+}
+</style>


### PR DESCRIPTION
*Issue #:* 4772
https://github.com/bcgov/entity/issues/4772

*Description of changes:*

Adds views for the PAD agreement TOS dialog.  Before this feature can be used, the Payment Selection feature must be completed.

NOTE: This also does not include the data model or API changes needed on the account model to determine if the TOS has already been accepted.  Placeholders have been put in where appropriate.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
