### PR TITLE
show bank institution number instead of bank name in pad confirmation pdf

### DIFF
--- a/queue_services/account-mailer/src/account_mailer/pdf_templates/pad_confirmation.html
+++ b/queue_services/account-mailer/src/account_mailer/pdf_templates/pad_confirmation.html
@@ -86,9 +86,9 @@
                 <span class="font-bold">{{accountName}}</span>
               </li>
               {% endif %}
-              {% if paymentInfo['bankName'] or paymentInfo['bankTransitNumber'] %}
-              <li>Financial Institution (Name & Transit #):
-                <span class="font-bold">{{paymentInfo['bankName']}}, {{paymentInfo['bankTransitNumber']}}</span>
+              {% if paymentInfo['bankInstitutionNumber'] or paymentInfo['bankTransitNumber'] %}
+              <li>Financial Institution & Transit #:
+                <span class="font-bold">{{paymentInfo['bankInstitutionNumber']}}, {{paymentInfo['bankTransitNumber']}}</span>
               </li>
               {% endif %}
               {% if paymentInfo['bankAccountNumber'] %}


### PR DESCRIPTION

*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
