### PR TITLE
#4402-API- create schemas for all response, write unit tests 

### DIFF
--- a/auth-api/src/auth_api/schemas/base_schema.py
+++ b/auth-api/src/auth_api/schemas/base_schema.py
@@ -29,14 +29,19 @@ class BaseSchema(ma.ModelSchema):  # pylint: disable=too-many-ancestors
 
     @post_dump(pass_many=True)
     def _remove_empty(self, data, many):  # pylint: disable=no-self-use
-        """Remove all empty values from the dumped dict."""
+        """Remove all empty values and versions from the dumped dict."""
         if not many:
+            for key in list(data):
+                if key == 'versions':
+                    data.pop(key)
+
             return {
                 key: value for key, value in data.items()
                 if value is not None
             }
         for item in data:
             for key in list(item):
-                if item[key] is None:
+                if (item[key] is None) or (key == 'versions'):
                     item.pop(key)
+
         return data

--- a/auth-api/src/auth_api/schemas/contact.py
+++ b/auth-api/src/auth_api/schemas/contact.py
@@ -27,7 +27,7 @@ class ContactSchema(BaseSchema):  # pylint: disable=too-many-ancestors, too-few-
         """Maps all of the User fields to a default schema."""
 
         model = ContactModel
-        exclude = ('id',)
+        exclude = ('id', 'links')
 
     email = fields.String(data_key='email')
     phone = fields.String(data_key='phone')

--- a/auth-api/src/auth_api/schemas/schemas/account_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/account_response.json
@@ -1,0 +1,166 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/account_response",
+    "type": "object",
+    "title": "The root schema",
+    "description": "The root schema comprises the entire JSON document.",
+    "default": {},
+    "examples": [
+        {
+            "account": {
+                "accountType": "TEST",
+                "id": 1,
+                "name": "My Test Org",
+                "paymentPreference": {
+                    "bcOnlineAccountId": "BCOL1",
+                    "bcOnlineUserId": ""
+                }
+            },
+            "business": {
+                "folioNumber": "1234",
+                "name": "Foobar, Inc."
+            },
+            "orgMembership": "ADMIN",
+            "roles": [
+                "edit",
+                "view"
+            ]
+        }
+    ],
+    "required": [
+        "roles"
+    ],
+    "properties": {
+        "account": {
+            "$id": "#/properties/account",
+            "type": "object",
+            "title": "Account",
+            "default": {},
+            "properties": {
+                "accountType": {
+                    "$id": "#/properties/account/properties/accountType",
+                    "type": "string",
+                    "title": "Account Type",
+                    "default": "",
+                    "examples": [
+                        "TEST"
+                    ]
+                },
+                "id": {
+                    "$id": "#/properties/account/properties/id",
+                    "type": "integer",
+                    "title": "ID",
+                    "default": 0,
+                    "examples": [
+                        1
+                    ]
+                },
+                "name": {
+                    "$id": "#/properties/account/properties/name",
+                    "type": "string",
+                    "title": "Name",
+                    "default": "",
+                    "examples": [
+                        "My Test Org"
+                    ]
+                },
+                "paymentPreference": {
+                    "$id": "#/properties/account/properties/paymentPreference",
+                    "type": "object",
+                    "title": "Payment Preference",
+                    "default": {},
+                    "required": [
+                    ],
+                    "properties": {
+                        "bcOnlineAccountId": {
+                            "$id": "#/properties/account/properties/paymentPreference/properties/bcOnlineAccountId",
+                            "type": "string",
+                            "title": "BC Online Account ID",
+                            "default": "",
+                            "examples": [
+                                "BCOL1"
+                            ]
+                        },
+                        "bcOnlineUserId": {
+                            "$id": "#/properties/account/properties/paymentPreference/properties/bcOnlineUserId",
+                            "type": "string",
+                            "title": "BC Online User ID",
+                            "default": "",
+                            "examples": [
+                                ""
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
+                }
+            },
+            "additionalProperties": true
+        },
+        "business": {
+            "$id": "#/properties/business",
+            "type": "object",
+            "title": "Business",
+            "default": {},
+            "required": [
+            ],
+            "properties": {
+                "folioNumber": {
+                    "$id": "#/properties/business/properties/folioNumber",
+                    "type": ["string", "null"],
+                    "title": "Folio Number",
+                    "default": "",
+                    "examples": [
+                        "1234"
+                    ]
+                },
+                "name": {
+                    "$id": "#/properties/business/properties/name",
+                    "type": ["string", "null"],
+                    "title": "Name",
+                    "default": "",
+                    "examples": [
+                        "Foobar, Inc."
+                    ]
+                }
+            },
+            "additionalProperties": true
+        },
+        "orgMembership": {
+            "$id": "#/properties/orgMembership",
+            "type": "string",
+            "title": "Organization Membership",
+            "default": "",
+            "examples": [
+                "ADMIN"
+            ]
+        },
+        "roles": {
+            "$id": "#/properties/roles",
+            "type": "array",
+            "title": "Roles",
+            "default": [],
+            "examples": [
+                [
+                    "edit",
+                    "view"
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/roles/items",
+                "anyOf": [
+                    {
+                        "$id": "#/properties/roles/items/anyOf/0",
+                        "type": "string",
+                        "default": "",
+                        "examples": [
+                            "edit",
+                            "view"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/affidavit_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/affidavit_response.json
@@ -1,0 +1,125 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/affidavit_response",
+    "type": "object",
+    "title": "Affidavit Response",
+    "description": "The affidavit schema for response.",
+    "default": {},
+    "examples": [
+        {
+            "contacts": [
+                {
+                    "created": "2020-11-23T11:39:33.011059+00:00",
+                    "createdBy": "None None",
+                    "email": "foo@bar.com",
+                    "modified": "2020-11-23T11:39:33.011066+00:00",
+                    "phone": "(555) 555-5555",
+                    "phoneExtension": "123"
+                }
+            ],
+            "created": "2020-11-23T11:39:32.989933+00:00",
+            "createdBy": "None None",
+            "documentUrl": "http://localhost:9000/accounts/Affidavits/e46e9818-3d87-416f-96f0-4292c706b344.jpeg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20201123%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201123T193933Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=50fd33daba591ee32878f563a04cef77c28cf8a3f0aaf48b31e82e943b7c9627",
+            "documentId": "Affidavits/e46e9818-3d87-416f-96f0-4292c706b344.jpeg",
+            "issuer": "ABC Notaries Inc.",
+            "modified": "2020-11-23T11:39:32.989941+00:00",
+            "status": "PENDING",
+            "user": 1
+        }
+    ],
+    "required": [
+        "contacts",
+        "created",
+        "createdBy",
+        "documentUrl",
+        "documentId",
+        "issuer",
+        "modified",
+        "status",
+        "user"
+    ],
+    "properties": {
+        "contacts": {
+            "$id": "#/properties/contacts",
+            "type": "array",
+            "title": "contacts",
+            "default": [],
+            "contacts": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/contact_response"
+              }
+        },
+        "created": {
+            "$id": "#/properties/created",
+            "type": "string",
+            "title": "Created",
+            "default": "",
+            "examples": [
+                "2020-11-23T11:39:32.989933+00:00"
+            ]
+        },
+        "createdBy": {
+            "$id": "#/properties/createdBy",
+            "type": "string",
+            "title": "Created By",
+            "default": "",
+            "examples": [
+                "None None"
+            ]
+        },
+        "documentUrl": {
+            "$id": "#/properties/documentUrl",
+            "type": "string",
+            "title": "Document URL",
+            "default": "",
+            "examples": [
+                "http://localhost:9000/accounts/Affidavits/e46e9818-3d87-416f-96f0-4292c706b344.jpeg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20201123%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20201123T193933Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=50fd33daba591ee32878f563a04cef77c28cf8a3f0aaf48b31e82e943b7c9627"
+            ]
+        },
+        "documentId": {
+            "$id": "#/properties/documentId",
+            "type": "string",
+            "title": "Document ID",
+            "default": "",
+            "examples": [
+                "Affidavits/e46e9818-3d87-416f-96f0-4292c706b344.jpeg"
+            ]
+        },
+        "issuer": {
+            "$id": "#/properties/issuer",
+            "type": "string",
+            "title": "Issuer",
+            "default": "",
+            "examples": [
+                "ABC Notaries Inc."
+            ]
+        },
+        "modified": {
+            "$id": "#/properties/modified",
+            "type": "string",
+            "title": "Modified",
+            "default": "",
+            "examples": [
+                "2020-11-23T11:39:32.989941+00:00"
+            ]
+        },
+        "status": {
+            "$id": "#/properties/status",
+            "type": "string",
+            "title": "Status",
+            "default": "",
+            "examples": [
+                "PENDING"
+            ]
+        },
+        "user": {
+            "$id": "#/properties/user",
+            "type": "integer",
+            "title": "User",
+            "default": 0,
+            "examples": [
+                1
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/affiliation_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/affiliation_response.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/affiliation_response",
+    "type": "object",
+    "title": "Affiliation Response",
+    "description": "The affiliation schema for resoonse.",
+    "default": {},
+    "examples": [
+        {
+            "business": {
+                "affiliations": [
+                    1
+                ],
+                "businessIdentifier": "CP0002103",
+                "businessNumber": "791861078BC0001",
+                "contacts": [],
+                "corpType": {
+                    "code": "CP",
+                    "default": true,
+                    "desc": "Cooperatives"
+                },
+                "created": "2020-11-06T19:15:21.347010+00:00",
+                "modified": "2020-11-06T19:15:21.970169+00:00",
+                "modifiedBy": "Rodney Leonard",
+                "name": "BarFoo, Inc.",
+                "passCodeClaimed": true
+            },
+            "created": "2020-11-06T19:15:21.939183+00:00",
+            "createdBy": "Rodney Leonard",
+            "id": 1,
+            "modified": "2020-11-06T19:15:21.939190+00:00",
+            "organization": {
+                "accessType": "REGULAR",
+                "billable": true,
+                "created": "2020-11-06T19:15:21.498289+00:00",
+                "createdBy": "Rodney Leonard",
+                "id": 1,
+                "loginOptions": [],
+                "modified": "2020-11-06T19:15:21.526356+00:00",
+                "modifiedBy": "Rodney Leonard",
+                "name": "My Test Org",
+                "orgType": "BASIC",
+                "orgStatus": "ACTIVE",
+                "products": [
+                    1
+                ],
+                "statusCode": "ACTIVE"
+            }
+        }
+    ],
+    "required": [
+        "business",
+        "created",
+        "createdBy",
+        "id",
+        "modified",
+        "organization"
+    ],
+    "properties": {
+        "business": {
+            "$id": "#/properties/business",
+            "type": "object",
+            "title": "Business",
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/business"
+        },
+        "created": {
+            "$id": "#/properties/created",
+            "type": "string",
+            "title": "Created",
+            "default": "",
+            "examples": [
+                "2020-11-06T19:15:21.939183+00:00"
+            ]
+        },
+        "createdBy": {
+            "$id": "#/properties/createdBy",
+            "type": "string",
+            "title": "Created By",
+            "default": "",
+            "examples": [
+                "Rodney Leonard"
+            ]
+        },
+        "id": {
+            "$id": "#/properties/id",
+            "type": "integer",
+            "title": "ID",
+            "default": 0,
+            "examples": [
+                1
+            ]
+        },
+        "modified": {
+            "$id": "#/properties/modified",
+            "type": "string",
+            "title": "Modified",
+            "default": "",
+            "examples": [
+                "2020-11-06T19:15:21.939190+00:00"
+            ]
+        },
+        "organization": {
+            "$id": "#/properties/organization",
+            "type": "object",
+            "title": "Organization",
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/org_response"
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/affiliations_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/affiliations_response.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/affiliations_response",
+    "type": "object",
+    "title": "Affiliations Response",
+    "description": "The affiliations schema for response.",
+    "default": {},
+    "examples": [
+        {
+            "entities": [
+                {
+                    "affiliations": [
+                        2
+                    ],
+                    "businessIdentifier": "CP0002106",
+                    "businessNumber": "791861078BC0002",
+                    "contacts": [],
+                    "corpType": {
+                        "code": "CP",
+                        "default": true,
+                        "desc": "Cooperatives"
+                    },
+                    "created": "2020-11-07T14:15:10.907043+00:00",
+                    "modified": "2020-11-07T14:15:11.858702+00:00",
+                    "modifiedBy": "Ronald Mahoney",
+                    "name": "Foobar, Inc.",
+                    "passCodeClaimed": true
+                },
+                {
+                    "affiliations": [
+                        1
+                    ],
+                    "businessIdentifier": "CP0002103",
+                    "businessNumber": "791861078BC0001",
+                    "contacts": [],
+                    "corpType": {
+                        "code": "CP",
+                        "default": true,
+                        "desc": "Cooperatives"
+                    },
+                    "created": "2020-11-07T14:15:10.640242+00:00",
+                    "modified": "2020-11-07T14:15:11.484755+00:00",
+                    "modifiedBy": "Ronald Mahoney",
+                    "name": "BarFoo, Inc.",
+                    "passCodeClaimed": true
+                }
+            ]
+        }
+    ],
+    "required": [
+        "entities"
+    ],
+    "properties": {
+        "entities": {
+            "$id": "#/properties/entities",
+            "type": "array",
+            "title": "The entities schema",
+            "default": [],
+            "items": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/business"
+            }
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/bconline_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/bconline_response.json
@@ -1,0 +1,317 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/bconline_response",
+    "type": "object",
+    "title": "BCOnline Response",
+    "description": "The BCOnline response schema.",
+    "default": {},
+    "examples": [
+        {
+            "accountNumber": "100670",
+            "accountType": "B",
+            "accountTypeDesc": "Billable",
+            "address": {
+                "city": "AB1",
+                "country": "CANADA",
+                "line1": "#400A - 6000 SEYMOUR PLACE",
+                "line2": "PENTHOUSE",
+                "postalCode": "V8X 5J8",
+                "province": "BC"
+            },
+            "authCode": "M",
+            "authCodeDesc": "Master",
+            "fax": "(250)953-8012",
+            "gstStatus": "",
+            "gstStatusDesc": "Must-Pay",
+            "orgName": "BC ONLINE TECHNICAL TEAM DEVL",
+            "orgType": "LAW",
+            "phone": "(250)953-8071 EX1999",
+            "profileFlags": [
+                "OSBR",
+                "ADS",
+                "COLIN_TYPE",
+                "COMP",
+                "ICBC",
+                "MH",
+                "LTO",
+                "SES",
+                "PPR",
+                "VS",
+                "CCREF",
+                "CCREL",
+                "ATSOURCE",
+                "COURT_SERVICES",
+                "EMERGIS",
+                "LOCATION_CODE"
+            ],
+            "pstStatus": "",
+            "pstStatusDesc": "Must-Pay",
+            "userId": "PB20020",
+            "userName": "BRIDGER, JAMES"
+        }
+    ],
+    "required": [
+        "accountNumber",
+        "accountType",
+        "accountTypeDesc",
+        "address",
+        "authCode",
+        "authCodeDesc",
+        "fax",
+        "gstStatus",
+        "gstStatusDesc",
+        "orgName",
+        "orgType",
+        "phone",
+        "profileFlags",
+        "pstStatus",
+        "pstStatusDesc",
+        "userId",
+        "userName"
+    ],
+    "properties": {
+        "accountNumber": {
+            "$id": "#/properties/accountNumber",
+            "type": "string",
+            "title": "Account Number",
+            "default": "",
+            "examples": [
+                "100670"
+            ]
+        },
+        "accountType": {
+            "$id": "#/properties/accountType",
+            "type": "string",
+            "title": "Account Type",
+            "default": "",
+            "examples": [
+                "B"
+            ]
+        },
+        "accountTypeDesc": {
+            "$id": "#/properties/accountTypeDesc",
+            "type": "string",
+            "title": "Account Type Description",
+            "default": "",
+            "examples": [
+                "Billable"
+            ]
+        },
+        "address": {
+            "$id": "#/properties/address",
+            "type": "object",
+            "title": "Address",
+            "default": {},
+            "examples": [
+                {
+                    "city": "AB1",
+                    "country": "CANADA",
+                    "line1": "#400A - 6000 SEYMOUR PLACE",
+                    "line2": "PENTHOUSE",
+                    "postalCode": "V8X 5J8",
+                    "province": "BC"
+                }
+            ],
+            "required": [
+                "city",
+                "country",
+                "line1",
+                "postalCode",
+                "province"
+            ],
+            "properties": {
+                "city": {
+                    "$id": "#/properties/address/properties/city",
+                    "type": "string",
+                    "title": "City",
+                    "default": "",
+                    "examples": [
+                        "AB1"
+                    ]
+                },
+                "country": {
+                    "$id": "#/properties/address/properties/country",
+                    "type": "string",
+                    "title": "Country",
+                    "default": "",
+                    "examples": [
+                        "CANADA"
+                    ]
+                },
+                "line1": {
+                    "$id": "#/properties/address/properties/line1",
+                    "type": "string",
+                    "title": "Address Line 1",
+                    "default": "",
+                    "examples": [
+                        "#400A - 6000 SEYMOUR PLACE"
+                    ]
+                },
+                "line2": {
+                    "$id": "#/properties/address/properties/line2",
+                    "type": "string",
+                    "title": "Address Line 2",
+                    "default": "",
+                    "examples": [
+                        "PENTHOUSE"
+                    ]
+                },
+                "postalCode": {
+                    "$id": "#/properties/address/properties/postalCode",
+                    "type": "string",
+                    "title": "Postal Code",
+                    "default": "",
+                    "examples": [
+                        "V8X 5J8"
+                    ]
+                },
+                "province": {
+                    "$id": "#/properties/address/properties/province",
+                    "type": "string",
+                    "title": "Province",
+                    "default": "",
+                    "examples": [
+                        "BC"
+                    ]
+                }
+            },
+            "additionalProperties": true
+        },
+        "authCode": {
+            "$id": "#/properties/authCode",
+            "type": "string",
+            "title": "Auth Code",
+            "default": "",
+            "examples": [
+                "M"
+            ]
+        },
+        "authCodeDesc": {
+            "$id": "#/properties/authCodeDesc",
+            "type": "string",
+            "title": "Auth Code Description",
+            "default": "",
+            "examples": [
+                "Master"
+            ]
+        },
+        "fax": {
+            "$id": "#/properties/fax",
+            "type": "string",
+            "title": "Fax",
+            "default": "",
+            "examples": [
+                "(250)953-8012"
+            ]
+        },
+        "gstStatus": {
+            "$id": "#/properties/gstStatus",
+            "type": "string",
+            "title": "GST Status",
+            "default": "",
+            "examples": [
+                ""
+            ]
+        },
+        "gstStatusDesc": {
+            "$id": "#/properties/gstStatusDesc",
+            "type": "string",
+            "title": "GST Status Desciption",
+            "default": "",
+            "examples": [
+                "Must-Pay"
+            ]
+        },
+        "orgName": {
+            "$id": "#/properties/orgName",
+            "type": "string",
+            "title": "Organization Name",
+            "default": "",
+            "examples": [
+                "BC ONLINE TECHNICAL TEAM DEVL"
+            ]
+        },
+        "orgType": {
+            "$id": "#/properties/orgType",
+            "type": "string",
+            "title": "Organization Type",
+            "default": "",
+            "examples": [
+                "LAW"
+            ]
+        },
+        "phone": {
+            "$id": "#/properties/phone",
+            "type": "string",
+            "title": "Phone",
+            "default": "",
+            "examples": [
+                "(250)953-8071 EX1999"
+            ]
+        },
+        "profileFlags": {
+            "$id": "#/properties/profileFlags",
+            "type": "array",
+            "title": "Profile Flags",
+            "default": [],
+            "examples": [
+                [
+                    "OSBR",
+                    "ADS"
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/profileFlags/items",
+                "anyOf": [
+                    {
+                        "$id": "#/properties/profileFlags/items/anyOf/0",
+                        "type": "string",
+                        "default": "",
+                        "examples": [
+                            "OSBR",
+                            "ADS"
+                        ]
+                    }
+                ]
+            }
+        },
+        "pstStatus": {
+            "$id": "#/properties/pstStatus",
+            "type": "string",
+            "title": "PST Status",
+            "default": "",
+            "examples": [
+                ""
+            ]
+        },
+        "pstStatusDesc": {
+            "$id": "#/properties/pstStatusDesc",
+            "type": "string",
+            "title": "PST Status Description",
+            "default": "",
+            "examples": [
+                "Must-Pay"
+            ]
+        },
+        "userId": {
+            "$id": "#/properties/userId",
+            "type": "string",
+            "title": "User ID",
+            "default": "",
+            "examples": [
+                "PB20020"
+            ]
+        },
+        "userName": {
+            "$id": "#/properties/userName",
+            "type": "string",
+            "title": "User Name",
+            "default": "",
+            "examples": [
+                "BRIDGER, JAMES"
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/business.json
+++ b/auth-api/src/auth_api/schemas/schemas/business.json
@@ -1,0 +1,153 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/business",
+    "type": "object",
+    "title": "Business",
+    "description": "The business schema.",
+    "default": {},
+    "examples": [
+        {
+            "affiliations": [
+                1
+            ],
+            "businessIdentifier": "CP0002103",
+            "businessNumber": "791861078BC0001",
+            "contacts": [],
+            "corpType": {
+                "code": "CP",
+                "default": true,
+                "desc": "Cooperatives"
+            },
+            "created": "2020-11-06T19:15:21.347010+00:00",
+            "folioNumber": "1234",
+            "modified": "2020-11-06T19:15:21.970169+00:00",
+            "modifiedBy": "Rodney Leonard",
+            "name": "BarFoo, Inc.",
+            "passCodeClaimed": true
+        }
+    ],
+    "required": [
+        "affiliations",
+        "businessIdentifier",
+        "corpType",
+        "created",
+        "modified",
+        "name",
+        "passCodeClaimed"
+    ],
+    "properties": {
+        "affiliations": {
+            "$id": "#/properties/affiliations",
+            "type": "array",
+            "title": "Affiliations",
+            "default": [],
+            "examples": [
+                [
+                    1
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/affiliations/items",
+                "anyOf": [
+                    {
+                        "$id": "#/properties/affiliations/items/anyOf/0",
+                        "type": "integer",
+                        "title": "The first anyOf schema",
+                        "default": 0,
+                        "examples": [
+                            1
+                        ]
+                    }
+                ]
+            }
+        },
+        "businessIdentifier": {
+            "$id": "#/properties/businessIdentifier",
+            "type": "string",
+            "title": "Business Identifier",
+            "default": "",
+            "examples": [
+                "CP0002103"
+            ]
+        },
+        "businessNumber": {
+            "$id": "#/properties/businessNumber",
+            "type": "string",
+            "title": "Business Number",
+            "default": "",
+            "examples": [
+                "791861078BC0001"
+            ]
+        },
+        "contacts": {
+            "$id": "#/properties/contacts",
+            "type": "array",
+            "title": "Contacts",
+            "items": {
+                  "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/contact_response"
+              }
+        },
+        "corpType": {
+            "$id": "#/properties/corpType",
+            "type": "object",
+            "title": "Corp Type",
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/corp_type"   
+        },
+        "created": {
+            "$id": "#/properties/created",
+            "type": "string",
+            "title": "Created",
+            "default": "",
+            "examples": [
+                "2020-11-06T19:15:21.347010+00:00"
+            ]
+        },
+        "folioNumber": {
+            "$id": "#/properties/folioNumber",
+            "type": "string",
+            "title": "Folio Number",
+            "default": "",
+            "examples": [
+                "1234"
+            ]
+        },
+        "modified": {
+            "$id": "#/properties/modified",
+            "type": "string",
+            "title": "Modified",
+            "default": "",
+            "examples": [
+                "2020-11-06T19:15:21.970169+00:00"
+            ]
+        },
+        "modifiedBy": {
+            "$id": "#/properties/modifiedBy",
+            "type": "string",
+            "title": "Modified By",
+            "default": "",
+            "examples": [
+                "Rodney Leonard"
+            ]
+        },
+        "name": {
+            "$id": "#/properties/name",
+            "type": "string",
+            "title": "Name",
+            "default": "",
+            "examples": [
+                "BarFoo, Inc."
+            ]
+        },
+        "passCodeClaimed": {
+            "$id": "#/properties/passCodeClaimed",
+            "type": "boolean",
+            "title": "PassCode Claimed",
+            "default": false,
+            "examples": [
+                true
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/codes.json
+++ b/auth-api/src/auth_api/schemas/schemas/codes.json
@@ -1,0 +1,120 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/codes",
+    "type": "array",
+    "title": "The root schema",
+    "description": "The root schema comprises the entire JSON document.",
+    "default": [],
+    "examples": [
+        [
+            {
+                "default": true,
+                "desc": "Member of the organization",
+                "displayName": "User",
+                "displayOrder": 1,
+                "icon": "mdi-account-outline",
+                "label": "Submit searches and filings, add / remove businesses",
+                "name": "USER"
+            },
+            {
+                "default": false,
+                "desc": "Admin for the organization",
+                "displayName": "Account Coordinator",
+                "displayOrder": 2,
+                "icon": "mdi-account-cog-outline",
+                "label": "Submit searches and filings, add / remove businesses, add / remove team members",
+                "name": "COORDINATOR"
+            }
+        ]
+    ],
+    "additionalItems": true,
+    "items": {
+        "$id": "#/items",
+        "anyOf": [
+            {
+                "$id": "#/items/anyOf/0",
+                "type": "object",
+                "default": {},
+                "required": [
+                    "default",
+                    "desc"
+                ],
+                "properties": {
+                    "code": {
+                        "$id": "#/items/anyOf/0/properties/code",
+                        "type": "string",
+                        "title": "Code",
+                        "default": "",
+                        "examples": [
+                            "PUBLIC"
+                        ]
+                    },
+                    "default": {
+                        "$id": "#/items/anyOf/0/properties/default",
+                        "type": "boolean",
+                        "title": "Default",
+                        "default": false,
+                        "examples": [
+                            true
+                        ]
+                    },
+                    "desc": {
+                        "$id": "#/items/anyOf/0/properties/desc",
+                        "type": "string",
+                        "title": "Description",
+                        "default": "",
+                        "examples": [
+                            "Member of the organization"
+                        ]
+                    },
+                    "displayName": {
+                        "$id": "#/items/anyOf/0/properties/displayName",
+                        "type": "string",
+                        "title": "Display Name",
+                        "default": "",
+                        "examples": [
+                            "User"
+                        ]
+                    },
+                    "displayOrder": {
+                        "$id": "#/items/anyOf/0/properties/displayOrder",
+                        "type": "integer",
+                        "title": "Display Order",
+                        "default": 0,
+                        "examples": [
+                            1
+                        ]
+                    },
+                    "icon": {
+                        "$id": "#/items/anyOf/0/properties/icon",
+                        "type": "string",
+                        "title": "Icon",
+                        "default": "",
+                        "examples": [
+                            "mdi-account-outline"
+                        ]
+                    },
+                    "label": {
+                        "$id": "#/items/anyOf/0/properties/label",
+                        "type": "string",
+                        "title": "Label",
+                        "default": "",
+                        "examples": [
+                            "Submit searches and filings, add / remove businesses"
+                        ]
+                    },
+                    "name": {
+                        "$id": "#/items/anyOf/0/properties/name",
+                        "type": "string",
+                        "title": "Name",
+                        "default": "",
+                        "examples": [
+                            "USER"
+                        ]
+                    }
+                },
+                "additionalProperties": true
+            }
+        ]
+    }
+}

--- a/auth-api/src/auth_api/schemas/schemas/contact_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/contact_response.json
@@ -1,0 +1,159 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/contact_response",
+    "type": "object",
+    "title": "contact_response",
+    "description": "This schema is for response of contact endpoint.",
+    "default": {},
+    "examples": [
+        {
+            "created": "2020-11-13T00:21:52.192810+00:00",
+            "createdBy": "abc-auth sbc-auth",
+            "email": "test@gmail.com",
+            "modified": "2020-11-13T00:21:52.192826+00:00",
+            "phone": "1111",
+            "phoneExtension": "11111",
+            "street": "123 Roundabout Lane",
+            "streetAdditional": "Unit 1",
+            "city": "Victoria",
+            "region": "British Columnbia",
+            "country": "CA",
+            "postalCode": "V1A 1A1",
+            "deliveryInstructions": "Ring buzzer 123"
+        }
+    ],
+    "required": [
+        "created",
+        "email",
+        "modified",
+        "phone",
+        "phoneExtension"
+    ],
+    "properties": {
+        "created": {
+            "$id": "#/properties/created",
+            "type": "string",
+            "title": "Created",
+            "default": "",
+            "examples": [
+                "2020-11-13T00:21:52.192810+00:00"
+            ]
+        },
+        "createdBy": {
+            "$id": "#/properties/createdBy",
+            "type": "string",
+            "title": "Created By",
+            "default": "",
+            "examples": [
+                "abc-auth sbc-auth"
+            ]
+        },
+        "email": {
+            "$id": "#/properties/email",
+            "type": "string",
+            "title": "Email",
+            "default": "",
+            "examples": [
+                "test@gmail.com"
+            ]
+        },
+        "modified": {
+            "$id": "#/properties/modified",
+            "type": "string",
+            "title": "Modified",
+            "default": "",
+            "examples": [
+                "2020-11-13T00:21:52.192826+00:00"
+            ]
+        },
+        "phone": {
+            "$id": "#/properties/phone",
+            "type": "string",
+            "title": "Phone",
+            "default": "",
+            "examples": [
+                "1111"
+            ]
+        },
+        "phoneExtension": {
+            "$id": "#/properties/phoneExtension",
+            "type": "string",
+            "title": "Phone Extension",
+            "default": "",
+            "examples": [
+                "11111"
+            ]
+        },
+        "street": {
+            "$id": "#/properties/street",
+            "type": "string",
+            "title": "Street",
+            "default": "",
+            "examples": [
+              "123 Roundabout Lane"
+            ],
+            "pattern": "^(.*)$"
+        },
+        "streetAdditional": {
+            "$id": "#/properties/street_additional",
+            "type": "string",
+            "title": "Street Additional",
+            "default": "",
+            "examples": [
+              "Unit 1"
+            ],
+            "pattern": "^(.*)$"
+        },
+        "city": {
+            "$id": "#/properties/city",
+            "type": "string",
+            "title": "City",
+            "default": "",
+            "examples": [
+              "Victoria"
+            ],
+            "pattern": "^(.*)$"
+        },
+        "region": {
+            "$id": "#/properties/region",
+            "type": "string",
+            "title": "Region",
+            "default": "",
+            "examples": [
+              "British Columbia"
+            ],
+            "pattern": "^(.*)$"
+        },
+        "country": {
+            "$id": "#/properties/country",
+            "type": "string",
+            "title": "Country",
+            "default": "",
+            "examples": [
+              "CA"
+            ],
+            "pattern": "^(.*)$"
+        },
+        "postalCode": {
+            "$id": "#/properties/postal_code",
+            "type": "string",
+            "title": "Postal Code",
+            "default": "",
+            "examples": [
+              "V1A 1A1"
+            ],
+            "pattern": "^(.*)$"
+        },
+        "deliveryInstructions": {
+            "$id": "#/properties/delivery_instructions",
+            "type": "string",
+            "title": "Delivery Instructions",
+            "default": "",
+            "examples": [
+              "Ring buzzer 123"
+            ],
+            "pattern": "^(.*)$"
+        }        
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/contacts.json
+++ b/auth-api/src/auth_api/schemas/schemas/contacts.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/contacts",
+    "type": "object",
+    "title": "Contact List",
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/contact_response"
+        }
+      }
+    }
+  }

--- a/auth-api/src/auth_api/schemas/schemas/corp_type.json
+++ b/auth-api/src/auth_api/schemas/schemas/corp_type.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/corp_type",
+    "type": "object",
+    "title": "Corp Type",
+    "description": "The Corpration Type schema.",
+    "default": {},
+    "examples": [
+        {
+            "code": "CP",
+            "default": true,
+            "desc": "Cooperatives"
+        }
+    ],
+    "required": [
+        "code",
+        "default",
+        "desc"
+    ],
+    "properties": {
+        "code": {
+            "$id": "#/properties/code",
+            "type": "string",
+            "title": "Code",
+            "default": "",
+            "examples": [
+                "CP"
+            ]
+        },
+        "default": {
+            "$id": "#/properties/default",
+            "type": "boolean",
+            "title": "Default",
+            "default": false,
+            "examples": [
+                true
+            ]
+        },
+        "desc": {
+            "$id": "#/properties/desc",
+            "type": "string",
+            "title": "Description",
+            "default": "",
+            "examples": [
+                "Cooperatives"
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/document.json
+++ b/auth-api/src/auth_api/schemas/schemas/document.json
@@ -1,0 +1,61 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/document",
+    "type": "object",
+    "title": "Document",
+    "description": "The document schema.",
+    "default": {},
+    "examples": [
+        {
+            "content": "\n <article>\n  <p>Content here. </p></article>\n",
+            "contentType": "text/html",
+            "type": "termsofuse_directorsearch",
+            "versionId": "d1"
+        }
+    ],
+    "required": [
+        "content",
+        "contentType",
+        "type",
+        "versionId"
+    ],
+    "properties": {
+        "content": {
+            "$id": "#/properties/content",
+            "type": "string",
+            "title": "Content",
+            "default": "",
+            "examples": [
+                "\n <article>\n  <p>Content here. </p></article>\n"
+            ]
+        },
+        "contentType": {
+            "$id": "#/properties/contentType",
+            "type": "string",
+            "title": "Content Type",
+            "default": "",
+            "examples": [
+                "text/html"
+            ]
+        },
+        "type": {
+            "$id": "#/properties/type",
+            "type": "string",
+            "title": "Type",
+            "default": "",
+            "examples": [
+                "termsofuse_directorsearch"
+            ]
+        },
+        "versionId": {
+            "$id": "#/properties/versionId",
+            "type": "string",
+            "title": "Version ID",
+            "default": "",
+            "examples": [
+                "d1"
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/error.json
+++ b/auth-api/src/auth_api/schemas/schemas/error.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/error",
+    "type": "object",
+    "title": "The Error response schema",
+    "description": "The error schema for unsucessful response status.",
+    "default": {},
+    "examples": [
+        {
+            "message": "The requested invitation could not be found."
+        }
+    ],
+    "required": [
+        "message"
+    ],
+    "properties": {
+        "message": {
+            "$id": "#/properties/message",
+            "type": "string",
+            "title": "Message",
+            "default": "",
+            "examples": [
+                "The requested invitation could not be found."
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/exception.json
+++ b/auth-api/src/auth_api/schemas/schemas/exception.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/exception",
+    "type": "object",
+    "title": "Error Message",
+    "required": [
+      "code",
+      "message"
+    ],
+    "properties": {
+      "code": {
+        "$id": "#/properties/code",
+        "type": "string",
+        "title": "Error Code",
+        "examples": [
+          "INVALID_CORP_OR_FILING_TYPE",
+          "INVALID_CORP_OR_FILING_TYPE"
+        ],
+        "pattern": "^(.*)$"
+      },
+      "message": {
+        "$id": "#/properties/message",
+        "type": "string",
+        "title": "Error Message",
+        "examples": [
+          "No matching record found for Corp Type and Filing Type"
+        ],
+        "pattern": "^(.*)$"
+      }
+    }
+  }
+  

--- a/auth-api/src/auth_api/schemas/schemas/invitation_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/invitation_response.json
@@ -1,0 +1,102 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/invitation_response",
+    "type": "object",
+    "title": "Invitation Response",
+    "description": "The Invation schema for response.",
+    "default": {},
+    "examples": [
+        {
+            "acceptedDate": "2020-11-08T12:03:50.863200+00:00",
+            "expiresOn": "2020-11-13T19:25:02.704139+00:00",
+            "id": 1580,
+            "recipientEmail": "test@gmai.com",
+            "sentDate": "2020-11-06T19:25:02.704139+00:00",
+            "status": "ACCEPTED",
+            "token": "eyJpZCI6NiwidHlwZSI6IlNUQU5EQVJEIn0.X7V-Jg.Pd0g1DvcmChr34dQk5DbDmQOXOQ",
+            "type": "STANDARD"
+        }
+    ],
+    "required": [
+        "id",
+        "recipientEmail",
+        "sentDate",
+        "status"
+    ],
+    "properties": {
+        "acceptedDate": {
+            "$id": "#/properties/acceptedDate",
+            "type": "string",
+            "title": "Accepted Date",
+            "default": "",
+            "examples": [
+                "2020-11-08T12:03:50.863200+00:00"
+            ]
+        },
+        "expiresOn": {
+            "$id": "#/properties/expiresOn",
+            "type": "string",
+            "title": "Expires On",
+            "default": "",
+            "examples": [
+                "2020-11-13T19:25:02.704139+00:00"
+            ]
+        },
+        "id": {
+            "$id": "#/properties/id",
+            "type": "integer",
+            "title": "ID",
+            "default": 0,
+            "examples": [
+                1580
+            ]
+        },
+        "recipientEmail": {
+            "$id": "#/properties/recipientEmail",
+            "type": "string",
+            "title": "Recipient Email",
+            "default": "",
+            "examples": [
+                "test@gmai.com"
+            ]
+        },
+        "sentDate": {
+            "$id": "#/properties/sentDate",
+            "type": "string",
+            "title": "Sent Date",
+            "default": "",
+            "examples": [
+                "2020-11-06T19:25:02.704139+00:00"
+            ]
+        },
+        "status": {
+            "$id": "#/properties/status",
+            "type": "string",
+            "title": "Status",
+            "default": "",
+            "examples": [
+                "ACCEPTED"
+            ]
+        },
+        "token": {
+            "$id": "#/properties/token",
+            "type": "string",
+            "title": "Token",
+            "default": "",
+            "examples": [
+                "eyJpZCI6NiwidHlwZSI6IlNUQU5EQVJEIn0.X7V-Jg.Pd0g1DvcmChr34dQk5DbDmQOXOQ"
+            ]
+        },        
+        "type": {
+            "$id": "#/properties/type",
+            "type": "string",
+            "title": "The type schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+                "STANDARD"
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/invitations.json
+++ b/auth-api/src/auth_api/schemas/schemas/invitations.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/invitations",
+    "type": "object",
+    "title": "Invitation List",
+    "required": [
+    ],
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/invitation_response"
+        }
+      }
+    }
+  }

--- a/auth-api/src/auth_api/schemas/schemas/members.json
+++ b/auth-api/src/auth_api/schemas/schemas/members.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/members",
+    "type": "object",
+    "title": "Contact List",
+    "required": [
+    ],
+    "properties": {
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/membership"
+        }
+      }
+    }
+  }

--- a/auth-api/src/auth_api/schemas/schemas/membership.json
+++ b/auth-api/src/auth_api/schemas/schemas/membership.json
@@ -1,0 +1,77 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/membership",
+    "type": "object",
+    "title": "membership",
+    "description": "The membership schema.",
+    "default": {},
+    "examples": [
+        {
+            "id": 3195,
+            "membershipStatus": "ACTIVE",
+            "membershipTypeCode": "ADMIN",
+            "user": {
+                "contacts": [
+                    {
+                        "created": "2020-11-03T20:51:30.535608+00:00",
+                        "createdBy": "abc-auth sbc-auth",
+                        "email": "test@gmail.com",
+                        "modified": "2020-11-03T20:51:30.535619+00:00",
+                        "phone": "1111",
+                        "phoneExtension": "11111"
+                    }
+                ],
+                "firstname": "abc-auth",
+                "id": 5389,
+                "lastname": "sbc-auth",
+                "loginSource": "BCSC",
+                "modified": "2020-11-03T20:50:39.366030+00:00",
+                "username": "service-account-registries-public-user-test"
+            }
+        }
+    ],
+    "required": [
+        "id",
+        "membershipStatus",
+        "membershipTypeCode",
+        "user"
+    ],
+    "properties": {
+        "id": {
+            "$id": "#/properties/id",
+            "type": "integer",
+            "title": "ID",
+            "default": 0,
+            "examples": [
+                3195
+            ]
+        },
+        "membershipStatus": {
+            "$id": "#/properties/membershipStatus",
+            "type": "string",
+            "title": "Membership Status",
+            "default": "",
+            "examples": [
+                "ACTIVE"
+            ]
+        },
+        "membershipTypeCode": {
+            "$id": "#/properties/membershipTypeCode",
+            "type": "string",
+            "title": "The membershipTypeCode schema",
+            "default": "",
+            "examples": [
+                "ADMIN"
+            ]
+        },
+        "user": {
+            "$id": "#/properties/user",
+            "type": "object",
+            "title": "User",
+            "user": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/user_response"
+              }
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/org_product_subscriptions_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/org_product_subscriptions_response.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/org_product_subscriptions_response",
+    "type": "object",
+    "title": "Organization Product Subscriptions",
+    "description": "The response schema of organization product subscriptions.",
+    "default": {},
+    "examples": [
+        {
+            "subscriptions": [
+                {
+                    "created": "2020-11-23T11:16:15.491065+00:00",
+                    "createdBy": "Ashley Mcguire",
+                    "id": 2,
+                    "modified": "2020-11-23T11:16:15.491073+00:00",
+                    "product": "PPR",
+                    "productSubscriptionRoles": [
+                        1
+                    ]
+                },
+                {
+                    "created": "2020-11-23T11:16:15.548317+00:00",
+                    "createdBy": "Ashley Mcguire",
+                    "id": 3,
+                    "modified": "2020-11-23T11:16:15.548325+00:00",
+                    "product": "DIR_SEARCH",
+                    "productSubscriptionRoles": [
+                        2
+                    ]
+                }
+            ]
+        }
+    ],
+    "required": [
+        "subscriptions"
+    ],
+    "properties": {
+        "subscriptions": {
+            "$id": "#/properties/subscriptions",
+            "type": "array",
+            "title": "Subscriptions",
+            "default": [],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/subscriptions/items",
+                "anyOf": [
+                    {
+                        "$id": "#/properties/subscriptions/items/anyOf/0",
+                        "type": "object",
+                        "default": {},
+                        "required": [
+                            "product",
+                            "productSubscriptionRoles"
+                        ],
+                        "properties": {
+                            "created": {
+                                "$id": "#/properties/subscriptions/items/anyOf/0/properties/created",
+                                "type": "string",
+                                "title": "Created",
+                                "default": "",
+                                "examples": [
+                                    "2020-11-23T11:16:15.491065+00:00"
+                                ]
+                            },
+                            "createdBy": {
+                                "$id": "#/properties/subscriptions/items/anyOf/0/properties/createdBy",
+                                "type": "string",
+                                "title": "Created By",
+                                "default": "",
+                                "examples": [
+                                    "Ashley Mcguire"
+                                ]
+                            },
+                            "id": {
+                                "$id": "#/properties/subscriptions/items/anyOf/0/properties/id",
+                                "type": "integer",
+                                "title": "ID",
+                                "default": 0,
+                                "examples": [
+                                    2
+                                ]
+                            },
+                            "modified": {
+                                "$id": "#/properties/subscriptions/items/anyOf/0/properties/modified",
+                                "type": "string",
+                                "title": "Modified",
+                                "default": "",
+                                "examples": [
+                                    "2020-11-23T11:16:15.491073+00:00"
+                                ]
+                            },
+                            "product": {
+                                "$id": "#/properties/subscriptions/items/anyOf/0/properties/product",
+                                "type": "string",
+                                "title": "Product",
+                                "default": "",
+                                "examples": [
+                                    "PPR"
+                                ]
+                            },
+                            "productSubscriptionRoles": {
+                                "$id": "#/properties/subscriptions/items/anyOf/0/properties/productSubscriptionRoles",
+                                "type": "array",
+                                "title": "Product Subscription Roles",
+                                "default": [],
+                                "examples": [
+                                    [
+                                        1
+                                    ]
+                                ],
+                                "additionalItems": true,
+                                "items": {
+                                    "$id": "#/properties/subscriptions/items/anyOf/0/properties/productSubscriptionRoles/items",
+                                    "anyOf": [
+                                        {
+                                            "$id": "#/properties/subscriptions/items/anyOf/0/properties/productSubscriptionRoles/items/anyOf/0",
+                                            "type": "integer",
+                                            "default": 0,
+                                            "examples": [
+                                                1
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "additionalProperties": true
+                    }
+                ]
+            }
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/org_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/org_response.json
@@ -1,0 +1,224 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/org_response",
+    "type": "object",
+    "title": "org_response",
+    "description": "The org_response is for add account response.",
+    "default": {},
+    "examples": [
+        {
+            "contacts": [],
+            "accessType": "REGULAR",
+            "bcolAccountId": "106700",
+            "bcolUserId": "PB99999",
+            "billable": true,
+            "created": "2020-11-12T21:42:30.850904+00:00",
+            "createdBy": "abc-auth sbc-auth",
+            "id": 2390,
+            "invitations": [
+                {
+                    "expiresOn": "2021-03-03T11:49:44.148559+00:00",
+                    "id": 2,
+                    "recipientEmail": "abc123@email.com",
+                    "sentDate": "2020-11-23T11:49:44.148559+00:00",
+                    "status": "PENDING",
+                    "token": "eyJpZCI6MiwidHlwZSI6IkRJUkVDVE9SX1NFQVJDSCJ9.X7wSWA.8_WvWRuAUSnk-Jsj9it869UvL-M",
+                    "type": "DIRECTOR_SEARCH"
+                }
+            ],
+            "loginOptions": [],
+            "modified": "2020-11-12T21:42:30.861522+00:00",
+            "modifiedBy": "abc-auth sbc-auth",
+            "name": "mytest1",
+            "orgType": "PREMIUM",
+            "orgStatus": "ACTIVE",
+            "products": [
+                2281
+            ],
+            "statusCode": "ACTIVE"
+        }
+    ],
+    "required": [
+        "accessType",
+        "billable",
+        "id",
+        "loginOptions",
+        "name",
+        "orgType",
+        "products",
+        "statusCode"
+    ],
+    "properties": {
+        "contacts": {
+            "$id": "#/properties/contacts",
+            "type": "array",
+            "contacts": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/contact_response"
+              }
+        },
+        "accessType": {
+            "$id": "#/properties/accessType",
+            "type": "string",
+            "title": "Access Type",
+            "default": "",
+            "examples": [
+                "REGULAR"
+            ]
+        },
+        "bcolAccountId": {
+            "$id": "#/properties/bcolAccountId",
+            "type": "string",
+            "title": "BC Oline Account ID",
+            "default": "",
+            "examples": [
+                "106700"
+            ]
+        },
+        "bcolUserId": {
+            "$id": "#/properties/bcolUserId",
+            "type": "string",
+            "title": "BC Oline User ID",
+            "default": "",
+            "examples": [
+                "PB99999"
+            ]
+        },        
+        "billable": {
+            "$id": "#/properties/billable",
+            "type": "boolean",
+            "title": "Billable",
+            "default": false,
+            "examples": [
+                true
+            ]
+        },
+        "created": {
+            "$id": "#/properties/created",
+            "type": "string",
+            "title": "Created",
+            "default": "",
+            "examples": [
+                "2020-11-12T21:42:30.850904+00:00"
+            ]
+        },
+        "createdBy": {
+            "$id": "#/properties/createdBy",
+            "type": "string",
+            "title": "Created By",
+            "default": "",
+            "examples": [
+                "abc-auth sbc-auth"
+            ]
+        },
+        "id": {
+            "$id": "#/properties/id",
+            "type": "integer",
+            "title": "ID",
+            "default": 0,
+            "examples": [
+                2390
+            ]
+        },
+        "invitations": {
+            "$id": "#/properties/invitations",
+            "type": "array",
+            "contacts": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/invitation_response"
+              }
+        },
+        "loginOptions": {
+            "$id": "#/properties/loginOptions",
+            "type": "array",
+            "title": "Login Options",
+            "default": [],
+            "examples": [
+                []
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/loginOptions/items"
+            }
+        },
+        "modified": {
+            "$id": "#/properties/modified",
+            "type": "string",
+            "title": "Modified",
+            "default": "",
+            "examples": [
+                "2020-11-12T21:42:30.861522+00:00"
+            ]
+        },
+        "modifiedBy": {
+            "$id": "#/properties/modifiedBy",
+            "type": "string",
+            "title": "Modified By",
+            "default": "",
+            "examples": [
+                "abc-auth sbc-auth"
+            ]
+        },
+        "name": {
+            "$id": "#/properties/name",
+            "type": "string",
+            "title": "Name",
+            "default": "",
+            "examples": [
+                "mytest1"
+            ]
+        },
+        "orgType": {
+            "$id": "#/properties/orgType",
+            "type": "string",
+            "title": "Organization Type",
+            "default": "",
+            "examples": [
+                "PREMIUM"
+            ]
+        },
+        "orgStatus": {
+            "$id": "#/properties/orgStatus",
+            "type": "string",
+            "title": "Organization Status",
+            "default": "",
+            "examples": [
+                "ACTIVE"
+            ]
+        },
+        "products": {
+            "$id": "#/properties/products",
+            "type": "array",
+            "title": "Products",
+            "default": [],
+            "examples": [
+                [
+                    2281
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "$id": "#/properties/products/items",
+                "anyOf": [
+                    {
+                        "$id": "#/properties/products/items/anyOf/0",
+                        "type": "integer",
+                        "title": "Any Of",
+                        "default": 0,
+                        "examples": [
+                            2281
+                        ]
+                    }
+                ]
+            }
+        },
+        "statusCode": {
+            "$id": "#/properties/statusCode",
+            "type": "string",
+            "title": "Status Code",
+            "default": "",
+            "examples": [
+                "ACTIVE"
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/orgs_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/orgs_response.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/orgs_response",
+    "type": "object",
+    "title": "Organizations Response",
+    "description": "The organizations schema for response.",
+    "default": {},
+    "examples": [
+        {
+            "orgs": [
+                {
+                    "accessType": "REGULAR",
+                    "billable": true,
+                    "created": "2020-11-17T14:58:14.701596+00:00",
+                    "createdBy": "Gilbert Campbell",
+                    "id": 1,
+                    "loginOptions": [],
+                    "modified": "2020-11-17T14:58:14.729096+00:00",
+                    "modifiedBy": "Gilbert Campbell",
+                    "name": "My Test Org",
+                    "orgType": "BASIC",
+                    "orgStatus": "ACTIVE",
+                    "products": [
+                        1
+                    ],
+                    "statusCode": "ACTIVE"
+                }
+            ]
+        }
+    ],
+    "required": [
+        "orgs"
+    ],
+    "properties": {
+        "orgs": {
+            "$id": "#/properties/orgs",
+            "type": "array",
+            "title": "Organizations",
+            "default": [],
+            "additionalItems": true,
+            "items": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/org_response"
+            }
+
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/paged_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/paged_response.json
@@ -1,0 +1,121 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/paged_response",
+    "type": "object",
+    "title": "Paged Response",
+    "description": "The schema of responses with paging info.",
+    "default": {},
+    "examples": [
+        {
+            "limit": 10,
+            "orgs": [
+                {
+                    "accessType": "ANONYMOUS",
+                    "billable": false,
+                    "contacts": [],
+                    "created": "2020-11-23T11:49:43.900310+00:00",
+                    "createdBy": "Susan Stewart",
+                    "id": 2,
+                    "invitations": [
+                        {
+                            "expiresOn": "2021-03-03T11:49:44.148559+00:00",
+                            "id": 2,
+                            "recipientEmail": "abc123@email.com",
+                            "sentDate": "2020-11-23T11:49:44.148559+00:00",
+                            "status": "PENDING",
+                            "token": "eyJpZCI6MiwidHlwZSI6IkRJUkVDVE9SX1NFQVJDSCJ9.X7wSWA.8_WvWRuAUSnk-Jsj9it869UvL-M",
+                            "type": "DIRECTOR_SEARCH"
+                        }
+                    ],
+                    "loginOptions": [],
+                    "modified": "2020-11-23T11:49:43.941148+00:00",
+                    "modifiedBy": "Susan Stewart",
+                    "name": "Another test org",
+                    "orgType": "BASIC",
+                    "orgStatus": "ACTIVE",
+                    "products": [
+                        2
+                    ],
+                    "statusCode": "ACTIVE"
+                },
+                {
+                    "accessType": "ANONYMOUS",
+                    "billable": false,
+                    "contacts": [],
+                    "created": "2020-11-23T11:49:42.735027+00:00",
+                    "createdBy": "Susan Stewart",
+                    "id": 1,
+                    "invitations": [
+                        {
+                            "expiresOn": "2021-03-03T11:49:43.152821+00:00",
+                            "id": 1,
+                            "recipientEmail": "abc123@email.com",
+                            "sentDate": "2020-11-23T11:49:43.152821+00:00",
+                            "status": "PENDING",
+                            "token": "eyJpZCI6MSwidHlwZSI6IkRJUkVDVE9SX1NFQVJDSCJ9.X7wSVw.pVZrsBz7EyKxaF3GtoZbbf7fLEY",
+                            "type": "DIRECTOR_SEARCH"
+                        }
+                    ],
+                    "loginOptions": [],
+                    "modified": "2020-11-23T11:49:42.762876+00:00",
+                    "modifiedBy": "Susan Stewart",
+                    "name": "My Test Anon Org",
+                    "orgType": "BASIC",
+                    "orgStatus": "ACTIVE",
+                    "products": [
+                        1
+                    ],
+                    "statusCode": "ACTIVE"
+                }
+            ],
+            "page": 1,
+            "total": 2
+        }
+    ],
+    "required": [
+        "limit",
+        "page",
+        "total"
+    ],
+    "properties": {
+        "limit": {
+            "$id": "#/properties/limit",
+            "type": "integer",
+            "title": "The limit schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": 0,
+            "examples": [
+                10
+            ]
+        },
+        "orgs": {
+            "$id": "#/properties/orgs",
+            "type": "array",
+            "title": "The orgs schema",
+            "orgs": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/org_response"
+              }
+        },
+        "page": {
+            "$id": "#/properties/page",
+            "type": "integer",
+            "title": "The page schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": 0,
+            "examples": [
+                1
+            ]
+        },
+        "total": {
+            "$id": "#/properties/total",
+            "type": "integer",
+            "title": "The total schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": 0,
+            "examples": [
+                2
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/product.json
+++ b/auth-api/src/auth_api/schemas/schemas/product.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/product",
+    "type": "object",
+    "title": "Product schema",
+    "description": "The schema of product.",
+    "default": {},
+    "examples": [
+        {
+            "name": "Personal Property Registry",
+            "description": "View and maintain records of charges such as liens, security interests, and encumberances filed against personal property.",
+            "url": "https://dev.bcregistry.ca/business/ppr",
+            "type": "INTERNAL",
+            "mdiIcon": "mdi-image-outline"
+        }
+    ],
+    "required": [
+        "name",
+        "description",
+        "url",
+        "type",
+        "mdiIcon"
+    ],
+    "properties": {
+        "name": {
+            "$id": "#/properties/name",
+            "type": "string",
+            "title": "Name",
+            "default": "",
+            "examples": [
+                "Personal Property Registry"
+            ]
+        },
+        "description": {
+            "$id": "#/properties/description",
+            "type": "string",
+            "title": "Description",
+            "default": "",
+            "examples": [
+                "View and maintain records of charges such as liens, security interests, and encumberances filed against personal property."
+            ]
+        },
+        "url": {
+            "$id": "#/properties/url",
+            "type": "string",
+            "title": "URL",
+            "default": "",
+            "examples": [
+                "https://dev.bcregistry.ca/business/ppr"
+            ]
+        },
+        "type": {
+            "$id": "#/properties/type",
+            "type": "string",
+            "title": "Type",
+            "default": "",
+            "examples": [
+                "INTERNAL"
+            ]
+        },
+        "mdiIcon": {
+            "$id": "#/properties/mdiIcon",
+            "type": "string",
+            "title": "MDI Icon",
+            "default": "",
+            "examples": [
+                "mdi-image-outline"
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/products.json
+++ b/auth-api/src/auth_api/schemas/schemas/products.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/products",
+  "type": "array",
+  "title": "Products",
+  "description": "Products Schema.",
+  "default": [],
+  "examples": [
+      [
+          {
+              "name": "Personal Property Registry",
+              "description": "View and maintain records of charges such as liens, security interests, and encumberances filed against personal property.",
+              "url": "https://dev.bcregistry.ca/business/ppr",
+              "type": "INTERNAL",
+              "mdiIcon": "mdi-image-outline"
+          },
+          {
+              "name": "Business Registry",
+              "description": "Information for companies, firms & societies. Most filings for BC & Extraprovincial companies can be done in the Business Registry.",
+              "url": "https://dev.bcregistry.ca/business",
+              "type": "INTERNAL",
+              "mdiIcon": "mdi-image-outline"
+          }
+      ]
+  ],
+  "additionalItems": true,
+  "items": {
+      "$id": "#/items",
+      "anyOf": [
+        {
+          "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/product"
+        }
+      ]
+  }
+}

--- a/auth-api/src/auth_api/schemas/schemas/user_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/user_response.json
@@ -1,0 +1,184 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/user_response",
+    "type": "object",
+    "title": "User Response",
+    "description": "The user schema for response.",
+    "default": {},
+    "examples": [
+        {
+            "contacts": [
+                {
+                    "created": "2020-11-03T20:51:30.535608+00:00",
+                    "createdBy": "abc-auth sbc-auth",
+                    "email": "test@gmail.com",
+                    "modified": "2020-11-03T20:51:30.535619+00:00",
+                    "phone": "1111",
+                    "phoneExtension": "11111"
+                }
+            ],
+            "created": "2020-11-03T15:14:20.711942+00:00",
+            "firstname": "abc-auth",
+            "id": 5389,
+            "keycloakGuid": "f7a4a1d3-73a8-4cbc-a40f-bb1145302064",
+            "lastname": "sbc-auth",
+            "loginSource": "BCSC",
+            "loginTime": "2020-11-23T15:14:20.712096+00:00",
+            "modified": "2020-11-03T20:50:39.366030+00:00",
+            "modifiedBy": "Jennifer Kirby",
+            "userStatus": 1,
+            "userTerms": {
+                "isTermsOfUseAccepted": true,
+                "termsOfUseAcceptedVersion": "1"
+            },
+            "username": "service-account-registries-public-user-test"
+        }
+    ],
+    "required": [
+        "firstname",
+        "id",
+        "lastname",
+        "username"
+    ],
+    "properties": {
+        "contacts": {
+            "$id": "#/properties/contacts",
+            "type": "array",
+            "contacts": {
+                "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/contact_response"
+              }
+        },
+        "created": {
+            "$id": "#/properties/created",
+            "type": "string",
+            "title": "Created",
+            "default": "",
+            "examples": [
+                "2020-11-03T15:14:20.711942+00:00"
+            ]
+        },
+        "firstname": {
+            "$id": "#/properties/firstname",
+            "type": "string",
+            "title": "Firstname",
+            "default": "",
+            "examples": [
+                "abc-auth"
+            ]
+        },
+        "id": {
+            "$id": "#/properties/id",
+            "type": "integer",
+            "title": "ID",
+            "default": 0,
+            "examples": [
+                5389
+            ]
+        },
+        "keycloakGuid": {
+            "$id": "#/properties/keycloakGuid",
+            "type": "string",
+            "title": "Keycloak GUID",
+            "default": "",
+            "examples": [
+                "f7a4a1d3-73a8-4cbc-a40f-bb1145302064"
+            ]
+        },
+        "lastname": {
+            "$id": "#/properties/lastname",
+            "type": "string",
+            "title": "Lastname",
+            "default": "",
+            "examples": [
+                "sbc-auth"
+            ]
+        },
+        "loginSource": {
+            "$id": "#/properties/loginSource",
+            "type": "string",
+            "title": "Login Source",
+            "default": "",
+            "examples": [
+                "BCSC"
+            ]
+        },
+        "loginTime": {
+            "$id": "#/properties/loginTime",
+            "type": "string",
+            "title": "Login Time",
+            "description": "An explanation about the purpose of this instance.",
+            "default": "",
+            "examples": [
+                "2020-11-23T15:14:20.712096+00:00"
+            ]
+        },
+        "modified": {
+            "$id": "#/properties/modified",
+            "type": "string",
+            "title": "Modified",
+            "default": "",
+            "examples": [
+                "2020-11-03T20:50:39.366030+00:00"
+            ]
+        },
+        "modifiedBy": {
+            "$id": "#/properties/modifiedBy",
+            "type": "string",
+            "title": "Modified By",
+            "default": "",
+            "examples": [
+                "Jennifer Kirby"
+            ]
+        },
+        "userStatus": {
+            "$id": "#/properties/userStatus",
+            "type": "integer",
+            "title": "User Status",
+            "default": 0,
+            "examples": [
+                1
+            ]
+        },
+        "userTerms": {
+            "$id": "#/properties/userTerms",
+            "type": "object",
+            "title": "User Terms",
+            "default": {},
+            "required": [
+                "isTermsOfUseAccepted",
+                "termsOfUseAcceptedVersion"
+            ],
+            "properties": {
+                "isTermsOfUseAccepted": {
+                    "$id": "#/properties/userTerms/properties/isTermsOfUseAccepted",
+                    "type": "boolean",
+                    "title": "Terms Of Use Accepted",
+                    "default": false,
+                    "examples": [
+                        true
+                    ]
+                },
+                "termsOfUseAcceptedVersion": {
+                    "$id": "#/properties/userTerms/properties/termsOfUseAcceptedVersion",
+                    "type": ["string", "null"],
+                    "title": "Terms Of Use Accepted Version",
+                    "default": "",
+                    "examples": [
+                        "1"
+                    ]
+                }
+            },
+            "additionalProperties": true
+        },
+        "username": {
+            "$id": "#/properties/username",
+            "type": "string",
+            "title": "Username",
+            "default": "",
+            "examples": [
+                "service-account-registries-public-user-test"
+            ]
+        }
+    },
+    "additionalProperties": true
+}

--- a/auth-api/src/auth_api/schemas/schemas/user_settings_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/user_settings_response.json
@@ -1,77 +1,110 @@
 {
-    "definitions": {},
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/user_settings_response",
-    "type": "object",
-    "title": "Response for user settings",
-    "additionalProperties": false,
-    "required": [
-      "id",
-      "urlpath",
-      "urlorigin",
-      "label",
-      "type"
-    ],
-    "properties": {
-      "id": {
-        "$id": "#/properties/id",
-        "type": "string",
-        "title": "Id of the entity",
-        "default": "",
-        "examples": [
-          "1"
-        ],
-        "pattern": "^(.*)$"
-      },
-      "urlpath": {
-        "$id": "#/properties/urlpath",
-        "type": "string",
-        "title": "context path of the resource.Must start with a backslash.No ending slash",
-        "default": "",
-        "examples": [
-          "/createaccount"
-        ],
-        "pattern": "^(.*)$"
-      },
-      "urlorigin": {
-        "$id": "#/properties/urlorigin",
-        "type": "string",
-        "title": "Url origin.Full url",
-        "default": "",
-        "examples": [
-          "https://dev.bcregistry.ca/cooperatives/auth/"
-        ],
-        "pattern": "^(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?$"
-      },
-      "label": {
-        "$id": "#/properties/label",
-        "type": "string",
-        "title": "Label which can be used to display to user",
-        "default": "",
-        "examples": [
-          "Create Profile"
-        ],
-        "pattern": "^(.*)$"
-      },
-      "type": {
-        "$id": "#/properties/type",
-        "type": "string",
-        "title": "Type of the resource.Like ACCOUNT",
-        "default": "",
-        "examples": [
-          "ACCOUNT"
-        ],
-        "pattern": "^(.*)$"
-      },
-      "accountType": {
-        "$id": "#/properties/accountType",
-        "type": "string",
-        "title": "Type of the account.Like Premium or basic",
-        "default": "",
-        "examples": [
-          "BASIC"
-        ],
-        "pattern": "^(.*)$"
-      }
-    }
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/user_settings_response",
+  "type": "array",
+  "title": "User Settings",
+  "description": "The user settings schema for response.",
+  "default": [],
+  "examples": [
+      [
+          {
+              "accountType": "BASIC",
+              "id": 1,
+              "label": "My Test Org",
+              "type": "ACCOUNT",
+              "urlorigin": "https://dev.bcregistry.ca/cooperatives/auth/",
+              "urlpath": "/account/1/settings"
+          },
+          {
+              "accountType": null,
+              "id": 1,
+              "label": "USER PROFILE",
+              "type": "USER_PROFILE",
+              "urlorigin": null,
+              "urlpath": "/userprofile"
+          }
+      ]
+  ],
+  "additionalItems": true,
+  "items": {
+      "$id": "#/items",
+      "anyOf": [
+          {
+              "$id": "#/items/anyOf/0",
+              "type": "object",
+              "title": "The first anyOf schema",
+              "description": "An explanation about the purpose of this instance.",
+              "default": {},
+              "required": [
+                  "accountType",
+                  "id",
+                  "label",
+                  "type",
+                  "urlorigin",
+                  "urlpath"
+              ],
+              "properties": {
+                  "accountType": {
+                      "$id": "#/items/anyOf/0/properties/accountType",
+                      "type": ["string", "null"],
+                      "title": "Account Type",
+                      "default": "",
+                      "examples": [
+                          "BASIC"
+                      ]
+                  },
+                  "id": {
+                      "$id": "#/items/anyOf/0/properties/id",
+                      "type": "integer",
+                      "title": "ID",
+                      "default": 0,
+                      "examples": [
+                          1
+                      ]
+                  },
+                  "label": {
+                      "$id": "#/items/anyOf/0/properties/label",
+                      "type": "string",
+                      "title": "Label",
+                      "default": "",
+                      "examples": [
+                          "My Test Org"
+                      ]
+                  },
+                  "type": {
+                      "$id": "#/items/anyOf/0/properties/type",
+                      "type": "string",
+                      "title": "Type",
+                      "default": "",
+                      "examples": [
+                          "ACCOUNT"
+                      ]
+                  },
+                  "urlorigin": {
+                      "$id": "#/items/anyOf/0/properties/urlorigin",
+                      "type": ["string","null"],
+                      "title": "URL Origin",
+                      "default": "",
+                      "examples": [
+                        "https://dev.bcregistry.ca/cooperatives/auth/"
+                      ],
+                      "pattern": "^(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?$"              
+                  },
+                  "urlpath": {
+                      "$id": "#/items/anyOf/0/properties/urlpath",
+                      "type": "string",
+                      "title": "URL Path",
+                      "description": "Context path of the resource. Must start with a backslash. No ending slash.",
+                      "default": "",
+                      "examples": [
+                          "/account/1/settings"
+                      ],
+                      "pattern": "^(.*)$"
+                  }
+              },
+              "additionalProperties": true
+          }
+      ]
   }
+}
+

--- a/auth-api/src/auth_api/schemas/schemas/users_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/users_response.json
@@ -1,0 +1,54 @@
+
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://bcrs.gov.bc.ca/.well_known/schemas/users_response",
+    "type": "array",
+    "title": "Products",
+    "description": "Products Schema.",
+    "default": [],
+    "examples": [
+        [
+            {
+                "contacts": [],
+                "created": "2020-11-23T15:19:35.488987+00:00",
+                "firstname": "Lisa",
+                "id": 1,
+                "keycloakGuid": "f7a4a1d3-73a8-4cbc-a40f-bb1145302064",
+                "lastname": "Wolfe",
+                "loginTime": "2020-11-23T15:19:35.489179+00:00",
+                "modified": "2020-11-23T15:19:35.496289+00:00",
+                "userStatus": 1,
+                "userTerms": {
+                    "isTermsOfUseAccepted": false,
+                    "termsOfUseAcceptedVersion": null
+                },
+                "username": "harveybenjamin"
+            },
+            {
+                "contacts": [],
+                "created": "2020-11-23T15:19:35.638131+00:00",
+                "firstname": "Craig",
+                "id": 2,
+                "keycloakGuid": "f7a4a1d3-73a8-4cbc-a40f-bb1145302065",
+                "lastname": "Collins",
+                "loginTime": "2020-11-23T15:19:35.638259+00:00",
+                "modified": "2020-11-23T15:19:35.640558+00:00",
+                "userStatus": 1,
+                "userTerms": {
+                    "isTermsOfUseAccepted": false,
+                    "termsOfUseAcceptedVersion": null
+                },
+                "username": "savannahlane"
+            }
+        ]
+    ],
+    "additionalItems": true,
+    "items": {
+        "$id": "#/items",
+        "anyOf": [
+          {
+            "$ref": "https://bcrs.gov.bc.ca/.well_known/schemas/user_response"
+          }
+        ]
+    }
+  }

--- a/auth-api/tests/unit/api/test_account.py
+++ b/auth-api/tests/unit/api/test_account.py
@@ -25,6 +25,7 @@ from tests.utilities.factory_utils import (
     factory_product_model, factory_user_model)
 
 from auth_api import status as http_status
+from auth_api.schemas import utils as schema_utils
 
 
 def test_authorizations_for_account_returns_200(app, client, jwt, session):  # pylint:disable=unused-argument
@@ -42,6 +43,7 @@ def test_authorizations_for_account_returns_200(app, client, jwt, session):  # p
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert len(rv.json.get('roles')) == 0
 
 
@@ -61,6 +63,7 @@ def test_authorizations_for_account_with_search_returns_200(client, jwt, session
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert rv.json.get('roles') == ['search']
 
 
@@ -84,6 +87,7 @@ def test_authorizations_with_multiple_accounts_returns_200(client, jwt, session)
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert len(rv.json.get('roles')) == 0
 
     headers = factory_auth_header(jwt=jwt, claims=claims)
@@ -91,6 +95,7 @@ def test_authorizations_with_multiple_accounts_returns_200(client, jwt, session)
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert rv.json.get('roles') == ['search']
 
 
@@ -110,5 +115,6 @@ def test_authorizations_for_extended_returns_200(app, client, jwt, session):  # 
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert len(rv.json.get('roles')) == 1
     assert rv.json.get('account').get('name') == org.name

--- a/auth-api/tests/unit/api/test_bcol_profiles.py
+++ b/auth-api/tests/unit/api/test_bcol_profiles.py
@@ -24,6 +24,7 @@ from tests.utilities.factory_scenarios import TestJwtClaims
 from tests.utilities.factory_utils import TestOrgInfo, factory_auth_header
 
 from auth_api import status as http_status
+from auth_api.schemas import utils as schema_utils
 
 
 def test_bcol_profiles_returns_200(app, client, jwt, session):  # pylint:disable=unused-argument
@@ -35,3 +36,4 @@ def test_bcol_profiles_returns_200(app, client, jwt, session):  # pylint:disable
                      headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'bconline_response')[0]

--- a/auth-api/tests/unit/api/test_codes.py
+++ b/auth-api/tests/unit/api/test_codes.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
+from auth_api.schemas import utils as schema_utils
 from auth_api.services import Codes as CodesService
 
 
@@ -30,9 +31,11 @@ def test_get_codes(client, jwt, session):  # pylint:disable=unused-argument
     code_type = 'membership_type'
     rv = client.get('/api/v1/codes/{}'.format(code_type), content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'codes')[0]
 
     rv = client.get('/api/v1/codes/{}'.format(code_type.upper()), content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'codes')[0]
 
 
 def test_get_codes_404(client, jwt, session):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/api/test_documents.py
+++ b/auth-api/tests/unit/api/test_documents.py
@@ -20,6 +20,7 @@ Test-Suite to ensure that the /documents endpoint is working as expected.
 from tests.utilities.factory_scenarios import TestJwtClaims
 from tests.utilities.factory_utils import factory_auth_header, factory_document_model
 
+from auth_api.schemas import utils as schema_utils
 from auth_api import status as http_status
 
 
@@ -35,6 +36,7 @@ def test_documents_returns_200(client, jwt, session):  # pylint:disable=unused-a
     rv = client.get('/api/v1/documents/termsofuse', headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'document')[0]
     assert rv.json.get('versionId') == 'd1'
 
 
@@ -44,6 +46,7 @@ def test_invalid_documents_returns_404(client, jwt, session):  # pylint:disable=
     rv = client.get('/api/v1/documents/junk', headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_404_NOT_FOUND
+    assert schema_utils.validate(rv.json, 'error')[0]
     assert rv.json.get('message') == 'The requested invitation could not be found.'
 
 
@@ -57,6 +60,7 @@ def test_documents_returns_200_for_some_type(client, jwt, session):  # pylint:di
     rv = client.get('/api/v1/documents/sometype', headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'document')[0]
     assert rv.json.get('content') == html_content
     assert rv.json.get('versionId') == version_id
 
@@ -75,6 +79,7 @@ def test_documents_returns_latest_always(client, jwt, session):  # pylint:disabl
     rv = client.get('/api/v1/documents/termsofuse', headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'document')[0]
     assert rv.json.get('content') == html_content_2
     assert rv.json.get('versionId') == version_id_2
 
@@ -88,6 +93,7 @@ def test_documents_returns_latest_always(client, jwt, session):  # pylint:disabl
     rv = client.get('/api/v1/documents/termsofuse', headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'document')[0]
     assert rv.json.get('content') == html_content_2
     assert rv.json.get('versionId') == version_id_4
 

--- a/auth-api/tests/unit/api/test_entity.py
+++ b/auth-api/tests/unit/api/test_entity.py
@@ -29,6 +29,7 @@ from tests.utilities.factory_utils import (
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
+from auth_api.schemas import utils as schema_utils
 from auth_api.services import Entity as EntityService
 
 
@@ -38,6 +39,7 @@ def test_add_entity(client, jwt, session):  # pylint:disable=unused-argument
     rv = client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity1),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'business')[0]
 
 
 def test_add_entity_invalid_returns_400(client, jwt, session):  # pylint:disable=unused-argument
@@ -77,6 +79,7 @@ def test_get_entity(client, jwt, session):  # pylint:disable=unused-argument
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'business')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['businessIdentifier'] == TestEntityInfo.entity1['businessIdentifier']
 
@@ -124,6 +127,7 @@ def test_add_contact(client, jwt, session):  # pylint:disable=unused-argument
     rv = client.post('/api/v1/entities/{}/contacts'.format(TestEntityInfo.entity1['businessIdentifier']),
                      headers=headers, data=json.dumps(TestContactInfo.contact1), content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'business')[0]
     dictionary = json.loads(rv.data)
     assert len(dictionary['contacts']) == 1
     assert dictionary['contacts'][0]['email'] == TestContactInfo.contact1['email']
@@ -172,6 +176,7 @@ def test_update_contact(client, jwt, session):  # pylint:disable=unused-argument
                     headers=headers, data=json.dumps(TestContactInfo.contact2), content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'business')[0]
     dictionary = json.loads(rv.data)
     assert len(dictionary['contacts']) == 1
     assert dictionary['contacts'][0]['email'] == TestContactInfo.contact2['email']
@@ -221,6 +226,8 @@ def test_update_entity_success(client, jwt, session):  # pylint:disable=unused-a
                       data=json.dumps(TestEntityInfo.entity2),
                       headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'business')[0]
+
     dictionary = json.loads(rv.data)
     assert dictionary['businessIdentifier'] == TestEntityInfo.entity2['businessIdentifier']
 
@@ -229,6 +236,8 @@ def test_update_entity_success(client, jwt, session):  # pylint:disable=unused-a
                       data=json.dumps({'businessIdentifier': 'CPNEW123'}),
                       headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'business')[0]
+
     dictionary = json.loads(rv.data)
     assert dictionary['businessIdentifier'] == 'CPNEW123'
 
@@ -248,6 +257,7 @@ def test_update_entity_with_folio_number(client, jwt, session):  # pylint:disabl
                       data=json.dumps(TestEntityInfo.entity_folio_number),
                       headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'business')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['businessIdentifier'] == TestEntityInfo.entity2['businessIdentifier']
     assert dictionary['folioNumber'] == TestEntityInfo.entity_folio_number['folioNumber']
@@ -277,6 +287,7 @@ def test_authorizations_for_staff_returns_200(client, jwt, session):  # pylint:d
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
 
 
 def test_authorizations_for_affiliated_users_returns_200(client, jwt, session):  # pylint:disable=unused-argument
@@ -295,6 +306,7 @@ def test_authorizations_for_affiliated_users_returns_200(client, jwt, session): 
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert rv.json.get('orgMembership') == 'ADMIN'
 
 
@@ -314,12 +326,14 @@ def test_authorizations_for_expanded_result(client, jwt, session):  # pylint:dis
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert rv.json.get('orgMembership') == 'ADMIN'
     assert rv.json.get('account', None) is None
 
     rv = client.get(f'/api/v1/entities/{entity.business_identifier}/authorizations?expanded=true',
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert rv.json.get('account') is not None
     assert rv.json.get('account').get('name') == org.name
     assert rv.json.get('business').get('name') == entity.name
@@ -342,6 +356,7 @@ def test_authorizations_expanded_for_staff(client, jwt, session):  # pylint:disa
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'account_response')[0]
     assert rv.json.get('account') is not None
     assert rv.json.get('account').get('name') == org.name
     assert rv.json.get('business').get('name') == entity.name
@@ -382,3 +397,4 @@ def test_add_entity_idempotent(client, jwt, session):  # pylint:disable=unused-a
     rv = client.post('/api/v1/entities', data=json.dumps(TestEntityInfo.entity1),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_202_ACCEPTED
+    assert schema_utils.validate(rv.json, 'business')[0]

--- a/auth-api/tests/unit/api/test_invitation.py
+++ b/auth-api/tests/unit/api/test_invitation.py
@@ -22,6 +22,7 @@ from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo
 from tests.utilities.factory_utils import factory_auth_header, factory_invitation
 
 from auth_api import status as http_status
+from auth_api.schemas import utils as schema_utils
 from auth_api.services import Invitation as InvitationService
 
 
@@ -38,6 +39,7 @@ def test_add_invitation(client, jwt, session, keycloak_mock):  # pylint:disable=
     dictionary = json.loads(rv.data)
     assert dictionary.get('token') is not None
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'invitation_response')[0]
 
 
 def test_add_invitation_invalid(client, jwt, session):  # pylint:disable=unused-argument
@@ -61,6 +63,7 @@ def test_get_invitations_by_id(client, jwt, session, keycloak_mock):  # pylint:d
     invitation_dictionary = json.loads(rv.data)
     invitation_id = invitation_dictionary['id']
     rv = client.get('/api/v1/invitations/{}'.format(invitation_id), headers=headers, content_type='application/json')
+    assert schema_utils.validate(rv.json, 'invitation_response')[0]
     assert rv.status_code == http_status.HTTP_200_OK
 
 
@@ -78,6 +81,7 @@ def test_delete_invitation(client, jwt, session, keycloak_mock):  # pylint:disab
     invitation_id = invitation_dictionary['id']
     rv = client.delete('/api/v1/invitations/{}'.format(invitation_id), headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+
     rv = client.get('/api/v1/invitations/{}'.format(invitation_id), headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_404_NOT_FOUND
     dictionary = json.loads(rv.data)
@@ -100,6 +104,7 @@ def test_update_invitation(client, jwt, session, keycloak_mock):  # pylint:disab
     rv = client.patch('/api/v1/invitations/{}'.format(invitation_id), data=json.dumps(updated_invitation),
                       headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'invitation_response')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['status'] == 'PENDING'
 
@@ -141,6 +146,7 @@ def test_accept_invitation(client, jwt, session, keycloak_mock):  # pylint:disab
     rv = client.put('/api/v1/invitations/tokens/{}'.format(invitation_id_token), headers=headers_invitee,
                     content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+
     rv = client.get('/api/v1/orgs/{}/members?status=PENDING_APPROVAL'.format(org_id),
                     headers=headers,
                     content_type='application/json')

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 from auth_api import status as http_status
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
+from auth_api.schemas import utils as schema_utils
 from auth_api.services import Affiliation as AffiliationService
 from auth_api.services import Invitation as InvitationService
 from auth_api.services import Org as OrgService
@@ -41,6 +42,7 @@ def test_add_org(client, jwt, session, keycloak_mock):  # pylint:disable=unused-
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'org_response')[0]
 
 
 def test_add_basic_org_with_online_banking(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -50,6 +52,7 @@ def test_add_basic_org_with_online_banking(client, jwt, session, keycloak_mock):
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org_onlinebanking),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'org_response')[0]
 
 
 def test_add_basic_org_with_pad_throws_error(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -94,6 +97,7 @@ def test_search_org_by_client(client, jwt, session, keycloak_mock):  # pylint:di
     rv = client.get('/api/v1/orgs?name={}'.format(TestOrgInfo.org1.get('name')),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
     orgs = json.loads(rv.data)
     assert orgs.get('orgs')[0].get('name') == TestOrgInfo.org1.get('name')
 
@@ -101,6 +105,7 @@ def test_search_org_by_client(client, jwt, session, keycloak_mock):  # pylint:di
     rv = client.get('/api/v1/orgs?status={}'.format('ACTIVE'),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
     orgs = json.loads(rv.data)
     assert orgs.get('orgs')[0].get('name') == TestOrgInfo.org1.get('name')
 
@@ -108,6 +113,7 @@ def test_search_org_by_client(client, jwt, session, keycloak_mock):  # pylint:di
     rv = client.get('/api/v1/orgs?status={}&type={}'.format('ACTIVE', 'REGULAR'),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
     orgs = json.loads(rv.data)
     assert orgs.get('orgs')[0].get('name') == TestOrgInfo.org1.get('name')
 
@@ -129,6 +135,7 @@ def test_search_org_for_dir_search(client, jwt, session, keycloak_mock):  # pyli
     rv = client.get('/api/v1/orgs',
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
     orgs = json.loads(rv.data)
     assert len(orgs.get('orgs')) == 2
 
@@ -137,6 +144,7 @@ def test_search_org_for_dir_search(client, jwt, session, keycloak_mock):  # pyli
     rv = client.get('/api/v1/orgs',
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
     orgs = json.loads(rv.data)
     assert len(orgs.get('orgs')) == 2
 
@@ -145,6 +153,7 @@ def test_search_org_for_dir_search(client, jwt, session, keycloak_mock):  # pyli
     rv = client.get('/api/v1/orgs',
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
     orgs = json.loads(rv.data)
     assert len(orgs.get('orgs')) == 1
 
@@ -158,6 +167,7 @@ def test_add_anonymous_org_staff_admin(client, jwt, session, keycloak_mock):  # 
     assert rv.status_code == http_status.HTTP_201_CREATED
     dictionary = json.loads(rv.data)
     assert dictionary['accessType'] == 'ANONYMOUS'
+    assert schema_utils.validate(rv.json, 'org_response')[0]
 
 
 def test_add_anonymous_org_by_user_exception(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -308,6 +318,7 @@ def test_add_org_invalid_returns_exception(client, jwt, session):  # pylint:disa
         rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1),
                          headers=headers, content_type='application/json')
         assert rv.status_code == 400
+        assert schema_utils.validate(rv.json, 'exception')[0]
 
 
 def test_get_org(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -323,6 +334,7 @@ def test_get_org(client, jwt, session, keycloak_mock):  # pylint:disable=unused-
     rv = client.get('/api/v1/orgs/{}'.format(org_id),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'org_response')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['id'] == org_id
 
@@ -364,6 +376,7 @@ def test_update_org(client, jwt, session, keycloak_mock):  # pylint:disable=unus
     assert rv.status_code == http_status.HTTP_200_OK
     dictionary = json.loads(rv.data)
     assert dictionary['id'] == org_id
+    assert schema_utils.validate(rv.json, 'org_response')[0]
 
     rv = client.post('/api/v1/orgs', data=json.dumps({'name': 'helo-duplicate'}),
                      headers=headers, content_type='application/json')
@@ -387,6 +400,9 @@ def test_update_org(client, jwt, session, keycloak_mock):  # pylint:disable=unus
     rv = client.get(f'/api/v1/orgs/{org_id}/contacts', headers=headers,
                     content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+
+    assert schema_utils.validate(rv.json, 'contacts')[0]
+
     dictionary = json.loads(rv.data)
     actual_mailing_address = org_with_mailing_address.get('mailingAddress')
     assert actual_mailing_address.get('city') == dictionary['contacts'][0].get('city')
@@ -459,11 +475,13 @@ def test_upgrade_org(client, jwt, session, keycloak_mock):  # pylint:disable=unu
                     data=json.dumps(premium_info), headers=headers,
                     content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'org_response')[0]
 
     rv = client.get('/api/v1/orgs/{}'.format(org_id),
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'org_response')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['id'] == org_id
     assert rv.json.get('orgType') == OrgType.PREMIUM.value
@@ -505,6 +523,7 @@ def test_upgrade_downgrade_reattach_bcol_todifferent_org(client, jwt, session,
     rv = client.get('/api/v1/orgs/{}'.format(org_id),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'org_response')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['id'] == org_id
     assert rv.json.get('orgType') == OrgType.BASIC.value
@@ -519,6 +538,7 @@ def test_upgrade_downgrade_reattach_bcol_todifferent_org(client, jwt, session,
 
     dictionary = json.loads(rv.data)
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'org_response')[0]
     assert rv.json.get('orgType') == OrgType.PREMIUM.value
     assert rv.json.get('name') == bcol_account.get('name')
 
@@ -546,6 +566,7 @@ def test_downgrade_org(client, jwt, session, keycloak_mock):  # pylint:disable=u
     rv = client.get('/api/v1/orgs/{}'.format(org_id),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'org_response')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['id'] == org_id
     assert rv.json.get('orgType') == OrgType.BASIC.value
@@ -566,6 +587,7 @@ def test_update_premium_org(client, jwt, session, keycloak_mock):  # pylint:disa
     rv = client.put('/api/v1/orgs/{}'.format(org_id), data=json.dumps(TestOrgInfo.bcol_linked()), headers=headers,
                     content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'org_response')[0]
 
 
 def test_get_org_payment_settings(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -575,6 +597,7 @@ def test_get_org_payment_settings(client, jwt, session, keycloak_mock):  # pylin
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.bcol_linked()),
                      headers=headers, content_type='application/json')
 
+    assert schema_utils.validate(rv.json, 'org_response')[0]
     assert rv.status_code == http_status.HTTP_201_CREATED
     assert rv.json.get('orgType') == OrgType.PREMIUM.value
 
@@ -583,6 +606,7 @@ def test_get_org_payment_settings(client, jwt, session, keycloak_mock):  # pylin
     dictionary = json.loads(rv.data)
     org_id = dictionary['id']
     rv = client.get('/api/v1/orgs/{}/contacts'.format(org_id), headers=headers)
+    assert schema_utils.validate(rv.json, 'contacts')[0]
 
 
 def test_update_org_returns_400(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -620,6 +644,7 @@ def test_update_org_returns_exception(client, jwt, session, keycloak_mock):  # p
         rv = client.put('/api/v1/orgs/{}'.format(org_id), data=json.dumps(TestOrgInfo.org1),
                         headers=headers, content_type='application/json')
         assert rv.status_code == 400
+        assert schema_utils.validate(rv.json, 'exception')[0]
 
 
 def test_add_contact(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -636,6 +661,7 @@ def test_add_contact(client, jwt, session, keycloak_mock):  # pylint:disable=unu
     assert rv.status_code == http_status.HTTP_201_CREATED
     dictionary = json.loads(rv.data)
     assert dictionary['email'] == TestContactInfo.contact1['email']
+    assert schema_utils.validate(rv.json, 'contact_response')[0]
 
 
 def test_add_contact_invalid_format_returns_400(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -664,6 +690,7 @@ def test_add_contact_valid_email_returns_201(client, jwt, session, keycloak_mock
     rv = client.post('/api/v1/orgs/{}/contacts'.format(org_id),
                      headers=headers, data=json.dumps(TestContactInfo.email_valid), content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'contacts')[0]
 
 
 def test_add_contact_no_org_returns_404(client, jwt, session):  # pylint:disable=unused-argument
@@ -707,6 +734,7 @@ def test_update_contact(client, jwt, session, keycloak_mock):  # pylint:disable=
                     headers=headers, data=json.dumps(TestContactInfo.contact2), content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'contact_response')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['email'] == TestContactInfo.contact2['email']
 
@@ -743,6 +771,7 @@ def test_update_contact_valid_email_format_returns_200(client, jwt, session,
     rv = client.put('/api/v1/orgs/{}/contacts'.format(org_id),
                     headers=headers, data=json.dumps(TestContactInfo.email_valid), content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'contact_response')[0]
 
 
 def test_update_contact_no_org_returns_404(client, jwt, session):  # pylint:disable=unused-argument
@@ -784,6 +813,7 @@ def test_delete_contact(client, jwt, session, keycloak_mock):  # pylint:disable=
                        headers=headers, data=json.dumps(TestContactInfo.contact2), content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'contact_response')[0]
 
     rv = client.get('/api/v1/orgs/{}/contacts'.format(org_id), headers=headers)
 
@@ -813,6 +843,7 @@ def test_delete_contact_returns_exception(client, jwt, session, keycloak_mock): 
     with patch.object(OrgService, 'delete_contact', side_effect=BusinessException(Error.DATA_ALREADY_EXISTS, None)):
         rv = client.delete('/api/v1/orgs/{}/contacts'.format(org_id), headers=headers, content_type='application/json')
         assert rv.status_code == 400
+        assert schema_utils.validate(rv.json, 'exception')[0]
 
 
 def test_get_members(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -828,6 +859,7 @@ def test_get_members(client, jwt, session, keycloak_mock):  # pylint:disable=unu
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'members')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['members']
     assert len(dictionary['members']) == 1
@@ -939,6 +971,7 @@ def test_get_invitations(client, jwt, session, keycloak_mock):  # pylint:disable
                     headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'invitations')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['invitations']
     assert len(dictionary['invitations']) == 2
@@ -1014,6 +1047,7 @@ def test_update_member(client, jwt, session, auth_mock, keycloak_mock):  # pylin
     rv = client.patch('/api/v1/orgs/{}/members/{}'.format(org_id, member_id), headers=headers_invitee,
                       data=json.dumps({'role': 'COORDINATOR'}), content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'membership')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['membershipTypeCode'] == 'COORDINATOR'
 
@@ -1033,6 +1067,8 @@ def test_add_affiliation(client, jwt, session, keycloak_mock):  # pylint:disable
     rv = client.post('/api/v1/orgs/{}/affiliations'.format(org_id), headers=headers,
                      data=json.dumps(TestAffliationInfo.affiliation3), content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'affiliation_response')[0]
+
     dictionary = json.loads(rv.data)
     assert dictionary['organization']['id'] == org_id
 
@@ -1079,6 +1115,7 @@ def test_add_affiliation_returns_exception(client, jwt, session, keycloak_mock):
                          headers=headers,
                          content_type='application/json')
         assert rv.status_code == 400
+        assert schema_utils.validate(rv.json, 'exception')[0]
 
 
 def test_get_affiliations(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -1106,6 +1143,8 @@ def test_get_affiliations(client, jwt, session, keycloak_mock):  # pylint:disabl
 
     rv = client.get('/api/v1/orgs/{}/affiliations'.format(org_id), headers=headers)
     assert rv.status_code == http_status.HTTP_200_OK
+
+    assert schema_utils.validate(rv.json, 'affiliations_response')[0]
     affiliations = json.loads(rv.data)
     # Result is sorted desc order of created date
     assert affiliations['entities'][1]['businessIdentifier'] == TestEntityInfo.entity_lear_mock['businessIdentifier']
@@ -1131,6 +1170,8 @@ def test_search_orgs_for_affiliation(client, jwt, session, keycloak_mock):  # py
     rv = client.get('/api/v1/orgs?affiliation={}'.format(TestAffliationInfo.affiliation3.get('businessIdentifier')),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'orgs_response')[0]
+
     orgs = json.loads(rv.data)
     assert orgs.get('orgs')[0].get('name') == TestOrgInfo.org1.get('name')
 
@@ -1164,6 +1205,7 @@ def test_add_bcol_linked_org(client, jwt, session, keycloak_mock):  # pylint:dis
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.bcol_linked()),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'org_response')[0]
     assert rv.json.get('orgType') == OrgType.PREMIUM.value
     assert rv.json.get('name') == TestOrgInfo.bcol_linked()['name']
 
@@ -1174,6 +1216,7 @@ def test_add_bcol_linked_org(client, jwt, session, keycloak_mock):  # pylint:dis
 
     assert len(org_search_response.json.get('orgs')) == 1
     assert org_search_response.status_code == http_status.HTTP_200_OK
+
     orgs = json.loads(org_search_response.data)
     assert orgs.get('orgs')[0].get('name') == TestOrgInfo.bcol_linked()['name']
     account_id = orgs.get('orgs')[0].get('bcolAccountId')
@@ -1219,6 +1262,7 @@ def test_new_business_affiliation(client, jwt, session, keycloak_mock, nr_mock):
     rv = client.post('/api/v1/orgs/{}/affiliations?newBusiness=true'.format(org_id), headers=headers,
                      data=json.dumps(TestAffliationInfo.nr_affiliation), content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'affiliation_response')[0]
     dictionary = json.loads(rv.data)
     assert dictionary['organization']['id'] == org_id
     assert dictionary['business']['businessIdentifier'] == TestAffliationInfo.nr_affiliation['businessIdentifier']
@@ -1248,6 +1292,8 @@ def test_get_org_admin_affidavits(client, jwt, session, keycloak_mock):  # pylin
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.bcol_admin_role)
     staff_response = client.get('/api/v1/orgs/{}/admins/affidavits'.format(org_response.json.get('id')),
                                 headers=headers, content_type='application/json')
+
+    assert schema_utils.validate(staff_response.json, 'affidavit_response')[0]
     assert staff_response.json.get('documentId') == doc_key
     assert staff_response.json.get('id') == affidavit_response.json.get('id')
 
@@ -1287,6 +1333,8 @@ def test_approve_org_with_pending_affidavits(client, jwt, session, keycloak_mock
 
     staff_response = client.get('/api/v1/orgs/{}/admins/affidavits'.format(org_response.json.get('id')),
                                 headers=headers, content_type='application/json')
+
+    assert schema_utils.validate(staff_response.json, 'affidavit_response')[0]
     assert staff_response.json.get('documentId') == doc_key
     assert staff_response.json.get('id') == affidavit_response.json.get('id')
     assert staff_response.json.get('status') == AffidavitStatus.APPROVED.value
@@ -1319,6 +1367,7 @@ def test_search_orgs_with_pending_affidavits(client, jwt, session, keycloak_mock
                                      headers=headers, content_type='application/json')
 
     assert len(org_search_response.json.get('orgs')) == 1
+    assert schema_utils.validate(org_search_response.json, 'paged_response')[0]
 
 
 def test_search_org_pagination(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -1337,6 +1386,7 @@ def test_search_org_pagination(client, jwt, session, keycloak_mock):  # pylint:d
     rv = client.get('/api/v1/orgs?page=1&limit=10',
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
     orgs = json.loads(rv.data)
     assert orgs.get('total') == 3
     assert len(orgs.get('orgs')) == 3
@@ -1344,6 +1394,7 @@ def test_search_org_pagination(client, jwt, session, keycloak_mock):  # pylint:d
     rv = client.get('/api/v1/orgs?page=1&limit=2',
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
     orgs = json.loads(rv.data)
     assert orgs.get('total') == 3
     assert len(orgs.get('orgs')) == 2
@@ -1374,6 +1425,8 @@ def test_search_org_invitations(client, jwt, session, keycloak_mock):  # pylint:
     rv = client.get('/api/v1/orgs?status={}'.format(OrgStatus.PENDING_ACTIVATION.value),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'paged_response')[0]
+
     orgs = json.loads(rv.data)
     assert len(orgs.get('orgs')) == 2
     assert len(orgs.get('orgs')[0].get('invitations')) == 1

--- a/auth-api/tests/unit/api/test_org_products.py
+++ b/auth-api/tests/unit/api/test_org_products.py
@@ -22,6 +22,7 @@ import json
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestOrgProductsInfo
 from tests.utilities.factory_utils import factory_auth_header
 
+from auth_api.schemas import utils as schema_utils
 from auth_api import status as http_status
 
 
@@ -37,6 +38,7 @@ def test_add_multiple_org_products(client, jwt, session, keycloak_mock):  # pyli
                               data=json.dumps(TestOrgProductsInfo.org_products2),
                               headers=headers, content_type='application/json')
     assert rv_products.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv_products.json, 'org_product_subscriptions_response')[0]
 
 
 def test_add_single_org_product(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -51,3 +53,4 @@ def test_add_single_org_product(client, jwt, session, keycloak_mock):  # pylint:
                               data=json.dumps(TestOrgProductsInfo.org_products1),
                               headers=headers, content_type='application/json')
     assert rv_products.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv_products.json, 'org_product_subscriptions_response')[0]

--- a/auth-api/tests/unit/api/test_product.py
+++ b/auth-api/tests/unit/api/test_product.py
@@ -17,12 +17,15 @@ Test suite to ensure that the Product api endpoints are working as expected.
 """
 
 import json
+from auth_api.schemas import utils as schema_utils
 
 
 def test_get_all_products(client, session):  # pylint:disable=unused-argument
     """Assert that an org can be retrieved via GET."""
     rv = client.get('/api/v1/products')
     item_list = json.loads(rv.data)
+
+    assert schema_utils.validate(item_list, 'products')[0]
     # assert the structure is correct by checking for name, description properties in each element
     for item in item_list:
         assert item['name'] and item['description']

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -50,6 +50,7 @@ def test_add_user(client, jwt, session):  # pylint:disable=unused-argument
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'user_response')[0]
 
 
 def test_delete_bcros_valdiations(client, jwt, session, keycloak_mock):
@@ -192,7 +193,7 @@ def test_add_user_admin_valid_bcros(client, jwt, session, keycloak_mock):  # pyl
         'username']
     assert dictionary['users'][0].get('password') is None
     assert dictionary['users'][0].get('type') == 'ANONYMOUS'
-    assert schema_utils.validate(rv.json, 'anonymous_user_response')
+    assert schema_utils.validate(rv.json, 'anonymous_user_response')[0]
 
     # different error scenarios
 
@@ -234,6 +235,7 @@ def test_update_user(client, jwt, session):  # pylint:disable=unused-argument
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'user_response')[0]
     user = json.loads(rv.data)
     assert user['firstname'] is not None
 
@@ -241,6 +243,7 @@ def test_update_user(client, jwt, session):  # pylint:disable=unused-argument
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.updated_test)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'user_response')[0]
     user = json.loads(rv.data)
     assert user['firstname'] is not None
 
@@ -259,12 +262,14 @@ def test_update_user_terms_of_use(client, jwt, session):  # pylint:disable=unuse
     rv = client.patch('/api/v1/users/@me', headers=headers,
                       data=input_data, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'user_response')[0]
     user = json.loads(rv.data)
     assert user['userTerms']['termsOfUseAcceptedVersion'] == '1'
 
     # version 1 is old version ; so api should return terms of service accepted as false
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'user_response')[0]
     user = json.loads(rv.data)
     assert user['userTerms']['isTermsOfUseAccepted'] is False
 
@@ -312,6 +317,7 @@ def test_staff_get_user(client, jwt, session):  # pylint:disable=unused-argument
     rv = client.get('/api/v1/users/{}'.format(TestJwtClaims.public_user_role['preferred_username']),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'user_response')[0]
     user = json.loads(rv.data)
     assert user['firstname'] is not None
 
@@ -339,6 +345,7 @@ def test_staff_search_users(client, jwt, session):  # pylint:disable=unused-argu
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_manage_accounts_role)
     rv = client.get('/api/v1/users', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'users_response')[0]
     users = json.loads(rv.data)
     assert len(users) == 2
 
@@ -346,6 +353,7 @@ def test_staff_search_users(client, jwt, session):  # pylint:disable=unused-argu
     rv = client.get('/api/v1/users?lastname={}'.format(TestJwtClaims.no_role['lastname']),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'users_response')[0]
     users = json.loads(rv.data)
     assert len(users) == 1
 
@@ -358,6 +366,7 @@ def test_get_user(client, jwt, session):  # pylint:disable=unused-argument
     assert rv.status_code == http_status.HTTP_201_CREATED
     rv = client.get('/api/v1/users/@me', headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'user_response')[0]
     user = json.loads(rv.data)
     assert user['firstname'] is not None
 
@@ -385,6 +394,7 @@ def test_add_contact(client, jwt, session):  # pylint:disable=unused-argument
     rv = client.post('/api/v1/users/contacts', data=json.dumps(TestContactInfo.contact1),
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'contact_response')[0]
     contact = json.loads(rv.data)
     assert contact['email'] == 'foo@bar.com'
 
@@ -452,6 +462,7 @@ def test_update_contact(client, jwt, session):  # pylint:disable=unused-argument
     rv = client.put('/api/v1/users/contacts', data=json.dumps(TestContactInfo.contact2),
                     headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'contact_response')[0]
     contact = json.loads(rv.data)
     assert contact['email'] == 'bar@foo.com'
 
@@ -534,6 +545,7 @@ def test_get_orgs_for_user(client, jwt, session, keycloak_mock):  # pylint:disab
     rv = client.get('/api/v1/users/orgs', headers=headers)
 
     assert rv.status_code == http_status.HTTP_200_OK
+    assert schema_utils.validate(rv.json, 'orgs_response')[0]
 
     response = json.loads(rv.data)
     assert response['orgs']
@@ -781,6 +793,7 @@ def test_add_bceid_user(client, jwt, session):  # pylint:disable=unused-argument
         'lastName': 'Doe'
     }))
     assert rv.status_code == http_status.HTTP_201_CREATED
+    assert schema_utils.validate(rv.json, 'user_response')[0]
     assert rv.json.get('firstname') == 'John-New'
 
 
@@ -797,4 +810,5 @@ def test_user_post_during_login(client, jwt, session):  # pylint:disable=unused-
     # Call same endpoint with login flag and assert login time is different
     rv = client.post('/api/v1/users', headers=headers, data=json.dumps({'isLogin': True}),
                      content_type='application/json')
+    assert schema_utils.validate(rv.json, 'user_response')[0]
     assert login_time != rv.json.get('loginTime')

--- a/auth-api/tests/unit/api/test_user_settings.py
+++ b/auth-api/tests/unit/api/test_user_settings.py
@@ -49,4 +49,4 @@ def test_get_user_settings(client, jwt, session, keycloak_mock):  # pylint:disab
     account = next(obj for obj in item_list if obj['type'] == 'ACCOUNT')
     assert account['accountType'] == 'BASIC'
     assert rv.status_code == http_status.HTTP_200_OK
-    assert schema_utils.validate(rv.json, 'user_settings_response')
+    assert schema_utils.validate(rv.json, 'user_settings_response')[0]


### PR DESCRIPTION
Create schemas for all response, write unit tests to assert schema matches the response.

*Issue #:*
https://github.com/bcgov/entity/issues/4402

*Description of changes:*
- Response schema added.
- Removed "links" from "contact" responses.
- Removed "versions" from all responses.
- Assert response matches the schemas.

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [X ] No lint errors
- [X ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
