### PR TITLE
#5436 #5685 validate duplicate account names

### DIFF
--- a/auth-api/src/auth_api/models/org.py
+++ b/auth-api/src/auth_api/models/org.py
@@ -159,7 +159,7 @@ class Org(VersionedModel):  # pylint: disable=too-few-public-methods,too-many-in
     def find_similar_org_by_name(cls, name, org_id=None):
         """Find an Org instance that matches the provided name."""
         # TODO: add more fancy comparison
-        query = cls.query.filter(Org.name.ilike(f'%{name}%')).filter(Org.status_code != OrgStatusEnum.INACTIVE.value)
+        query = cls.query.filter(Org.name == name).filter(Org.status_code != OrgStatusEnum.INACTIVE.value)
         if org_id:
             query = query.filter(Org.id != org_id)
         return query.first()

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -91,8 +91,8 @@ class Org:  # pylint: disable=too-many-public-methods
 
         access_type = Org.validate_access_type(is_bceid_user, is_staff_admin, org_info)
 
-        duplicate_check = org_type == OrgType.BASIC.value
-        if duplicate_check:  # Allow duplicate names if premium
+        duplicate_check = (org_type == OrgType.BASIC.value) or (not bcol_credential)
+        if duplicate_check:  # Allow duplicate names if premium and link to bcol
             Org.raise_error_if_duplicate_name(org_info['name'])
 
         org = OrgModel.create_from_dict(camelback2snake(org_info))

--- a/auth-api/tests/unit/models/test_org.py
+++ b/auth-api/tests/unit/models/test_org.py
@@ -103,6 +103,32 @@ def test_org_find_by_name_inactive(session):  # pylint:disable=unused-argument
     assert len(found_org) == 0
 
 
+def test_find_similar_org_by_name(session):  # pylint:disable=unused-argument
+    """Assert that an Org can retrieved by its name."""
+    org = factory_org_model(name='My Test Org', session=session)
+    session.add(org)
+    session.commit()
+
+    found_org = OrgModel.find_similar_org_by_name(org.name)
+    assert found_org
+    assert found_org.name == org.name
+
+    found_org = OrgModel.find_similar_org_by_name('Test Or')
+    assert found_org is None
+
+
+def test_find_similar_org_by_name_inactive(session):  # pylint:disable=unused-argument
+    """Assert that an inactive Org can not be retrieved by its name."""
+    org = factory_org_model(name='My Test Org', session=session)
+    session.add(org)
+    session.commit()
+
+    org.delete()
+
+    found_org = OrgModel.find_similar_org_by_name(org.name)
+    assert found_org is None
+
+
 def test_update_org_from_dict(session):  # pylint:disable=unused-argument
     """Assert that an Org can be updated from a dictionary."""
     org = factory_org_model(name='My Test Org', session=session)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/5436
https://github.com/bcgov/entity/issues/5685

*Description of changes:*
- change duplicate name validation rule from similar to equal 
- duplicated names are not allowed for premium account without BCOL. 

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [X] No lint errors
- [X] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
