### PR TITLE
Fix for ui breaking due to navigation from account info page

### DIFF
--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -54,7 +54,7 @@
           </div>
         </template>
 
-        <div class="nv-list-item mb-10" v-can:VIEW_ADMIN_CONTACT.hide>
+        <div class="nv-list-item mb-10" v-if="isAdminContactViewable">
           <div class="name" id="adminContact">Account Contact</div>
           <div class="value" aria-labelledby="adminContact">
             <OrgAdminContact></OrgAdminContact>
@@ -331,6 +331,10 @@ export default class AccountInfo extends Mixins(AccountChangeMixin) {
 
   get isAddressViewable () : boolean {
     return [Permission.VIEW_ADDRESS].some(per => this.permissions.includes(per))
+  }
+
+  get isAdminContactViewable () : boolean {
+    return [Permission.VIEW_ADMIN_CONTACT].some(per => this.permissions.includes(per))
   }
 
   get isBaseAddressEditMode () : boolean {

--- a/auth-web/src/components/auth/account-settings/account-info/OrgAdminContact.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/OrgAdminContact.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="value__title">
-    <div  v-for="(member, index) in getActiveAdmins()" v-bind:key="index + 1">
+    <div v-for="(member, index) in getActiveAdmins" v-bind:key="index">
       <div v-if="!anonAccount">
         <div>
           {{ member.user.firstname }} {{ member.user.lastname }}
@@ -54,7 +54,7 @@ export default class OrgAdminContact extends Vue {
     this.syncActiveOrgMembers()
   }
 
-  private getActiveAdmins (): Member[] {
+  private get getActiveAdmins (): Member[] {
     return this.activeOrgMembers.filter(member => member.membershipTypeCode === MembershipType.Admin)
   }
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
- Fix for ui breaking due to navigation from account info page

*Checklist:*
I confirm that below checklist items are addressed in this pull request; (check the boxes applicable)
- [ ] No lint errors
- [ ] No test case failures and proper coverage for all modules/classes
- [ ] Updated the deployment configs for new environment variable(s)
- [ ] Updtaed the postman collection in entity repository (https://github.com/bcgov/entity/tree/master/api-e2e/postman) for e2e tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
