### PR TITLE
Fixed the bank info not showing for NSF accounts

### DIFF
--- a/auth-api/migrations/versions/e38ad1ce6d21_added_bank_permissions.py
+++ b/auth-api/migrations/versions/e38ad1ce6d21_added_bank_permissions.py
@@ -9,7 +9,6 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.sql import column, table
 
-
 # revision identifiers, used by Alembic.
 revision = 'e38ad1ce6d21'
 down_revision = '316ae45f54bc'
@@ -18,7 +17,6 @@ depends_on = None
 
 
 def upgrade():
-
     permissions_table = table('permissions',
                               column('id', sa.Integer()),
                               column('membership_type_code', sa.String(length=15)),
@@ -33,10 +31,14 @@ def upgrade():
              'actions': 'manage_bank_info'},
             {'id': 56, 'membership_type_code': 'ADMIN', 'org_status_code': None,
              'actions': 'view_bank_account_number'},
+            {'id': 57, 'membership_type_code': 'ADMIN', 'org_status_code': 'NSF_SUSPENDED',
+             'actions': 'manage_bank_info'},
+            {'id': 58, 'membership_type_code': 'ADMIN', 'org_status_code': 'NSF_SUSPENDED',
+             'actions': 'view_bank_account_number'},
         ]
     )
     # Update actions to lower case
 
-def downgrade():
-    op.execute('delete from permissions where id between 55 and 56')
 
+def downgrade():
+    op.execute('delete from permissions where id between 55 and 58')


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/5514

*Description of changes:*

Added the missing permission.
NSF account can view the bank information.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
