### PR TITLE
payment to continue instead of failing

### DIFF
--- a/auth-web/src/views/pay/PaymentView.vue
+++ b/auth-web/src/views/pay/PaymentView.vue
@@ -106,17 +106,21 @@ export default class PaymentView extends Vue {
       // user should be signed in and should have account as well
       if (this.isUserSignedIn && !!accountSettings) {
         // get the invoice and check for OB
-        const invoice: Invoice = await this.getInvoice(this.paymentId)
-        if (invoice?.paymentMethod === PaymentTypes.ONLINE_BANKING) {
-          // get account data to show in the UI
-          const paymentDetails: OrgPaymentDetails = await this.getOrgPayments(accountSettings?.id)
-          this.paymentCardData = {
-            totalBalanceDue: invoice?.total || 0,
-            payeeName: ConfigHelper.getPaymentPayeeName(),
-            cfsAccountId: paymentDetails?.cfsAccount?.cfsAccountNumber || ''
+        try {
+          const invoice: Invoice = await this.getInvoice(this.paymentId)
+          if (invoice?.paymentMethod === PaymentTypes.ONLINE_BANKING) {
+            // get account data to show in the UI
+            const paymentDetails: OrgPaymentDetails = await this.getOrgPayments(accountSettings?.id)
+            this.paymentCardData = {
+              totalBalanceDue: invoice?.total || 0,
+              payeeName: ConfigHelper.getPaymentPayeeName(),
+              cfsAccountId: paymentDetails?.cfsAccount?.cfsAccountNumber || ''
+            }
+            this.showLoading = false
+            this.showOnlineBanking = true
           }
-          this.showLoading = false
-          this.showOnlineBanking = true
+        }catch (error) {
+          console.error('error in accessing the invoice.Defaulting to CC flow')
         }
       }
 

--- a/auth-web/src/views/pay/PaymentView.vue
+++ b/auth-web/src/views/pay/PaymentView.vue
@@ -120,6 +120,7 @@ export default class PaymentView extends Vue {
             this.showOnlineBanking = true
           }
         }catch (error) {
+          // eslint-disable-next-line no-console
           console.error('error in accessing the invoice.Defaulting to CC flow')
         }
       }


### PR DESCRIPTION
*Description of changes:*

payment to continue instead of failing incase if invoice is not fetchable. To handle NRO users who are logged in auth and not logged in NRO

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
