### PR TITLE
added edit and view for nsf account for admins

### DIFF
--- a/auth-api/migrations/versions/b72d4946fb3c_added_view_edit_for_nsf_account.py
+++ b/auth-api/migrations/versions/b72d4946fb3c_added_view_edit_for_nsf_account.py
@@ -1,0 +1,44 @@
+"""added view edit for NSF account
+
+Revision ID: b72d4946fb3c
+Revises: f7362101e761
+Create Date: 2021-01-06 14:34:14.575613
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import column, table
+
+# revision identifiers, used by Alembic.
+revision = 'b72d4946fb3c'
+down_revision = 'f7362101e761'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    permissions_table = table('permissions',
+                              column('id', sa.Integer()),
+                              column('membership_type_code', sa.String(length=15)),
+                              column('org_status_code', sa.String(length=25)),
+                              column('actions', sa.String(length=100)))
+    conn = op.get_bind()
+    res = conn.execute(
+        f"select max(id) from permissions;")
+    latest_id = res.fetchall()[0][0]
+    op.bulk_insert(
+        permissions_table,
+        [
+            {'id': latest_id + 1, 'membership_type_code': 'ADMIN', 'org_status_code': 'NSF_SUSPENDED',
+             'actions': 'edit'},
+            {'id': latest_id + 2, 'membership_type_code': 'ADMIN', 'org_status_code': 'NSF_SUSPENDED',
+             'actions': 'view'}
+        ]
+    )
+
+
+def downgrade():
+    op.execute(
+        "delete from permissions where membership_type_code='ADMIN' "
+        "and org_status_code='NSF_SUSPENDED' and actions in ('view','edit')")
+


### PR DESCRIPTION
*Issue #:*

*Description of changes:*

view and edit was missing for admins for NSF account


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
