### PR TITLE
Bank validation fix in the UI

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -3210,12 +3210,18 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+        }
       }
     },
     "axios-mock-adapter": {
@@ -13525,6 +13531,17 @@
         "vuelidate": "^0.7.4",
         "vuetify": "^2.1.5",
         "vuex": "^3.1.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        }
       }
     },
     "schema-utils": {

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -16,7 +16,7 @@
     "@mdi/font": "^4.5.95",
     "@sentry/browser": "^5.27.2",
     "@sentry/integrations": "^5.27.2",
-    "axios": "^0.18.0",
+    "axios": "^0.21.1",
     "core-js": "^3.3.3",
     "keycloak-js": "^9.0.3",
     "mime-types": "^2.1.27",

--- a/auth-web/src/components/auth/account-freeze/ReviewBankInformation.vue
+++ b/auth-web/src/components/auth/account-freeze/ReviewBankInformation.vue
@@ -158,21 +158,24 @@ export default class ReviewBankInformation extends Mixins(Steppable) {
       // proceed to next step even if the response is empty
       return true
     }
+    // is validation service not reachable ,ignore and proceed
+    if (verifyPad?.statusCode !== 200) {
+      return true
+    }
     if (verifyPad?.isValid) {
       // proceed if PAD info is valid
       return true
-    } else {
-      this.isLoading = false
-      this.errorText = 'Bank information validation failed'
-      if (verifyPad?.message?.length) {
-        let msgList = ''
-        verifyPad.message.forEach((msg) => {
-          msgList += `<li>${msg}</li>`
-        })
-        this.errorText = `<ul class="error-list">${msgList}</ul>`
-      }
-      return false
     }
+    this.isLoading = false
+    this.errorText = 'Bank information validation failed'
+    if (verifyPad?.message?.length) {
+      let msgList = ''
+      verifyPad.message.forEach((msg) => {
+        msgList += `<li>${msg}</li>`
+      })
+      this.errorText = `<ul class="error-list">${msgList}</ul>`
+    }
+    return false
   }
 }
 </script>

--- a/auth-web/src/views/pay/PaymentView.vue
+++ b/auth-web/src/views/pay/PaymentView.vue
@@ -119,7 +119,7 @@ export default class PaymentView extends Vue {
             this.showLoading = false
             this.showOnlineBanking = true
           }
-        }catch (error) {
+        } catch (error) {
           // eslint-disable-next-line no-console
           console.error('error in accessing the invoice.Defaulting to CC flow')
         }

--- a/auth-web/tests/unit/components/AccountPaymentMethods.spec.ts
+++ b/auth-web/tests/unit/components/AccountPaymentMethods.spec.ts
@@ -28,7 +28,7 @@ describe('AccountPaymentMethods.vue', () => {
         currentMembership: []
       },
       actions: {
-        validatePADInfo:jest.fn(),
+        validatePADInfo: jest.fn(),
         getOrgPayments: jest.fn(),
         updateOrg: jest.fn()
       },
@@ -69,6 +69,5 @@ describe('AccountPaymentMethods.vue', () => {
 
   it('renders the components properly and address is being shown', () => {
     expect(wrapper.find(AccountPaymentMethods).exists()).toBe(true)
-
   })
 })


### PR DESCRIPTION
Fixing Bank validation shouldn't show error message if service is unable to validate cfs.

*Description of changes:*

- Axios version updated .Looks ok so far
- bank validation skip corrected.
- some lints fixed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
