### PR TITLE
[entity5722] Remove Reference to Developer API

### DIFF
--- a/auth-web/src/components/auth/create-account/AccountTypeSelector.vue
+++ b/auth-web/src/components/auth/create-account/AccountTypeSelector.vue
@@ -81,7 +81,6 @@ import { AccessType } from '@/util/constants'
               <li>Unlimited team members</li>
               <li>Pay by pre-authorized debit or <a href="https://www.bconline.gov.bc.ca/" target="_blank" rel="noopener noreferrer">BC Online deposit account</a></li>
               <li>Financial Statements</li>
-              <li>Developer API</li>
             </ul>
 
             <!-- State Button (Create Account) -->


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/entity5722

Removing the reference to the 'Developer API' for premium account types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
