### PR TITLE
fix for invitation flow breaking

### DIFF
--- a/auth-web/src/App.vue
+++ b/auth-web/src/App.vue
@@ -214,9 +214,6 @@ export default class App extends Mixins(NextPageMixin) {
         if (!isSigninComplete) {
           await KeyCloakService.initializeToken(this.$store)
         }
-        this.loadUserInfo()
-        await this.syncUser()
-        this.setupNavigationBar()
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log('Could not initialize token refresher: ' + e)
@@ -224,7 +221,11 @@ export default class App extends Mixins(NextPageMixin) {
         this.$store.dispatch('user/reset')
         this.$store.commit('loadComplete')
         this.$router.push('/home')
+        return
       }
+      this.loadUserInfo()
+      await this.syncUser()
+      this.setupNavigationBar()
     }
     this.$store.commit('loadComplete')
   }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6180

*Description of changes:*

It was a bit tricky to track this bug down. In case of pending account status , the call to the org is failing.I think that behaviour didn't change.But the code block is moved to an try catch and catch had a redirection.Because of that , the redirection kicks in and redirects the pending user from pending page to home page. 
I just moved the code out of the try catch ; the error happens ;logs in console;but no more redirection.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
