### PR TITLE
Fix for not showing address

### DIFF
--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -240,14 +240,17 @@ export default class AccountInfo extends Mixins(AccountChangeMixin) {
   private async setup () {
     const accountSettings = this.getAccountFromSession()
     this.orgName = this.currentOrganization?.name || ''
-    if (!this.anonAccount && this.enableMandatoryAddress) {
+    if (this.isPremiumAccount || this.enablePaymentMethodSelectorStep) {
       await this.syncAddress()
-      if (Object.keys(this.currentOrgAddress).length === 0) {
-        this.isCompleteAccountInfo = false
-        this.errorMessage = this.isAddressEditable ? 'Your account info is incomplete. Please enter your address in order to proceed.'
-          : 'This accounts profile is incomplete. You will not be able to proceed until an account administrator entered the missing information for this account.'
-        this.$refs.editAccountForm?.validate() // validate form fields and show error message
-        this.$refs.mailingAddress?.$refs.baseAddress?.$refs.addressForm?.validate() // validate form fields and show error message for address component from sbc-common-comp
+      // show this part only when enablePaymentMethodSelectorStep= true and account is not anon
+      if (!this.anonAccount && this.enableMandatoryAddress) {
+        if (Object.keys(this.currentOrgAddress).length === 0) {
+          this.isCompleteAccountInfo = false
+          this.errorMessage = this.isAddressEditable ? 'Your account info is incomplete. Please enter your address in order to proceed.'
+            : 'This accounts profile is incomplete. You will not be able to proceed until an account administrator entered the missing information for this account.'
+          this.$refs.editAccountForm?.validate() // validate form fields and show error message
+          this.$refs.mailingAddress?.$refs.baseAddress?.$refs.addressForm?.validate() // validate form fields and show error message for address component from sbc-common-comp
+        }
       }
     } else {
       // inorder to hide the address if not premium account


### PR DESCRIPTION
*Issue #:*
with the last fix , I introduced a bug. Without that flag , nobody was shown address. So fixed that.
The enable-mandatory-address is just used to show the error message , not to affect the address display

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
