### PR TITLE
5912 account name should be unique - API

### DIFF
--- a/auth-api/migrations/versions/dfd28e2b34a3_add_bcol_account_name_to_org.py
+++ b/auth-api/migrations/versions/dfd28e2b34a3_add_bcol_account_name_to_org.py
@@ -1,0 +1,30 @@
+"""add bcol_account_name to org
+
+Revision ID: dfd28e2b34a3
+Revises: 5f51253eeced
+Create Date: 2021-01-21 13:33:36.454377
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'dfd28e2b34a3'
+down_revision = '5f51253eeced'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add new column to save original BCOL account name for account linked to BCOL account
+    op.add_column('org', sa.Column('bcol_account_name', sa.String(length=250), nullable=True))
+    op.add_column('org_version', sa.Column('bcol_account_name', sa.String(length=250), autoincrement=False, nullable=True))
+
+    # Set BCOL account name to name for existing account who already linked to BCOL account
+    op.execute("UPDATE org SET bcol_account_name=name WHERE bcol_account_id is not null;")
+
+
+def downgrade():
+    op.drop_column('org', 'bcol_account_name')
+    op.drop_column('org_version', 'bcol_account_name')

--- a/auth-api/migrations/versions/dfd28e2b34a3_add_bcol_account_name_to_org.py
+++ b/auth-api/migrations/versions/dfd28e2b34a3_add_bcol_account_name_to_org.py
@@ -1,7 +1,7 @@
 """add bcol_account_name to org
 
 Revision ID: dfd28e2b34a3
-Revises: 5f51253eeced
+Revises: be4475027882
 Create Date: 2021-01-21 13:33:36.454377
 
 """
@@ -11,20 +11,20 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'dfd28e2b34a3'
-down_revision = '5f51253eeced'
+down_revision = 'be4475027882'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
     # Add new column to save original BCOL account name for account linked to BCOL account
-    op.add_column('org', sa.Column('bcol_account_name', sa.String(length=250), nullable=True))
-    op.add_column('org_version', sa.Column('bcol_account_name', sa.String(length=250), autoincrement=False, nullable=True))
+    op.add_column('orgs', sa.Column('bcol_account_name', sa.String(length=250), nullable=True))
+    op.add_column('orgs_version', sa.Column('bcol_account_name', sa.String(length=250), autoincrement=False, nullable=True))
 
     # Set BCOL account name to name for existing account who already linked to BCOL account
-    op.execute("UPDATE org SET bcol_account_name=name WHERE bcol_account_id is not null;")
+    op.execute("UPDATE orgs SET bcol_account_name=name WHERE bcol_account_id is not null;")
 
 
 def downgrade():
-    op.drop_column('org', 'bcol_account_name')
-    op.drop_column('org_version', 'bcol_account_name')
+    op.drop_column('orgs', 'bcol_account_name')
+    op.drop_column('orgs_version', 'bcol_account_name')

--- a/auth-api/src/auth_api/models/org.py
+++ b/auth-api/src/auth_api/models/org.py
@@ -87,8 +87,9 @@ class Org(VersionedModel):  # pylint: disable=too-few-public-methods,too-many-in
 
     @classmethod
     def find_by_bcol_id(cls, bcol_account_id):
-        """Find an Org instance that matches the provided id."""
-        return cls.query.filter_by(bcol_account_id=bcol_account_id).first()
+        """Find an Org instance that matches the provided id and not in INACTIVE status."""
+        return cls.query.filter(Org.bcol_account_id == bcol_account_id).filter(
+            Org.status_code != OrgStatusEnum.INACTIVE.value).first()
 
     @classmethod
     def find_by_org_name(cls, org_name):

--- a/auth-api/src/auth_api/models/org.py
+++ b/auth-api/src/auth_api/models/org.py
@@ -47,6 +47,7 @@ class Org(VersionedModel):  # pylint: disable=too-few-public-methods,too-many-in
     decision_made_on = Column(DateTime, nullable=True)
     bcol_user_id = Column(String(20))
     bcol_account_id = Column(String(20))
+    bcol_account_name = Column(String(250))
 
     contacts = relationship('ContactLink', lazy='select')
     org_type = relationship('OrgType')

--- a/auth-api/src/auth_api/schemas/schemas/org_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/org_response.json
@@ -10,6 +10,7 @@
             "contacts": [],
             "accessType": "REGULAR",
             "bcolAccountId": "106700",
+            "bcolAccountName": "BC ONLINE TECHNICAL TEAM DEVL",
             "bcolUserId": "PB99999",
             "billable": true,
             "created": "2020-11-12T21:42:30.850904+00:00",
@@ -72,6 +73,15 @@
             "default": "",
             "examples": [
                 "106700"
+            ]
+        },
+        "bcolAccountName": {
+            "$id": "#/properties/bcolAccountName",
+            "type": "string",
+            "title": "BC Oline Account Name",
+            "default": "",
+            "examples": [
+                "BC ONLINE TECHNICAL TEAM DEVL"
             ]
         },
         "bcolUserId": {

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -352,7 +352,7 @@ class Org:  # pylint: disable=too-many-public-methods
 
         has_org_updates: bool = False  # update the org table if this variable is set true
 
-        is_name_getting_updated = 'name' in org_info and self._model.type_code == OrgType.BASIC.value
+        is_name_getting_updated = 'name' in org_info
         if is_name_getting_updated:
             existing_similar__org = OrgModel.find_similar_org_by_name(org_info['name'], self._model.id)
             if existing_similar__org is not None:

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -81,7 +81,7 @@ class Org:  # pylint: disable=too-many-public-methods
 
         # If the account is created using BCOL credential, verify its valid bc online account
         if bcol_credential:
-            bcol_response = Org.get_bcol_details(bcol_credential, org_info, bearer_token).json()
+            bcol_response = Org.get_bcol_details(bcol_credential, bearer_token).json()
             Org._map_response_to_org(bcol_response, org_info)
 
         is_staff_admin = token_info and Role.STAFF_CREATE_ACCOUNTS.value in token_info.get('realm_access').get('roles')
@@ -253,7 +253,7 @@ class Org:  # pylint: disable=too-many-public-methods
             'DIRECT_PAY_ENABLED') else PaymentMethod.CREDIT_CARD.value
 
     @staticmethod
-    def get_bcol_details(bcol_credential: Dict, org_info: Dict = None, bearer_token: str = None, org_id=None):
+    def get_bcol_details(bcol_credential: Dict, bearer_token: str = None, org_id=None):
         """Retrieve and validate BC Online credentials."""
         bcol_response = None
         if bcol_credential:
@@ -309,7 +309,7 @@ class Org:  # pylint: disable=too-many-public-methods
         if action == ChangeType.UPGRADE.value:
             if org_info.get('typeCode') != OrgType.PREMIUM.value or bcol_credential is None:
                 raise BusinessException(Error.INVALID_INPUT, None)
-            bcol_response = Org.get_bcol_details(bcol_credential, org_info, bearer_token, self._model.id).json()
+            bcol_response = Org.get_bcol_details(bcol_credential, bearer_token, self._model.id).json()
             Org._map_response_to_org(bcol_response, org_info)
             payment_type = PaymentMethod.BCOL.value
 
@@ -362,7 +362,7 @@ class Org:  # pylint: disable=too-many-public-methods
         # If the account is created using BCOL credential, verify its valid bc online account
         # If it's a valid account disable the current one and add a new one
         if bcol_credential := org_info.pop('bcOnlineCredential', None):
-            bcol_response = Org.get_bcol_details(bcol_credential, org_info, bearer_token, self._model.id).json()
+            bcol_response = Org.get_bcol_details(bcol_credential, bearer_token, self._model.id).json()
             Org._map_response_to_org(bcol_response, org_info)
             has_org_updates = True
 

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -1241,13 +1241,13 @@ def test_add_bcol_linked_org_failure_mailing_address(client, jwt, session,
     assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
 
 
-def test_add_bcol_linked_org_invalid_name(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
+def test_add_bcol_linked_org_different_name(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that an org can be POSTed."""
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
     rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
-    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.bcol_linked_invalid_name()),
+    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.bcol_linked_different_name()),
                      headers=headers, content_type='application/json')
-    assert rv.status_code == http_status.HTTP_400_BAD_REQUEST
+    assert rv.status_code == http_status.HTTP_201_CREATED
 
 
 def test_new_business_affiliation(client, jwt, session, keycloak_mock, nr_mock):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -654,7 +654,7 @@ def test_create_org_with_different_name_than_bcol_account(session, keycloak_mock
     org = OrgService.create_org(TestOrgInfo.bcol_linked_different_name(), user_id=user.id)
     assert org
     dictionary = org.as_dict()
-    
+
     assert dictionary['name'] == TestOrgInfo.bcol_linked_different_name()['name']
     assert dictionary['orgType'] == OrgType.PREMIUM.value
     assert dictionary['bcol_user_id'] is not None

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -654,7 +654,7 @@ def test_create_org_with_different_name_than_bcol_account(session, keycloak_mock
     org = OrgService.create_org(TestOrgInfo.bcol_linked_different_name(), user_id=user.id)
     assert org
     dictionary = org.as_dict()
-    print(dictionary)
+    
     assert dictionary['name'] == TestOrgInfo.bcol_linked_different_name()['name']
     assert dictionary['orgType'] == OrgType.PREMIUM.value
     assert dictionary['bcol_user_id'] is not None

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -494,8 +494,8 @@ class TestOrgInfo(dict, Enum):
         }
 
     @staticmethod
-    def bcol_linked_invalid_name():
-        """Return org info for bcol linked info with invalid name."""
+    def bcol_linked_different_name():
+        """Return org info for bcol linked info with different org name than bcol account name."""
         return {
             'name': 'Test',
             'bcOnlineCredential': {
@@ -508,7 +508,8 @@ class TestOrgInfo(dict, Enum):
                 'region': 'BC',
                 'postalCode': 'T1T1T1',
                 'country': 'CA'
-            }
+            },
+            'typeCode': OrgType.PREMIUM.value
         }
 
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/5912

*Description of changes:*
Add new column bcol_account_name to save original linked BCOL account name.
Remove checking BCOL account name and org name matching checking.
Check if name is duplicate when create and update org for all org types.
Inactive account excluded when find by bcol_account_id, so bcol account could be reuse for new org, because delete org doesn't remove bcol account info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
