### PR TITLE
duplicate name check added for bcol

### DIFF
--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -47,7 +47,7 @@
             <div class="name mt-3" id="accountName">Linked BC Online Account Details</div>
             <div class="value">
               <LinkedBCOLBanner
-                :bcolAccountName="currentOrganization.name"
+                :bcolAccountName="currentOrganization.bcolAccountName"
                 :bcolAccountDetails="currentOrganization.bcolAccountDetails"
               ></LinkedBCOLBanner>
             </div>

--- a/auth-web/src/components/auth/common/PaymentMethods.vue
+++ b/auth-web/src/components/auth/common/PaymentMethods.vue
@@ -56,7 +56,7 @@
                 <div class="pt-7" v-else-if="(payment.type === paymentTypes.BCOL)">
                   <!-- showing BCOL details banner -->
                   <LinkedBCOLBanner
-                    :bcolAccountName="currentOrganization.name"
+                    :bcolAccountName="currentOrganization.bcolAccountName || currentOrganization.name"
                     :bcolAccountDetails="currentOrganization.bcolAccountDetails"
                   ></LinkedBCOLBanner>
                 </div>

--- a/auth-web/src/components/auth/common/PaymentMethods.vue
+++ b/auth-web/src/components/auth/common/PaymentMethods.vue
@@ -56,7 +56,7 @@
                 <div class="pt-7" v-else-if="(payment.type === paymentTypes.BCOL)">
                   <!-- showing BCOL details banner -->
                   <LinkedBCOLBanner
-                    :bcolAccountName="currentOrganization.bcolAccountName || currentOrganization.name"
+                    :bcolAccountName="currentOrganization.bcolAccountName"
                     :bcolAccountDetails="currentOrganization.bcolAccountDetails"
                   ></LinkedBCOLBanner>
                 </div>

--- a/auth-web/src/components/auth/create-account/AccountCreatePremium.vue
+++ b/auth-web/src/components/auth/create-account/AccountCreatePremium.vue
@@ -73,7 +73,7 @@
           Back
         </v-btn>
         <v-spacer></v-spacer>
-        <v-btn class="mr-3" large depressed color="primary" :loading="saving" :disabled="!grantAccess || saving || !isBaseAddressValid" @click="save">
+        <v-btn class="mr-3" large depressed color="primary" :loading="saving" :disabled="!grantAccess || saving || !isBaseAddressValid || !isFormValid()" @click="save">
           <span v-if="!isAccountChange">Next
             <v-icon right class="ml-1">mdi-arrow-right</v-icon>
           </span>
@@ -189,7 +189,7 @@ export default class AccountCreatePremium extends Mixins(Steppable) {
   private readonly teamNameRules = [v => !!v || 'An account name is required']
 
   private isFormValid (): boolean {
-    return !!this.username && !!this.password && !!this.orgName && !!this.errorMessage
+    return !!this.orgName && !this.errorMessage
   }
 
   private async mounted () {

--- a/auth-web/src/components/auth/create-account/AccountCreatePremium.vue
+++ b/auth-web/src/components/auth/create-account/AccountCreatePremium.vue
@@ -13,7 +13,7 @@
         The following information will be imported from your existing BC Online account. Review your account <br> information below and update if needed.
       </p>
       <LinkedBCOLBanner class="mb-9"
-        :bcolAccountName="currentOrganization.bcolAccountDetails.orgName"
+        :bcolAccountName="currentOrganization.bcolAccountName"
         :bcolAccountDetails="currentOrganization.bcolAccountDetails"
         :showUnlinkAccountBtn="true"
         @unlink-account="unlinkAccount"

--- a/auth-web/src/components/auth/create-account/AccountCreatePremium.vue
+++ b/auth-web/src/components/auth/create-account/AccountCreatePremium.vue
@@ -285,7 +285,6 @@ export default class AccountCreatePremium extends Mixins(Steppable) {
                     'An error occurred while attempting to create your account.'
       }
     } else {
-      // TODO make sure name is valid
       const isValidName = await this.validateAccountNameUnique()
       if (isValidName) {
         this.stepForward()

--- a/auth-web/src/models/Organization.ts
+++ b/auth-web/src/models/Organization.ts
@@ -35,6 +35,7 @@ export interface Organization {
   accessType?: string;
   bcolProfile?:BcolProfile
   bcolAccountDetails?:BcolAccountDetails
+  bcolAccountName?: string,
   grantAccess?:boolean
   statusCode?:string
   decisionMadeBy?: string,

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -205,6 +205,11 @@ export default class OrgModule extends VuexModule {
   }
 
   @Mutation
+  public setCurrentOrganizationName (name: string) {
+    this.currentOrganization.name = name
+  }
+
+  @Mutation
   public setCurrentOrganizationPaymentType (paymentType: string) {
     this.currentOrgPaymentType = paymentType
   }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/5912

*Description of changes:*

1) change for handling duplicate name check for bcol accounts
2) bcol banner changes everywhere to show bcol account name


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
