### PR TITLE
[entity4658] Front-end Clean-up

### DIFF
--- a/auth-web/src/components/auth/common/AccountSuspendAlert.vue
+++ b/auth-web/src/components/auth/common/AccountSuspendAlert.vue
@@ -1,23 +1,19 @@
 <template>
-<v-card flat class="" color="error">
-  <v-alert :icon="false" prominent type="error" class="mb-0">
-    <v-row>
-      <v-col cols="9">
-        <div class="banner-info">
-          <v-icon color="link" left x-large>mdi-information-outline</v-icon>
-          <div class="ml-4">
-            <div class="font-weight-bold">Account Suspended</div>
-            <div>Account has been suspended for outstanding balance (NSF).</div>
-          </div>
+  <v-alert class="px-8 py-7" :icon="false" prominent type="error">
+    <div class="account-alert">
+      <div class="account-alert-inner">
+        <v-icon large class="mt-2">mdi-information-outline</v-icon>
+        <div class="account-alert__info ml-7">
+          <div class="font-weight-bold">Account Suspended</div>
+          <div>Account has been suspended for outstanding balance (NSF).</div>
+          <div class="mt-6 title font-weight-bold">BALANCE DUE:  ${{totalAmountToPay.toFixed(2)}}</div>
         </div>
-      </v-col>
-      <v-col class="text-end">{{suspendedDate}}</v-col>
-    </v-row>
-    <v-row>
-      <v-col cols="9" class="font-weight-bold balance">BALANCE DUE:  ${{totalAmountToPay.toFixed(2)}}</v-col>
-    </v-row>
+        <div class="account-alert__date">
+          {{suspendedDate}}
+        </div>
+      </div>
+    </div>
   </v-alert>
-</v-card>
 </template>
 
 <script lang="ts">
@@ -52,17 +48,18 @@ export default class AccountSuspendAlert extends Vue {
 </script>
 
 <style lang="scss" scoped>
-.banner{
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
+  .account-alert-inner {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+  }
 
-}
- .banner-info{
-    display: flex
+  .account-alert__info {
+    flex: 1 1 auto;
   }
-.balance{
-    margin-left: 63px;
-    font-size: 1.25rem;
+
+  .account-alert__date {
+    flex: 0 0 auto;
   }
+
 </style>

--- a/auth-web/src/components/auth/staff/account-management/StaffSuspendedAccountsTable.vue
+++ b/auth-web/src/components/auth/staff/account-management/StaffSuspendedAccountsTable.vue
@@ -18,18 +18,7 @@
         Loading...
       </template>
       <template v-slot:[`item.statusCode`]="{ item }">
-          <div class="value" aria-labelledby="accountStatus">
-              <div class="value__title">
-                <v-chip
-                  small
-                  label
-                  class="font-weight-bold account-list__status"
-                  color="error"
-                >
-                  {{ getStatusText(item.statusCode) }}
-                </v-chip>
-              </div>
-            </div>
+          {{ getStatusText(item.statusCode) }}
       </template>
       <template v-slot:[`item.suspendedOn`]="{ item }">
           {{formatDate(item.suspendedOn)}}
@@ -83,18 +72,6 @@ export default class StaffActiveAccountsTable extends Mixins(PaginationMixin) {
 
   private readonly headerAccounts = [
     {
-      text: 'Date Suspended',
-      align: 'left',
-      sortable: true,
-      value: 'suspendedOn'
-    },
-    {
-      text: 'Reason',
-      align: 'left',
-      sortable: true,
-      value: 'statusCode'
-    },
-    {
       text: 'Name',
       align: 'left',
       sortable: true,
@@ -111,6 +88,18 @@ export default class StaffActiveAccountsTable extends Mixins(PaginationMixin) {
       align: 'left',
       sortable: true,
       value: 'decisionMadeBy'
+    },
+    {
+      text: 'Date Suspended',
+      align: 'left',
+      sortable: true,
+      value: 'suspendedOn'
+    },
+    {
+      text: 'Reason',
+      align: 'left',
+      sortable: true,
+      value: 'statusCode'
     },
     {
       text: 'Actions',

--- a/auth-web/src/views/auth/AccountSettings.vue
+++ b/auth-web/src/views/auth/AccountSettings.vue
@@ -60,7 +60,7 @@
       <p class="mt-3 mb-0" v-else>Manage account information, team members, and authentication settings.</p>
     </div>
     <!-- Suspend Account Banner-->
-    <AccountSuspendAlert  v-if="showAccountFreezeBanner"/>
+    <AccountSuspendAlert class="account-alert mb-0" v-if="showAccountFreezeBanner"/>
 
     <v-card flat class="account-settings-card" data-test="account-settings-card">
       <v-container class="nav-container py-6 pr-0 pl-8">
@@ -353,5 +353,15 @@ export default class AccountSettings extends Mixins(AccountMixin) {
 
   .crumbs-visible {
     padding-top: 0 !important;
+  }
+
+  .account-alert.v-alert {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .account-alert + .v-card {
+    border-top-right-radius: 0;
+    border-top-left-radius: 0;
   }
 </style>


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/entity4658

Cleaning up front-end. Removing redundant error chips in the suspended tab (no state differentiation between items in this list outside of the actual messaging).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
