### PR TITLE
#4909-Provide administrators the ability to remove other admins.

### DIFF
--- a/auth-api/src/auth_api/services/invitation.py
+++ b/auth-api/src/auth_api/services/invitation.py
@@ -283,11 +283,20 @@ class Invitation:
         admin_list = UserService.get_admins_for_membership(membership_id)
         invitation: InvitationModel = InvitationModel.find_invitation_by_id(invitation_id)
         context_path = CONFIG.AUTH_WEB_TOKEN_CONFIRM_PATH
-        admin_emails = ','.join([str(x.contacts[0].contact.email) for x in admin_list if x.contacts])
-        Invitation.send_admin_notification(user.as_dict(),
-                                           '{}/{}'.format(invitation_origin, context_path),
-                                           admin_emails, invitation.membership[0].org.name)
-        current_app.logger.debug('>notify_admin')
+
+        # Don't send email in case no admin exist in the org. (staff sent invitation)
+        if len(admin_list) >= 1:
+            admin_emails = ','.join([str(x.contacts[0].contact.email) for x in admin_list if x.contacts])
+        else:
+            # No admin, find Sender email to notify sender (staff)
+            admin_emails = invitation.sender.email
+
+        if admin_emails != '':
+            Invitation.send_admin_notification(user.as_dict(),
+                                               '{}/{}'.format(invitation_origin, context_path),
+                                               admin_emails, invitation.membership[0].org.name)
+            current_app.logger.debug('>notify_admin')
+
         return Invitation(invitation)
 
     @staticmethod

--- a/auth-web/src/components/auth/account-settings/team-management/MemberDataTable.vue
+++ b/auth-web/src/components/auth/account-settings/team-management/MemberDataTable.vue
@@ -370,8 +370,7 @@ export default class MemberDataTable extends Vue {
       case MembershipType.Admin:
         // Owners can change roles of other users who are not owners
         if (
-          !this.isOwnMembership(memberBeingChanged) &&
-          memberBeingChanged.membershipTypeCode !== MembershipType.Admin
+          !this.isOwnMembership(memberBeingChanged) 
         ) {
           return true
         }
@@ -410,9 +409,13 @@ export default class MemberDataTable extends Vue {
       return false
     }
 
-    // No one can change an OWNER's status, only option is OWNER to leave the team. #2319
+    // Admin can be removed by other admin. #4909
     if (memberToRemove.membershipTypeCode === MembershipType.Admin) {
-      return false
+      if (this.currentMembership.membershipTypeCode === MembershipType.Admin){
+        return true
+      } else {
+        return false
+      }
     }
 
     return true


### PR DESCRIPTION
*Issue #: 4909
https://github.com/bcgov/entity/issues/4909

*Description of changes:*
Enable admin and staff remove other admins by set them inactive or downgrade.
Send notification to the staff who sent invitation if no active admin in the org, so staff can approve the new member.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
