### PR TITLE
Added suspend/activate accounts

### DIFF
--- a/auth-api/migrations/versions/8260fac9943d_suspended_status.py
+++ b/auth-api/migrations/versions/8260fac9943d_suspended_status.py
@@ -1,0 +1,39 @@
+"""suspended status 
+
+Revision ID: 8260fac9943d
+Revises: b23a04d2e331
+Create Date: 2021-02-08 10:41:23.530382
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import column, table
+from sqlalchemy import Boolean, String
+
+
+# revision identifiers, used by Alembic.
+revision = '8260fac9943d'
+down_revision = 'b23a04d2e331'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Insert codes and descriptions for organization status
+    org_status_table = table('org_statuses',
+                             column('code', String),
+                             column('desc', String),
+                             column('default', Boolean)
+                             )
+    op.bulk_insert(
+        org_status_table,
+        [
+            {'code': 'SUSPENDED', 'description': 'Status for an org which is suspended.',
+             'default': False}
+        ]
+    )
+
+
+def downgrade():
+    op.execute('delete from org_statuses where code=\'SUSPENDED\'')
+

--- a/auth-api/migrations/versions/8260fac9943d_suspended_status.py
+++ b/auth-api/migrations/versions/8260fac9943d_suspended_status.py
@@ -22,7 +22,7 @@ def upgrade():
     # Insert codes and descriptions for organization status
     org_status_table = table('org_statuses',
                              column('code', String),
-                             column('desc', String),
+                             column('description', String),
                              column('default', Boolean)
                              )
     op.bulk_insert(

--- a/auth-api/requirements.txt
+++ b/auth-api/requirements.txt
@@ -1,19 +1,19 @@
 Flask-Caching==1.9.0
 Flask-Mail==0.9.1
-Flask-Migrate==2.5.3
+Flask-Migrate==2.6.0
 Flask-Moment==0.11.0
 Flask-SQLAlchemy==2.4.4
 Flask-Script==2.0.6
 Flask==1.1.2
-Jinja2==2.11.2
-Mako==1.1.3
+Jinja2==2.11.3
+Mako==1.1.4
 MarkupSafe==1.1.1
 SQLAlchemy-Continuum==1.3.11
 SQLAlchemy-Utils==0.36.8
-SQLAlchemy==1.3.22
+SQLAlchemy==1.3.23
 Werkzeug==0.16.1
-alembic==1.4.3
-aniso8601==8.1.0
+alembic==1.5.4
+aniso8601==8.1.1
 asyncio-nats-client==0.11.4
 asyncio-nats-streaming==0.4.0
 attrs==20.3.0
@@ -47,7 +47,7 @@ python-dateutil==2.8.1
 python-dotenv==0.15.0
 python-editor==1.0.4
 python-jose==3.2.0
-pytz==2020.5
+pytz==2021.1
 requests==2.25.1
 rsa==4.7
 sentry-sdk==0.19.5
@@ -55,5 +55,5 @@ six==1.15.0
 threadloop==1.0.2
 thrift==0.13.0
 tornado==6.1
-urllib3==1.26.2
+urllib3==1.26.3
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -680,6 +680,31 @@ class Org:  # pylint: disable=too-many-public-methods
         return False
 
     @staticmethod
+    def change_org_status(org_id: int, status_code, token_info: Dict = None):
+        """Update the status of the org.
+
+        Used now for suspending/activate account.
+
+            1) check access .only staff can do it now
+            2) check org status/eligiblity
+            3) suspend it
+
+        """
+        current_app.logger.debug('<change_org_status ')
+
+        org_model: OrgModel = OrgModel.find_by_org_id(org_id)
+
+        user: UserModel = UserModel.find_by_jwt_token(token=token_info)
+        current_app.logger.debug('<setting org status to  ')
+        org_model.status_code = status_code
+        org_model.decision_made_by = user.id  # not sure if a new field is needed for this.
+        if status_code == ChangeType.SUSPEND.value:
+            org_model.suspended_on = datetime.today()
+        org_model.save()
+        current_app.logger.debug('change_org_status>')
+        return Org(org_model)
+
+    @staticmethod
     def approve_or_reject(org_id: int, is_approved: bool, token_info: Dict, origin_url: str = None):
         """Mark the affidavit as approved or rejected."""
         current_app.logger.debug('<find_affidavit_by_org_id ')

--- a/auth-api/src/auth_api/services/permissions.py
+++ b/auth-api/src/auth_api/services/permissions.py
@@ -55,7 +55,8 @@ class Permissions:  # pylint: disable=too-few-public-methods
         """Get the permissions for the membership type."""
         # Just a tweak til we get all org status to DB
         # TODO fix this logic
-        if org_status not in (OrgStatus.NSF_SUSPENDED.value, OrgStatus.PENDING_AFFIDAVIT_REVIEW.value):
+        if org_status not in (
+                OrgStatus.NSF_SUSPENDED.value, OrgStatus.PENDING_AFFIDAVIT_REVIEW.value, OrgStatus.SUSPENDED.value):
             org_status = None
         key_tuple = (org_status, membership_type)
         actions_from_cache = cache.get(key_tuple)

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -93,6 +93,8 @@ class ChangeType(Enum):
 
     UPGRADE = 'UPGRADE'
     DOWNGRADE = 'DOWNGRADE'
+    SUSPEND = 'SUSPEND'
+    UNSUSPEND = 'UNSUSPEND'
 
 
 class DocumentType(Enum):
@@ -160,6 +162,7 @@ class OrgStatus(Enum):
     REJECTED = 'REJECTED'
     PENDING_ACTIVATION = 'PENDING_ACTIVATION'
     NSF_SUSPENDED = 'NSF_SUSPENDED'
+    SUSPENDED = 'SUSPENDED'  # this is basically staff suspended for now
 
 
 class InvitationType(Enum):

--- a/auth-api/src/auth_api/utils/roles.py
+++ b/auth-api/src/auth_api/utils/roles.py
@@ -34,6 +34,7 @@ class Role(Enum):
     STAFF_SEARCH = 'search'
     STAFF_CREATE_ACCOUNTS = 'create_accounts'
     STAFF_MANAGE_BUSINESS = 'manage_business'
+    STAFF_SUSPEND_ACCOUNTS = 'suspend_accounts'
 
 
 # Membership types
@@ -42,9 +43,9 @@ COORDINATOR = 'COORDINATOR'
 ADMIN = 'ADMIN'
 USER = 'USER'
 
-
 VALID_STATUSES = (Status.ACTIVE.value, Status.PENDING_APPROVAL.value)
-VALID_ORG_STATUSES = (OrgStatus.ACTIVE.value, OrgStatus.PENDING_AFFIDAVIT_REVIEW.value, OrgStatus.NSF_SUSPENDED.value)
+VALID_ORG_STATUSES = (OrgStatus.ACTIVE.value, OrgStatus.PENDING_AFFIDAVIT_REVIEW.value, OrgStatus.NSF_SUSPENDED.value,
+                      OrgStatus.SUSPENDED.value)
 
 CLIENT_ADMIN_ROLES = (COORDINATOR, ADMIN)
 CLIENT_AUTH_ROLES = (*CLIENT_ADMIN_ROLES, USER)

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -274,6 +274,19 @@ def test_update_org(session):  # pylint:disable=unused-argument
     assert dictionary['name'] == TestOrgInfo.org2['name']
 
 
+def test_suspend_org(session):  # pylint:disable=unused-argument
+    """Assert that an Org can be updated."""
+    org = factory_org_service()
+    user = factory_user_model_with_contact()
+    token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.BCEID.value)
+
+    updated_org = OrgService.change_org_status(org._model.id, OrgStatus.SUSPENDED.value, token_info=token_info)
+    assert updated_org.as_dict()['status_code'] == OrgStatus.SUSPENDED.value
+
+    updated_org = OrgService.change_org_status(org._model.id, OrgStatus.ACTIVE.value, token_info=token_info)
+    assert updated_org.as_dict()['status_code'] == OrgStatus.ACTIVE.value
+
+
 def test_update_duplicate_org(session):  # pylint:disable=unused-argument
     """Assert that an Org cannot be updated."""
     org = factory_org_service()

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -290,7 +290,8 @@ def test_suspend_org(session):  # pylint:disable=unused-argument
 def test_update_duplicate_org(session):  # pylint:disable=unused-argument
     """Assert that an Org cannot be updated."""
     org = factory_org_service()
-
+    8260
+    fac9943d_suspended_status.py
     factory_org_model(org_info=TestOrgInfo.org2, org_type_info=TestOrgTypeInfo.implicit, org_status_info=None,
                       payment_type_info=None)
 

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -290,8 +290,7 @@ def test_suspend_org(session):  # pylint:disable=unused-argument
 def test_update_duplicate_org(session):  # pylint:disable=unused-argument
     """Assert that an Org cannot be updated."""
     org = factory_org_service()
-    8260
-    fac9943d_suspended_status.py
+
     factory_org_model(org_info=TestOrgInfo.org2, org_type_info=TestOrgTypeInfo.implicit, org_status_info=None,
                       payment_type_info=None)
 

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -231,7 +231,8 @@ class TestJwtClaims(dict, Enum):
             'roles': [
                 'staff',
                 'manage_accounts',
-                'view_accounts'
+                'view_accounts',
+                'suspend_accounts'
             ]
         },
         'roles': [


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6121

*Description of changes:*

Added suspend/activate account patch end point. 
New role will be added in keycloak.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
