### PR TITLE
Implementing suspend account server call from org service

### DIFF
--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -178,6 +178,7 @@
           class="font-weight-bold white--text"
           :color="getDialogStatusButtonColor(currentOrganization.orgStatus)"
           data-test='btn-suspend-dialog'
+          @click="confirmSuspendAccount()"
         >
           {{ isAccountStatusActive ? 'Suspend' : 'Unsuspend' }}
         </v-btn>
@@ -232,7 +233,7 @@ import { getModule } from 'vuex-module-decorators'
     ])
   },
   methods: {
-    ...mapActions('org', ['updateOrg', 'syncAddress', 'syncOrganization']),
+    ...mapActions('org', ['updateOrg', 'syncAddress', 'syncOrganization', 'suspendOrganization']),
     ...mapMutations('org', ['setCurrentOrganizationAddress'])
   }
 })
@@ -252,6 +253,7 @@ export default class AccountInfo extends Mixins(AccountChangeMixin) {
   ) => Promise<Organization>
   private readonly syncAddress!: () => Address
   protected readonly syncOrganization!: (currentAccount: number) => Promise<Organization>
+  protected readonly suspendOrganization!: () => Promise<Organization>
   private orgName = ''
   private errorMessage: string = ''
   private readonly setCurrentOrganizationAddress!: (address: Address) => void
@@ -274,7 +276,7 @@ export default class AccountInfo extends Mixins(AccountChangeMixin) {
     return this.currentUser.roles.includes(Role.Staff)
   }
 
-  private isSuspendButtonVisible (): boolean {
+  private get isSuspendButtonVisible (): boolean {
     return this.currentOrganization.statusCode === AccountStatus.ACTIVE || this.currentOrganization.statusCode === AccountStatus.SUSPENDED
   }
 
@@ -323,6 +325,11 @@ export default class AccountInfo extends Mixins(AccountChangeMixin) {
       this.dialogText = 'Are you sure you want to unsuspend access to this account?'
     }
     this.$refs.suspendAccountDialog.open()
+  }
+
+  private async confirmSuspendAccount (): Promise<void> {
+    await this.suspendOrganization()
+    this.$router.push(Pages.STAFF_DASHBOARD)
   }
 
   private closeSuspendAccountDialog () {
@@ -506,6 +513,8 @@ export default class AccountInfo extends Mixins(AccountChangeMixin) {
   private getStatusText (status) {
     switch (status) {
       case AccountStatus.NSF_SUSPENDED:
+        return 'NSF SUSPENDED'
+      case AccountStatus.SUSPENDED:
         return 'SUSPENDED'
       default:
         return status

--- a/auth-web/src/services/org.services.ts
+++ b/auth-web/src/services/org.services.ts
@@ -1,6 +1,6 @@
+import { AccountStatus, Actions } from '@/util/constants'
 import { Affiliation, CreateRequestBody as CreateAffiliationRequestBody, CreateNRAffiliationRequestBody } from '@/models/affiliation'
 import { CreateRequestBody as CreateOrganizationRequestBody, Member, Members, Organization, UpdateMemberPayload } from '@/models/Organization'
-import { Actions } from '@/util/constants'
 import { Address } from '@/models/address'
 import { AffidavitInformation } from '@/models/affidavit'
 import { AxiosResponse } from 'axios'
@@ -83,6 +83,10 @@ export default class OrgService {
 
   static async rejectPendingOrg (orgIdentifier: number): Promise<AxiosResponse> {
     return axios.patch(`${ConfigHelper.getValue('VUE_APP_AUTH_ROOT_API')}/orgs/${orgIdentifier}/status`, { statusCode: 'REJECTED' })
+  }
+
+  static async suspendOrg (orgIdentifier: number, statusCode: AccountStatus): Promise<AxiosResponse> {
+    return axios.patch(`${ConfigHelper.getValue('VUE_APP_AUTH_ROOT_API')}/orgs/${orgIdentifier}/status`, { statusCode: statusCode })
   }
 
   public static async getMemberLoginOption (orgId: number): Promise<string> {

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -245,8 +245,15 @@ export default class OrgModule extends VuexModule {
     const orgId = this.context.state['currentOrganization']?.id
     const orgStatus = this.context.state['currentOrganization'].statusCode === AccountStatus.ACTIVE ? AccountStatus.SUSPENDED : AccountStatus.ACTIVE
     if (orgId && orgStatus) {
-      await OrgService.suspendOrg(orgId, orgStatus)
-      await this.context.dispatch('syncOrganization', orgId)
+      try {
+        const response = await OrgService.suspendOrg(orgId, orgStatus)
+        if (response.status === 200) {
+          await this.context.dispatch('syncOrganization', orgId)
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Suspend/Unsuspend Account operation failed! - ', error)
+      }
     }
   }
 

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -1,4 +1,4 @@
-import { Account, Actions, LoginSource, Pages, PaymentTypes, Role, SessionStorageKeys } from '@/util/constants'
+import { Account, AccountStatus, Actions, LoginSource, Pages, PaymentTypes, Role, SessionStorageKeys } from '@/util/constants'
 import { Action, Module, Mutation, VuexModule } from 'vuex-module-decorators'
 import {
   AddUserBody,
@@ -238,6 +238,16 @@ export default class OrgModule extends VuexModule {
     const organization = response?.data
     this.context.commit('setCurrentOrganization', organization)
     return organization
+  }
+
+  @Action({ rawError: true })
+  public async suspendOrganization () {
+    const orgId = this.context.state['currentOrganization']?.id
+    const orgStatus = this.context.state['currentOrganization'].statusCode === AccountStatus.ACTIVE ? AccountStatus.SUSPENDED : AccountStatus.ACTIVE
+    if (orgId && orgStatus) {
+      await OrgService.suspendOrg(orgId, orgStatus)
+      await this.context.dispatch('syncOrganization', orgId)
+    }
   }
 
   @Action({ rawError: true })

--- a/auth-web/src/views/auth/account-freeze/AccountFreezeUnlockView.vue
+++ b/auth-web/src/views/auth/account-freeze/AccountFreezeUnlockView.vue
@@ -130,7 +130,7 @@ export default class AccountFreezeUnlockView extends Vue {
     await this.$router.push(`${Pages.MAKE_PAD_PAYMENT}${payment.id}/transactions/${encodedUrl}`)
   }
 
-  get isAccountStatusNsfSuspended () : boolean {
+  private get isAccountStatusNsfSuspended () : boolean {
     return this.currentOrganization.statusCode === AccountStatus.NSF_SUSPENDED
   }
   private closeError () {

--- a/auth-web/src/views/auth/account-freeze/AccountFreezeView.vue
+++ b/auth-web/src/views/auth/account-freeze/AccountFreezeView.vue
@@ -37,7 +37,7 @@ export default class AccountCreationSuccessView extends Mixins(AccountMixin) {
   protected readonly currentOrganization!: Organization
   private formatDate = CommonUtils.formatDisplayDate
 
-  get isAccountStatusNsfSuspended () : boolean {
+  private get isAccountStatusNsfSuspended () : boolean {
     return this.currentOrganization?.accountStatus === AccountStatus.NSF_SUSPENDED
   }
 

--- a/auth-web/src/views/auth/account-freeze/AccountSuspendedView.vue
+++ b/auth-web/src/views/auth/account-freeze/AccountSuspendedView.vue
@@ -1,15 +1,15 @@
 <template>
   <v-container class="view-container">
-       <v-row justify="center">
+      <v-row justify="center">
       <v-col cols="12" sm="6" class="text-center">
-        <v-icon size="40" color="error" class="mb-6">mdi-lock-outline</v-icon>
-        <h1>Account Suspended</h1>
-        <div v-if="isAdmin">
+        <v-icon size="40" data-test="icon-lock-suspend-account" color="error" class="mb-6">mdi-lock-outline</v-icon>
+        <h1 data-test="header-account-suspend">Account Suspended</h1>
+        <div v-if="isAdmin" data-test="div-is-admin">
              <p class="mt-8 mb-10">Your account is suspended. For more information, please contact the BC Online Partnership Office at:<br/></p>
              <p class="mt-1 mb-1">Email: <span class="text-underline">bconline@gov.bc.ca</span></p>
              <p>Telephone: 1-800-663-6102</p>
         </div>
-        <div v-else>
+        <div v-else data-test="div-is-user">
         <p class="mt-8 mb-10">Your account is suspended. Please contact the account administrator</p>
         </div>
       </v-col>

--- a/auth-web/tests/unit/components/AccountInfo.spec.ts
+++ b/auth-web/tests/unit/components/AccountInfo.spec.ts
@@ -37,7 +37,7 @@ describe('AccountInfo.vue', () => {
       state: {
         currentOrganization: {
           name: '',
-          orgStatus: AccountStatus.ACTIVE
+          statusCode: AccountStatus.ACTIVE
         },
         currentMembership: {},
         currentOrgAddress: {},

--- a/auth-web/tests/unit/views/AccountFreezeUnlockView.spec.ts
+++ b/auth-web/tests/unit/views/AccountFreezeUnlockView.spec.ts
@@ -12,13 +12,13 @@ Vue.use(VueRouter)
 const router = new VueRouter()
 const vuetify = new Vuetify({})
 
-// Prevent the warning "[Vuetify] Unable to locate target [data-app]"
-document.body.setAttribute('data-app', 'true')
-
 const mockSession = {
   'NRO_URL': 'Mock NRO URL',
   'NAME_REQUEST_URL': 'Mock Name Request URL'
 }
+
+// Prevent the warning "[Vuetify] Unable to locate target [data-app]"
+document.body.setAttribute('data-app', 'true')
 
 describe('AccountFreezeUnlockView.vue', () => {
   let wrapper: any


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*

- Added suspendaccount patch call to backend in org service file
- event handling of the suspend account dialog button in the account info page.
- fixed minor code smells


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
