### PR TITLE
Changes for sending email for JV failures

### DIFF
--- a/.github/workflows/account-mailer-ci.yml
+++ b/.github/workflows/account-mailer-ci.yml
@@ -25,6 +25,12 @@ jobs:
       JWT_OIDC_ISSUER: "http://localhost:8081/auth/realms/demo"
       SBC_AUTH_ADMIN_CLIENT_ID: "sbc-auth-admin"
       SBC_AUTH_ADMIN_CLIENT_SECRET: "2222222222"
+      MINIO_ENDPOINT: "localhost:9000"
+      MINIO_ACCESS_KEY: "minio"
+      MINIO_ACCESS_SECRET: "minio123"
+      MINIO_BUCKET_NAME: "payment-sftp"
+      MINIO_SECURE: False
+      BCOL_ADMIN_EMAIL: "test@test.com"
 
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ node_modules/
 .DS_Store
 
 auth-api/tests/docker/somefolder/.minio.sys
+queue_services/account-mailer/FEEDBACK.*

--- a/queue_services/account-mailer/requirements.txt
+++ b/queue_services/account-mailer/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.2
-Jinja2==2.11.2
+Jinja2==2.11.3
 MarkupSafe==1.1.1
 Werkzeug==0.16.1
 asyncio-nats-client==0.11.4
@@ -9,19 +9,19 @@ blinker==1.4
 certifi==2020.12.5
 click==7.1.2
 itsdangerous==1.1.0
-jaeger-client==4.3.0
+jaeger-client==4.4.0
 jsonschema==3.2.0
 opentracing==2.4.0
-protobuf==3.14.0
+protobuf==3.15.1
 pycountry==20.7.3
 pyrsistent==0.17.3
 python-dotenv==0.15.0
-sentry-sdk==0.19.5
+sentry-sdk==0.20.3
 six==1.15.0
 threadloop==1.0.2
 thrift==0.13.0
 tornado==6.1
-urllib3==1.26.2
+urllib3==1.26.3
 -e git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python
 -e git+https://github.com/bcgov/sbc-auth.git@development#egg=auth-api&subdirectory=auth-api

--- a/queue_services/account-mailer/src/account_mailer/config.py
+++ b/queue_services/account-mailer/src/account_mailer/config.py
@@ -122,7 +122,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     MINIO_ACCESS_KEY = os.getenv('MINIO_ACCESS_KEY')
     MINIO_ACCESS_SECRET = os.getenv('MINIO_ACCESS_SECRET')
     MINIO_BUCKET = os.getenv('MINIO_BUCKET', 'account-mailer')
-    MINIO_SECURE = True
+    MINIO_SECURE = os.getenv('MINIO_SECURE', 'true').lower() == 'true'
 
     REFUND_REQUEST = {
         'recipients': os.getenv('REFUND_REQUEST_RECIPIENTS', ''),
@@ -139,6 +139,9 @@ class _Config():  # pylint: disable=too-few-public-methods
     # If any value is present in this flag, starts up a keycloak docker
     USE_TEST_KEYCLOAK_DOCKER = os.getenv('USE_TEST_KEYCLOAK_DOCKER', None)
     USE_DOCKER_MOCK = os.getenv('USE_DOCKER_MOCK', None)
+
+    # BC online admin email
+    BCOL_ADMIN_EMAIL = os.getenv('BCOL_ADMIN_EMAIL', 'test@test.com')
 
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods
@@ -175,6 +178,14 @@ class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     # Service account details
     KEYCLOAK_SERVICE_ACCOUNT_ID = os.getenv('KEYCLOAK_TEST_ADMIN_CLIENTID')
     KEYCLOAK_SERVICE_ACCOUNT_SECRET = os.getenv('KEYCLOAK_TEST_ADMIN_SECRET')
+    BCOL_ADMIN_EMAIL = 'test@test.com'
+
+    # Minio variables
+    MINIO_ENDPOINT = 'localhost:9000'
+    MINIO_ACCESS_KEY = 'minio'
+    MINIO_ACCESS_SECRET = 'minio123'
+    MINIO_BUCKET_NAME = 'cgi-ejv'
+    MINIO_SECURE = False
 
 
 class ProdConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/queue_services/account-mailer/src/account_mailer/email_processors/ejv_failures.py
+++ b/queue_services/account-mailer/src/account_mailer/email_processors/ejv_failures.py
@@ -1,0 +1,68 @@
+# Copyright © 2019 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A Template for the EJV Failure email."""
+
+import base64
+
+from entity_queue_common.service_utils import logger
+from flask import current_app
+from jinja2 import Template
+
+from account_mailer.email_processors import generate_template
+from account_mailer.enums import SubjectType, TemplateType
+from account_mailer.services import minio_service
+
+
+def process(email_msg: dict) -> dict:
+    """Build the email for JV failures."""
+    logger.debug('ejv_failures: %s', email_msg)
+    # fill in template
+    failed_jv_file_name = email_msg.get('fileName')
+    file_location = email_msg.get('minioLocation')
+    bcol_admin_email = current_app.config['BCOL_ADMIN_EMAIL']
+    feedback_attachment = _get_jv_file(file_location, failed_jv_file_name)
+    html_body = _get_body()
+    return {
+        'recipients': bcol_admin_email,
+        'content': {
+            'subject': SubjectType.EJV_FAILED.value,
+            'body': f'{html_body}',
+            'attachments': [
+                {
+                    'fileName': failed_jv_file_name,
+                    'fileBytes': feedback_attachment.decode('utf-8'),
+                    'fileUrl': '',
+                    'attachOrder': '1'
+                }
+            ]
+        }
+    }
+
+
+def _get_body():
+    filled_template = generate_template(current_app.config.get('TEMPLATE_PATH'),
+                                        TemplateType.EJV_FAILED_TEMPLATE_NAME.value)
+    # render template with vars from email msg
+    jnja_template = Template(filled_template, autoescape=True)
+    html_out = jnja_template.render()
+    return html_out
+
+
+def _get_jv_file(file_location: str, file_name: str):
+    file = None
+    mino_object = minio_service.MinioService.get_minio_file(file_location, file_name)
+    if mino_object:
+        file = base64.b64encode(mino_object.data)
+
+    return file

--- a/queue_services/account-mailer/src/account_mailer/email_templates/ejv_failed_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/ejv_failed_email.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <base href="/">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="referrer" content="origin-when-cross-origin"/>
+    <meta name="author" content="BC Registries and Online Services">
+    <title>Failed EJV</title>
+    [[style.html]]
+  </head>
+  <body>
+    <div style="font-family: Verdana, Arial, sans-serif; font-size: 14px; padding: 16px;">
+      <div style="margin-left: -6px;">
+        [[logo.html]]
+      </div>
+      <p style="padding-top: 10px; padding-bottom: 10px">
+        The GL disbursement failed for the electronic journal voucher batch. Please contact the ministry to get the correct GL and update in the BC Registries application. The error report is attached with further details.
+      </p>
+    </div>
+  </body>
+</html>

--- a/queue_services/account-mailer/src/account_mailer/enums.py
+++ b/queue_services/account-mailer/src/account_mailer/enums.py
@@ -32,6 +32,7 @@ class MessageType(Enum):
     ONLINE_BANKING_PAYMENT = 'bc.registry.payment.Payment'
     PAD_SETUP_FAILED = 'bc.registry.payment.PadSetupFailed'
     PAYMENT_PENDING = 'bc.registry.payment.ob.outstandingInvoice'
+    EJV_FAILED = 'bc.registry.payment.ejvFailed'
 
 
 class SubjectType(Enum):
@@ -46,6 +47,7 @@ class SubjectType(Enum):
     ONLINE_BANKING_PAYMENT_SUBJECT = '[BC Registries and Online Services] Online Banking payment has been received'
     PAD_SETUP_FAILED = '[BC Registries and Online Services] Your Account is Temporarily Suspended'
     PAYMENT_PENDING = '[BC Registries and Online Services] Payment is now due for pending transaction on your account'
+    EJV_FAILED = 'GL disbursement failure for EJV'
 
 
 class TemplateType(Enum):
@@ -62,3 +64,4 @@ class TemplateType(Enum):
     ONLINE_BANKING_UNDER_PAYMENT_TEMPLATE_NAME = 'online_banking_under_payment'
     PAD_SETUP_FAILED_TEMPLATE_NAME = 'pad_setup_failed'
     PAYMENT_PENDING_TEMPLATE_NAME = 'paymanet_pending'
+    EJV_FAILED_TEMPLATE_NAME = 'ejv_failed_email'

--- a/queue_services/account-mailer/src/account_mailer/services/minio_service.py
+++ b/queue_services/account-mailer/src/account_mailer/services/minio_service.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """This module is a wrapper for Minio."""
 
+import io
+import os
+
 from flask import current_app
 from minio import Minio
 
@@ -29,11 +32,24 @@ class MinioService:
         return minio_client.get_object(bucket_name, file_name)
 
     @staticmethod
+    def put_minio_file(bucket_name: str, file_name: str, value_as_bytes: bytearray):
+        """Return the file from Minio."""
+        minio_client: Minio = MinioService._get_client()
+        current_app.logger.debug(f'Put Minio file {bucket_name}/{file_name}')
+
+        value_as_stream = io.BytesIO(value_as_bytes)
+        minio_client.put_object(current_app.config['MINIO_BUCKET_NAME'], file_name, value_as_stream,
+                                os.stat(file_name).st_size)
+
+        return minio_client.get_object(bucket_name, file_name)
+
+    @staticmethod
     def _get_client() -> Minio:
         """Return a minio client."""
         minio_endpoint = current_app.config['MINIO_ENDPOINT']
         minio_key = current_app.config['MINIO_ACCESS_KEY']
         minio_secret = current_app.config['MINIO_ACCESS_SECRET']
         minio_secure = current_app.config['MINIO_SECURE']
+
         return Minio(minio_endpoint, access_key=minio_key, secret_key=minio_secret,
                      secure=minio_secure)

--- a/queue_services/account-mailer/src/account_mailer/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/worker.py
@@ -39,6 +39,7 @@ from flask import Flask  # pylint: disable=wrong-import-order
 from account_mailer import config  # pylint: disable=wrong-import-order
 from account_mailer.auth_utils import get_member_emails
 from account_mailer.email_processors import common_mailer  # pylint: disable=wrong-import-order
+from account_mailer.email_processors import ejv_failures  # pylint: disable=wrong-import-order
 from account_mailer.email_processors import pad_confirmation  # pylint: disable=wrong-import-order
 from account_mailer.email_processors import payment_completed  # pylint: disable=wrong-import-order
 from account_mailer.email_processors import refund_requested  # pylint: disable=wrong-import-order
@@ -171,12 +172,16 @@ async def process_event(event_message: dict, flask_app):
             }
             email_dict = common_mailer.process(org_id, admin_coordinator_emails, template_name, subject,
                                                **args)
+        elif message_type == MessageType.EJV_FAILED.value:
+            email_msg = event_message.get('data')
+            email_dict = ejv_failures.process(email_msg)
+
         if email_dict:
             logger.debug('Extracted email msg Recipient: %s ', email_dict.get('recipients', ''))
             process_email(email_dict, FLASK_APP, token)
         else:
-            # TODO probably an unnhandled event.handle better
-            logger.error('No email content generate----------------------')
+            # TODO probably an unhandled event.handle better
+            logger.error('No email content generated')
 
 
 def process_email(email_dict: dict, flask_app: Flask, token: str):  # pylint: disable=too-many-branches

--- a/queue_services/account-mailer/tests/conftest.py
+++ b/queue_services/account-mailer/tests/conftest.py
@@ -174,6 +174,7 @@ def auto(docker_services, app):
 
     if app.config['USE_DOCKER_MOCK']:
         docker_services.start('notify')
+        docker_services.start('minio')
         time.sleep(10)
 
 

--- a/queue_services/account-mailer/tests/docker/docker-compose.yml
+++ b/queue_services/account-mailer/tests/docker/docker-compose.yml
@@ -49,3 +49,12 @@ services:
       command: >
         mock -p 4010 --host 0.0.0.0
         https://raw.githubusercontent.com/bcgov/sbc-auth/development/docs/docs/api_contract/notify-api-1.0.0.yaml
+
+    minio:
+      image: 'bitnami/minio:latest'
+      ports:
+        - '9000:9000'
+      environment:
+        - MINIO_ACCESS_KEY=minio
+        - MINIO_SECRET_KEY=minio123
+        - MINIO_DEFAULT_BUCKETS=cgi-ejv


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6350

*Description of changes:*
- Changes for listening to JV failure message and send email to BCOL Admin


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
