### PR TITLE
6426 Give BC Registries and Online Services Staff the ability to support suspended accounts.

### DIFF
--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -75,7 +75,8 @@ class Orgs(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF_VIEW_ACCOUNTS.value, Role.PUBLIC_USER.value])
+    @_JWT.has_one_of_roles(
+        [Role.SYSTEM.value, Role.STAFF_VIEW_ACCOUNTS.value, Role.PUBLIC_USER.value])
     def get():
         """Search orgs."""
         # Search based on request arguments
@@ -122,7 +123,8 @@ class Org(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF_VIEW_ACCOUNTS.value, Role.PUBLIC_USER.value])
+    @_JWT.has_one_of_roles(
+        [Role.SYSTEM.value, Role.STAFF_VIEW_ACCOUNTS.value, Role.PUBLIC_USER.value])
     def get(org_id):
         """Get the org specified by the provided id."""
         org = OrgService.find_by_org_id(org_id, g.jwt_oidc_token_info, allowed_roles=ALL_ALLOWED_ROLES)
@@ -524,7 +526,7 @@ class OrgStatus(Resource):
     """Resource for changing the status of org."""
 
     @staticmethod
-    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF_MANAGE_ACCOUNTS.value])
+    @_JWT.has_one_of_roles([Role.SYSTEM.value, Role.STAFF_MANAGE_ACCOUNTS.value, Role.STAFF_SUSPEND_ACCOUNTS.value])
     @TRACER.trace()
     @cors.crossdomain(origin='*')
     def patch(org_id):

--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -180,7 +180,7 @@
           req
           :rules="suspensionSelectRules"
           :items="suspensionReasonCodes"
-          item-text="code"
+          item-text="desc"
           item-value="code"
           v-model="selectedSuspensionReasonCode"
           v-if="isAccountStatusActive"

--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -329,7 +329,7 @@ export default class AccountInfo extends Mixins(AccountChangeMixin) {
   }
 
   private get isSuspendButtonVisible (): boolean {
-    return this.currentOrganization.statusCode === AccountStatus.ACTIVE || this.currentOrganization.statusCode === AccountStatus.SUSPENDED
+    return (this.currentOrganization.statusCode === AccountStatus.ACTIVE || this.currentOrganization.statusCode === AccountStatus.SUSPENDED) && this.currentUser.roles.includes(Role.StaffSuspendAccounts)
   }
 
   private get isConfirmSuspendButtonDisabled (): boolean {

--- a/auth-web/src/components/auth/staff/account-management/StaffAccountManagement.vue
+++ b/auth-web/src/components/auth/staff/account-management/StaffAccountManagement.vue
@@ -182,7 +182,6 @@ export default class StaffAccountManagement extends Vue {
     await this.getCodes()
     await this.syncPendingStaffOrgs()
     await this.syncRejectedStaffOrgs()
-    await this.getCodes()
     await this.syncSuspendedStaffOrgs()
     if (this.canAdminAccounts) {
       await this.syncPendingInvitationOrgs()

--- a/auth-web/src/components/auth/staff/account-management/StaffAccountManagement.vue
+++ b/auth-web/src/components/auth/staff/account-management/StaffAccountManagement.vue
@@ -175,10 +175,10 @@ export default class StaffAccountManagement extends Vue {
   ]
 
   private async mounted () {
+    await this.getCodes()
     await this.syncPendingStaffOrgs()
     await this.syncRejectedStaffOrgs()
     await this.syncPendingInvitationOrgs()
-    await this.getCodes()
     await this.syncSuspendedStaffOrgs()
   }
 

--- a/auth-web/src/components/auth/staff/account-management/StaffAccountManagement.vue
+++ b/auth-web/src/components/auth/staff/account-management/StaffAccountManagement.vue
@@ -22,7 +22,7 @@
       <v-tab data-test="active-tab" :to=pagesEnum.STAFF_DASHBOARD_ACTIVE
         v-if="canViewAccounts">Active</v-tab>
 
-      <template v-if="canCreateAccounts">
+      <template v-if="canAdminAccounts">
         <v-tab data-test="invitations-tab" :to=pagesEnum.STAFF_DASHBOARD_INVITATIONS>
           <v-badge
             inline
@@ -53,6 +53,9 @@
             Rejected
           </v-badge>
         </v-tab>
+      </template>
+
+      <template v-if="canSuspendAccounts">
         <v-tab data-test="suspended-tab" :to=pagesEnum.STAFF_DASHBOARD_SUSPENDED>
           <v-badge
             inline
@@ -63,6 +66,7 @@
           </v-badge>
         </v-tab>
       </template>
+
     </v-tabs>
 
     <!-- Tab Contents -->
@@ -178,8 +182,11 @@ export default class StaffAccountManagement extends Vue {
     await this.getCodes()
     await this.syncPendingStaffOrgs()
     await this.syncRejectedStaffOrgs()
-    await this.syncPendingInvitationOrgs()
+    await this.getCodes()
     await this.syncSuspendedStaffOrgs()
+    if (this.canAdminAccounts) {
+      await this.syncPendingInvitationOrgs()
+    }
   }
 
   openCreateAccount () {
@@ -196,6 +203,14 @@ export default class StaffAccountManagement extends Vue {
 
   private get canViewAccounts () {
     return this.currentUser?.roles?.includes(Role.StaffViewAccounts)
+  }
+
+  private get canSuspendAccounts () {
+    return this.currentUser?.roles?.includes(Role.StaffSuspendAccounts) || this.currentUser?.roles?.includes(Role.StaffViewAccounts)
+  }
+
+  private get canAdminAccounts () {
+    return this.currentUser?.roles?.includes(Role.AdminStaff)
   }
 
   private async tabChange (tabIndex) {

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -27,7 +27,8 @@ export enum Role {
     Tester = 'tester',
     AccountHolder = 'account_holder',
     PublicUser = 'public_user',
-    AdminStaff = 'admin'
+    AdminStaff = 'admin',
+    StaffSuspendAccounts = 'suspend_accounts'
 }
 
 export enum Pages {

--- a/auth-web/tests/unit/components/AccountInfo.spec.ts
+++ b/auth-web/tests/unit/components/AccountInfo.spec.ts
@@ -69,7 +69,7 @@ describe('AccountInfo.vue', () => {
       namespaced: true,
       state: {
         currentUser: {
-          roles: [Role.Staff]
+          roles: [Role.Staff, Role.StaffSuspendAccounts]
         }
       },
       actions: UserModule.actions,


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6426

*Description of changes:*
Allow users with view_accounts role to see suspend account tab.
Allow any users with suspend_accounts role to suspend\unsuspend accounts.
Hide suspend account button for users without suspend_accounts role.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
