### PR TITLE
Incorrect screen displayed for user/coordinator for suspended account

### DIFF
--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -275,7 +275,10 @@ export default class OrgModule extends VuexModule {
       response = await UserService.getMembership(orgId)
       membership = response?.data
       const org: Organization = this.context.state['currentOrganization']
-      const res = await PermissionService.getPermissions(org?.statusCode, membership?.membershipTypeCode)
+      const currentAccountSettings = this.context.state['currentAccountSettings']
+      const statusCode = org && org.statusCode ? org?.statusCode : currentAccountSettings.accountStatus
+      // to fix permission issue. check currentOrganization account , if its not set take status from currentAccountSettings
+      const res = await PermissionService.getPermissions(statusCode, membership?.membershipTypeCode)
       permissions = res?.data
     } else {
       // Check for better approach


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6813

*Description of changes:*
*if account status is not available take from accountsettings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
