### PR TITLE
6220-reset passcode-backend.

### DIFF
--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -363,8 +363,10 @@ class OrgAffiliation(Resource):
     @cors.crossdomain(origin='*')
     def delete(org_id, business_identifier):
         """Delete an affiliation between an org and an entity."""
+        request_json = request.get_json()
+        email_addresses = request_json.get('passcodeResetEmail')
         try:
-            AffiliationService.delete_affiliation(org_id, business_identifier, g.jwt_oidc_token_info)
+            AffiliationService.delete_affiliation(org_id, business_identifier, email_addresses, g.jwt_oidc_token_info)
             response, status = {}, http_status.HTTP_200_OK
 
         except BusinessException as exception:

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -239,7 +239,7 @@ class Affiliation:
         return Affiliation(affiliation_model)
 
     @staticmethod
-    def delete_affiliation(org_id, business_identifier, token_info: Dict = None):
+    def delete_affiliation(org_id, business_identifier, email_addresses: str = None, token_info: Dict = None):
         """Delete the affiliation for the provided org id and business id."""
         current_app.logger.info(f'<delete_affiliation org_id:{org_id} business_identifier:{business_identifier}')
         org = OrgService.find_by_org_id(org_id, token_info=token_info, allowed_roles=(*CLIENT_AUTH_ROLES, STAFF))
@@ -258,6 +258,7 @@ class Affiliation:
             raise BusinessException(Error.DATA_NOT_FOUND, None)
 
         affiliation.delete()
+        entity.reset_passcode(entity.business_identifier, email_addresses, token_info)
         entity.set_pass_code_claimed(False)
 
     @staticmethod

--- a/auth-api/src/auth_api/services/entity.py
+++ b/auth-api/src/auth_api/services/entity.py
@@ -14,6 +14,8 @@
 """Service for managing Entity data."""
 
 from typing import Dict, Tuple
+import string
+import random
 
 from sbc_common_components.tracing.service_tracing import ServiceTracing  # noqa: I001
 
@@ -45,6 +47,11 @@ class Entity:
     def identifier(self):
         """Return the unique identifier for this entity."""
         return self._model.id
+
+    @property
+    def business_identifier(self):
+        """Return the business identifier for this entity."""
+        return self._model.business_identifier
 
     @property
     def pass_code(self):
@@ -151,8 +158,11 @@ class Entity:
         """Reset the entity passcode and send email."""
         check_auth(token_info, one_of_roles=ALL_ALLOWED_ROLES, business_identifier=business_identifier)
         entity: EntityModel = EntityModel.find_by_business_identifier(business_identifier)
-        # TODO generate passcoe and set
-        new_pass_code: str = None  # TODO
+        # generate passcode and set
+        new_pass_code = ''.join(random.choices(string.digits, k=9))
+        entity.pass_code = passcode_hash(new_pass_code)
+        entity.pass_code_claimed = False
+        entity.save()
 
         if email_addresses:
             mailer_payload = dict(

--- a/auth-api/src/auth_api/services/entity.py
+++ b/auth-api/src/auth_api/services/entity.py
@@ -15,7 +15,7 @@
 
 from typing import Dict, Tuple
 import string
-import random
+import secrets
 
 from sbc_common_components.tracing.service_tracing import ServiceTracing  # noqa: I001
 
@@ -159,7 +159,8 @@ class Entity:
         check_auth(token_info, one_of_roles=ALL_ALLOWED_ROLES, business_identifier=business_identifier)
         entity: EntityModel = EntityModel.find_by_business_identifier(business_identifier)
         # generate passcode and set
-        new_pass_code = ''.join(random.choices(string.digits, k=9))
+        new_pass_code = ''.join(secrets.choice(string.digits) for i in range(9))
+
         entity.pass_code = passcode_hash(new_pass_code)
         entity.pass_code_claimed = False
         entity.save()

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -24,7 +24,7 @@ from auth_api.exceptions.errors import Error
 from auth_api.models.affiliation import Affiliation as AffiliationModel
 from auth_api.models.org import Org as OrgModel
 from auth_api.services import Affiliation as AffiliationService
-from tests.utilities.factory_scenarios import TestEntityInfo, TestOrgTypeInfo
+from tests.utilities.factory_scenarios import TestEntityInfo, TestJwtClaims, TestOrgTypeInfo
 from tests.utilities.factory_utils import factory_entity_service, factory_org_service
 
 
@@ -215,7 +215,8 @@ def test_delete_affiliation(session, auth_mock):  # pylint:disable=unused-argume
                                                         TestEntityInfo.entity_lear_mock['passCode'],
                                                         {})
 
-    AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier)
+    AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier,
+                                          email_addresses=None, token_info=TestJwtClaims.user_test)
 
     found_affiliation = AffiliationModel.query.filter_by(id=affiliation.identifier).first()
     assert found_affiliation is None
@@ -237,7 +238,8 @@ def test_delete_affiliation_no_org(session, auth_mock):  # pylint:disable=unused
                                           {})
 
     with pytest.raises(BusinessException) as exception:
-        AffiliationService.delete_affiliation(org_id=None, business_identifier=business_identifier)
+        AffiliationService.delete_affiliation(org_id=None, business_identifier=business_identifier,
+                                              email_addresses=None, token_info=TestJwtClaims.user_test)
 
     assert exception.value.code == Error.DATA_NOT_FOUND.name
 
@@ -258,7 +260,8 @@ def test_delete_affiliation_no_entity(session, auth_mock):  # pylint:disable=unu
                                           {})
 
     with pytest.raises(BusinessException) as exception:
-        AffiliationService.delete_affiliation(org_id=org_id, business_identifier=None)
+        AffiliationService.delete_affiliation(org_id=org_id, business_identifier=None,
+                                              email_addresses=None, token_info=TestJwtClaims.user_test)
 
     assert exception.value.code == Error.DATA_NOT_FOUND.name
 
@@ -277,10 +280,12 @@ def test_delete_affiliation_no_affiliation(session, auth_mock):  # pylint:disabl
                                           business_identifier,
                                           TestEntityInfo.entity_lear_mock['passCode'],
                                           {})
-    AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier)
+    AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier,
+                                          email_addresses=None, token_info=TestJwtClaims.user_test)
 
     with pytest.raises(BusinessException) as exception:
-        AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier)
+        AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier,
+                                              email_addresses=None, token_info=TestJwtClaims.user_test)
 
     assert exception.value.code == Error.DATA_NOT_FOUND.name
 
@@ -300,7 +305,8 @@ def test_delete_affiliation_implicit(session, auth_mock):  # pylint:disable=unus
                                                         TestEntityInfo.entity_lear_mock['passCode'],
                                                         {})
 
-    AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier)
+    AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier,
+                                          email_addresses=None, token_info=TestJwtClaims.user_test)
 
     found_affiliation = AffiliationModel.query.filter_by(id=affiliation.identifier).first()
     assert found_affiliation is None
@@ -376,7 +382,8 @@ def test_find_affiliations_for_new_business(session, auth_mock, nr_mock):  # pyl
     assert len(affiliated_entities) == 1
     assert affiliated_entities[0]['business_identifier'] == business_identifier2
 
-    AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier2)
+    AffiliationService.delete_affiliation(org_id=org_id, business_identifier=business_identifier2,
+                                          email_addresses=None, token_info=TestJwtClaims.user_test)
 
     affiliated_entities = AffiliationService.find_affiliated_entities_by_org_id(org_id)
 

--- a/auth-api/tests/unit/services/test_entity.py
+++ b/auth-api/tests/unit/services/test_entity.py
@@ -347,3 +347,16 @@ def test_delete_entity(app, session):  # pylint:disable=unused-argument
     entity = EntityService.find_by_entity_id(entity.identifier)
 
     assert entity is None
+
+
+def test_reset_pass_code(app, session):  # pylint:disable=unused-argument
+    """Assert that the new passcode in not the same as old passcode."""
+    entity_model = factory_entity_model(entity_info=TestEntityInfo.entity_passcode)
+
+    entity = EntityService(entity_model)
+    old_passcode = entity.pass_code
+
+    entity.reset_passcode(entity.business_identifier, '', TestJwtClaims.user_test)
+    new_passcode = entity.pass_code
+
+    assert old_passcode != new_passcode

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -508,7 +508,7 @@ def test_delete_org_with_affiliation_fail(session, auth_mock, keycloak_mock):  #
 
     assert exception.value.code == Error.ORG_CANNOT_BE_DISSOLVED.name
 
-    AffiliationService.delete_affiliation(org_id, business_identifier,
+    AffiliationService.delete_affiliation(org_id, business_identifier, None,
                                           TestEntityInfo.entity_lear_mock['passCode'])
     OrgService.delete_org(org.as_dict()['id'], TestJwtClaims.public_user_role)
     org_inactive = OrgService.find_by_org_id(org.as_dict()['id'])


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6220

*Description of changes:*
Add reset passcode function to affiliation removal. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
