### PR TITLE
Adding productSettings to user settings endpoint

### DIFF
--- a/auth-api/requirements.txt
+++ b/auth-api/requirements.txt
@@ -2,7 +2,7 @@ Flask-Caching==1.10.1
 Flask-Mail==0.9.1
 Flask-Migrate==2.7.0
 Flask-Moment==0.11.0
-Flask-SQLAlchemy==2.4.4
+Flask-SQLAlchemy==2.5.1
 Flask-Script==2.0.6
 Flask==1.1.2
 Jinja2==2.11.3
@@ -12,7 +12,7 @@ SQLAlchemy-Continuum==1.3.11
 SQLAlchemy-Utils==0.36.8
 SQLAlchemy==1.3.23
 Werkzeug==0.16.1
-alembic==1.5.7
+alembic==1.5.8
 aniso8601==9.0.1
 asyncio-nats-client==0.11.4
 asyncio-nats-streaming==0.4.0

--- a/auth-api/src/auth_api/models/user_settings.py
+++ b/auth-api/src/auth_api/models/user_settings.py
@@ -17,7 +17,7 @@ It defines the settings available for the user which can be displayed in the hea
 """
 
 
-class UserSettings():  # pylint: disable=too-few-public-methods
+class UserSettings():  # pylint: disable=too-few-public-methods, too-many-instance-attributes
     """
     This is the User Settings model.
 
@@ -27,7 +27,7 @@ class UserSettings():  # pylint: disable=too-few-public-methods
     """
 
     def __init__(self, id_, label, urlorigin, urlpath, type_, account_type=None,  # pylint: disable=too-many-arguments
-                 account_status=None):
+                 account_status=None, product_settings=None):
         """Return a usersettings."""
         self.id = id_
         self.label = label
@@ -36,3 +36,4 @@ class UserSettings():  # pylint: disable=too-few-public-methods
         self.type = type_
         self.account_type = account_type
         self.account_status = account_status
+        self.product_settings = product_settings

--- a/auth-api/src/auth_api/schemas/schemas/user_settings_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/user_settings_response.json
@@ -36,7 +36,6 @@
               "description": "An explanation about the purpose of this instance.",
               "default": {},
               "required": [
-                  "accountType",
                   "id",
                   "label",
                   "type",
@@ -98,6 +97,17 @@
                       "default": "",
                       "examples": [
                           "/account/1/settings"
+                      ],
+                      "pattern": "^(.*)$"
+                  },
+                  "productSettings": {
+                      "$id": "#/items/anyOf/0/properties/productSettings",
+                      "type": "string",
+                      "title": "URL Path",
+                      "description": "Product Settings relative URL",
+                      "default": "",
+                      "examples": [
+                          "/account/1/product-settings"
                       ],
                       "pattern": "^(.*)$"
                   }

--- a/auth-api/src/auth_api/schemas/user_settings.py
+++ b/auth-api/src/auth_api/schemas/user_settings.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Manager for org schema and export."""
+"""Manager for User settings schema and export."""
+
+from marshmallow import post_dump
 
 from auth_api.models import ma
 
@@ -22,4 +24,19 @@ class UserSettingsSchema(ma.ModelSchema):  # pylint: disable=too-many-ancestors,
     class Meta:  # pylint: disable=too-few-public-methods
         """Maps all of the User Settings fields to a default schema."""
 
-        fields = ('id', 'label', 'urlorigin', 'urlpath', 'type', 'account_type', 'account_status')
+        fields = ('id', 'label', 'urlorigin', 'urlpath', 'type', 'account_type', 'account_status', 'product_settings')
+
+    @post_dump(pass_many=True)
+    def _remove_empty(self, data, many):  # pylint: disable=no-self-use
+        """Remove all empty values from the dumped dict."""
+        if not many:
+            return {
+                key: value for key, value in data.items()
+                if value or isinstance(value, float)
+            }
+        for item in data:
+            for key in list(item):
+                value = item[key]
+                if not value and not isinstance(value, float):
+                    item.pop(key)
+        return data

--- a/auth-api/src/auth_api/services/user_settings.py
+++ b/auth-api/src/auth_api/services/user_settings.py
@@ -36,7 +36,7 @@ class UserSettings:  # pylint: disable=too-few-public-methods
         for org in all_orgs:
             all_settings.append(
                 UserSettingsModel(org.id, org.name, url_origin, '/account/' + str(org.id) + '/settings', 'ACCOUNT',
-                                  org.type_code, org.status_code))
+                                  org.type_code, org.status_code, '/account/' + str(org.id) + '/product-settings'))
 
         all_settings.append(UserSettingsModel(user_id, 'USER PROFILE', url_origin, '/userprofile', 'USER_PROFILE'))
         all_settings.append(

--- a/auth-api/tests/unit/api/test_user_settings.py
+++ b/auth-api/tests/unit/api/test_user_settings.py
@@ -17,15 +17,13 @@
 Test-Suite to ensure that the /users endpoint is working as expected.
 """
 import copy
-import json
-
-from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestUserInfo
-from tests.utilities.factory_utils import factory_auth_header, factory_contact_model, factory_user_model
 
 from auth_api import status as http_status
 from auth_api.models import ContactLink as ContactLinkModel
 from auth_api.schemas import utils as schema_utils
 from auth_api.services import Org as OrgService
+from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestUserInfo
+from tests.utilities.factory_utils import factory_auth_header, factory_contact_model, factory_user_model
 
 
 def test_get_user_settings(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
@@ -45,8 +43,9 @@ def test_get_user_settings(client, jwt, session, keycloak_mock):  # pylint:disab
     # post token with updated claims
     headers = factory_auth_header(jwt=jwt, claims=claims)
     rv = client.get(f'/api/v1/users/{kc_id}/settings', headers=headers, content_type='application/json')
-    item_list = json.loads(rv.data)
+    item_list = rv.json
     account = next(obj for obj in item_list if obj['type'] == 'ACCOUNT')
     assert account['accountType'] == 'BASIC'
     assert rv.status_code == http_status.HTTP_200_OK
-    assert schema_utils.validate(rv.json, 'user_settings_response')[0]
+    assert schema_utils.validate(item_list, 'user_settings_response')[0]
+    assert account['productSettings'] == f'/account/{account["id"]}/product-settings'

--- a/queue_services/account-mailer/src/account_mailer/enums.py
+++ b/queue_services/account-mailer/src/account_mailer/enums.py
@@ -49,7 +49,7 @@ class SubjectType(Enum):
     PAD_SETUP_FAILED = '[BC Registries and Online Services] Your Account is Temporarily Suspended'
     PAYMENT_PENDING = '[BC Registries and Online Services] Payment is now due for pending transaction on your account'
     EJV_FAILED = 'GL disbursement failure for EJV'
-    RESET_PASSCODE = 'Passcode reset'
+    RESET_PASSCODE = 'BC Registries Account Passcode Reset'
 
 
 class TemplateType(Enum):
@@ -73,5 +73,4 @@ class TemplateType(Enum):
 class Constants(Enum):
     """Constants."""
 
-    RESET_PASSCODE_STAFF_HEADER = 'BC Registries staff have generated a new passcode for your business.'
-    RESET_PASSCODE_CUSTOMER_HEADER = 'BC Registries have generated a new passcode for your business.'
+    RESET_PASSCODE_HEADER = 'BC Registries have generated a new passcode for your business.'

--- a/queue_services/account-mailer/src/account_mailer/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/worker.py
@@ -187,11 +187,8 @@ async def process_event(event_message: dict, flask_app):
             template_name = TemplateType.RESET_PASSCODE_TEMPLATE_NAME.value
 
             subject = SubjectType.RESET_PASSCODE.value
-            header: str = Constants.RESET_PASSCODE_CUSTOMER_HEADER.value
-            if email_msg.get('isStaffInitiated', False):
-                header = Constants.RESET_PASSCODE_STAFF_HEADER.value
             email_msg.update({
-                'header': header
+                'header': Constants.RESET_PASSCODE_HEADER.value
             })
 
             email_dict = common_mailer.process(


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6723

*Description of changes:*
- Adding productSettings URL as part of /users/settings endpoint
- Changes to email subject for passcode reset as per latest comments


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
