### PR TITLE
made loginsource optional

### DIFF
--- a/auth-web/src/routes/router.ts
+++ b/auth-web/src/routes/router.ts
@@ -348,7 +348,7 @@ export function getRoutes (): RouteConfig[] {
       redirect: '/undefined/validatetoken/BCSC/:token'
     },
     {
-      path: '/confirmtoken/:token/:loginSource',
+      path: '/confirmtoken/:token/:loginSource?',
       name: 'confirmtoken',
       component: AcceptInviteView,
       props: true,


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*

Login source in the confirm token was added last sprint and missed to add an optional param

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
