### PR TITLE
Clean up for product subscriptions and tasks

### DIFF
--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -111,19 +111,7 @@ class Org:  # pylint: disable=too-many-public-methods
         # Send an email to staff to remind review the pending account
         if access_type in (AccessType.EXTRA_PROVINCIAL.value, AccessType.REGULAR_BCEID.value) \
                 and not AffidavitModel.find_approved_by_user_id(user_id=user_id):
-            org.status_code = OrgStatus.PENDING_STAFF_REVIEW.value
-            user = UserModel.find_by_jwt_token(token=token_info)
-            Org.send_staff_review_account_reminder(user, org.id, origin_url)
-            # create a staff review task for this account
-            task_info = {'name': org.name,
-                         'relationshipId': org.id,
-                         'relatedTo': user.id,
-                         'dateSubmitted': datetime.today(),
-                         'relationshipType': TaskRelationshipType.ORG.value,
-                         'type': TaskType.PENDING_STAFF_REVIEW.value,
-                         'status': TaskStatus.OPEN.value
-                         }
-            TaskService.create_task(task_info)
+            Org._handle_bceid_status_and_notification(org, origin_url, token_info)
 
         if access_type == AccessType.GOVM.value:
             org.status_code = OrgStatus.PENDING_INVITE_ACCEPT.value
@@ -135,7 +123,10 @@ class Org:  # pylint: disable=too-many-public-methods
         # create the membership record for this user if its not created by staff and access_type is anonymous
         Org.create_membership(access_type, is_staff_admin, org, user_id)
 
-        ProductService.create_default_product_subscriptions(org, is_new_transaction=False)
+        # dir search doesnt need default products
+
+        if access_type not in (AccessType.ANONYMOUS.value,):
+            ProductService.create_default_product_subscriptions(org, is_new_transaction=False)
         payment_method = Org._validate_and_get_payment_method(selected_payment_method, OrgType[org_type],
                                                               access_type=access_type)
 
@@ -155,6 +146,22 @@ class Org:  # pylint: disable=too-many-public-methods
         current_app.logger.info(f'<created_org org_id:{org.id}')
 
         return Org(org)
+
+    @staticmethod
+    def _handle_bceid_status_and_notification(org, origin_url, token_info):
+        org.status_code = OrgStatus.PENDING_STAFF_REVIEW.value
+        user = UserModel.find_by_jwt_token(token=token_info)
+        Org.send_staff_review_account_reminder(user, org.id, origin_url)
+        # create a staff review task for this account
+        task_info = {'name': org.name,
+                     'relationshipId': org.id,
+                     'relatedTo': user.id,
+                     'dateSubmitted': datetime.today(),
+                     'relationshipType': TaskRelationshipType.ORG.value,
+                     'type': TaskType.PENDING_STAFF_REVIEW.value,
+                     'status': TaskStatus.OPEN.value
+                     }
+        TaskService.create_task(task_info, do_commit=False)
 
     @staticmethod
     def _validate_and_get_payment_method(selected_payment_type: str, org_type: OrgType, access_type=None) -> str:

--- a/auth-api/src/auth_api/services/products.py
+++ b/auth-api/src/auth_api/services/products.py
@@ -26,7 +26,7 @@ from auth_api.models import ProductCode as ProductCodeModel
 from auth_api.models import ProductSubscription as ProductSubscriptionModel
 from auth_api.models import db
 from auth_api.utils.enums import ProductTypeCode, ProductCode, OrgType, \
-                                 ProductSubscriptionStatus, TaskRelationshipType, TaskType, TaskStatus
+    ProductSubscriptionStatus, TaskRelationshipType, TaskType, TaskStatus
 from .task import Task as TaskService
 from .authorization import check_auth
 from ..utils.cache import cache
@@ -59,7 +59,8 @@ class Product:
         return getattr(product_code_model, 'type_code', '')
 
     @staticmethod
-    def create_product_subscription(org_id, subscription_data: Dict[str, Any], is_new_transaction: bool = True,
+    def create_product_subscription(org_id, subscription_data: Dict[str, Any],  # pylint: disable=too-many-locals
+                                    is_new_transaction: bool = True,
                                     token_info: Dict = None, skip_auth=False):
         """Create product subscription for the user.
 
@@ -86,20 +87,23 @@ class Product:
             if product_model:
                 product_subscription = ProductSubscriptionModel(org_id=org_id,
                                                                 product_code=product_code,
-                                                                status_code=product_model.default_subscription_status)\
+                                                                status_code=product_model.default_subscription_status) \
                     .flush()
-                # create a staff review task for this product subscription
-                user = UserModel.find_by_jwt_token(token=token_info)
-                task_info = {'name': f'{org.name} - {product_model.description}',
-                             'relationshipId': product_subscription.id,
-                             'relatedTo': user.id,
-                             'dateSubmitted': datetime.today(),
-                             'relationshipType': TaskRelationshipType.PRODUCT.value,
-                             'type': TaskType.PENDING_STAFF_REVIEW.value,
-                             'status': TaskStatus.OPEN.value,
-                             'accountId': org_id
-                             }
-                TaskService.create_task(task_info)
+
+                # create a staff review task for this product subscription if pending status
+                if product_model.default_subscription_status == ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value:
+                    user = UserModel.find_by_jwt_token(token=token_info)
+                    task_info = {'name': f'{org.name} - {product_model.description}',
+                                 'relationshipId': product_subscription.id,
+                                 'relatedTo': user.id,
+                                 'dateSubmitted': datetime.today(),
+                                 'relationshipType': TaskRelationshipType.PRODUCT.value,
+                                 'type': TaskType.PENDING_STAFF_REVIEW.value,
+                                 'status': TaskStatus.OPEN.value,
+                                 'accountId': org_id
+                                 }
+                    do_commit = False
+                    TaskService.create_task(task_info, do_commit)
 
                 subscriptions_model_list.append(product_subscription)
             else:
@@ -183,3 +187,18 @@ class Product:
                                                                      ProductSubscriptionStatus.NOT_SUBSCRIBED.value)
                     })
         return merged_product_infos
+
+    @staticmethod
+    def update_product_subscription(product_subscription_id: int, is_approved: bool, is_new_transaction: bool = True):
+        """Update Product Subscription."""
+        current_app.logger.debug('<update_task_product ')
+        # Approve/Reject Product subscription
+        product_subscription: ProductSubscriptionModel = ProductSubscriptionModel.find_by_id(product_subscription_id)
+        if is_approved:
+            product_subscription.status_code = ProductSubscriptionStatus.ACTIVE.value
+        else:
+            product_subscription.status_code = ProductSubscriptionStatus.REJECTED.value
+        product_subscription.flush()
+        if is_new_transaction:  # Commit the transaction if it's a new transaction
+            db.session.commit()
+        current_app.logger.debug('>update_task_product ')

--- a/auth-api/tests/unit/api/test_org_products.py
+++ b/auth-api/tests/unit/api/test_org_products.py
@@ -82,3 +82,21 @@ def test_add_single_org_product_vs(client, jwt, session, keycloak_mock):  # pyli
                              content_type='application/json')
     list_products = json.loads(rv_products.data)
     assert len(list_products) == 2, 'total 2 products'
+
+
+def test_dir_search_doesnt_get_any_product(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
+    """Assert dir search doesnt get any active product subscriptions."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    client.post('/api/v1/users', headers=headers, content_type='application/json')
+    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org_anonymous),
+                     headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_201_CREATED
+    dictionary = json.loads(rv.data)
+    assert dictionary['accessType'] == 'ANONYMOUS'
+    assert schema_utils.validate(rv.json, 'org_response')[0]
+
+    rv_products = client.get(f"/api/v1/orgs/{dictionary.get('id')}/products?includeInternal=false", headers=headers,
+                             content_type='application/json')
+
+    list_products = json.loads(rv_products.data)
+    assert len([x for x in list_products if x.get('subscriptionStatus') != 'NOT_SUBSCRIBED']) == 0


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/4118

*Description of changes:*

1) handled transactions in tasks
2) dir search accounts doesn't need default subscriptions
3) tasks not needed for all products.only products which has default status as staff review needs it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
