### PR TITLE
Fixed Roles not getting displayed for GOVM member invitations

### DIFF
--- a/auth-api/src/auth_api/services/invitation.py
+++ b/auth-api/src/auth_api/services/invitation.py
@@ -256,7 +256,7 @@ class Invitation:
         govm_member_configs = {
             'token_confirm_path': token_confirm_path,
             'template_name': 'govm_member_invitation_email',
-            'subject': '[BC Registries and Online Services] You have been added as a team member.',
+            'subject': '[BC Registries and Online Services] You have been added as a team member',
         }
         director_search_configs = {
             'token_confirm_path': token_confirm_path,

--- a/auth-api/src/auth_api/services/invitation.py
+++ b/auth-api/src/auth_api/services/invitation.py
@@ -222,11 +222,12 @@ class Invitation:
         recipient = invitation.recipient_email
         token_confirm_url = '{}/{}/{}'.format(app_url, mail_configs.get('token_confirm_path'), invitation.token)
         template = ENV.get_template(f"email_templates/{mail_configs.get('template_name')}.html")
-
+        role = invitation.membership[0].membership_type.display_name
         sent_response = send_email(subject, sender, recipient,
                                    template.render(invitation=invitation,
                                                    url=token_confirm_url,
                                                    user=user,
+                                                   role=role,
                                                    org_name=org_name,
                                                    logo_url=f'{app_url}/{CONFIG.REGISTRIES_LOGO_IMAGE_NAME}'))
         if not sent_response:


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/7180

*Description of changes:*

Fixed roles getting displayed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
