### PR TITLE
Open NR UI in same tab

### DIFF
--- a/auth-web/src/assets/scss/base.scss
+++ b/auth-web/src/assets/scss/base.scss
@@ -154,3 +154,7 @@ legend {
     background: #bdbdbd4d !important;
   }
 }
+
+.cursor-pointer {
+  cursor: pointer !important;
+}

--- a/auth-web/src/components/auth/home/NameRequestButton.vue
+++ b/auth-web/src/components/auth/home/NameRequestButton.vue
@@ -20,6 +20,7 @@ import LaunchDarklyService from 'sbc-common-components/src/services/launchdarkly
 export default class NameRequestButton extends Vue {
   @Prop() isWide: boolean
 
+  // open Name Request in current tab to retain current account and user
   goToNameRequest (): void {
     if (LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)) {
       window.location.href = ConfigHelper.getNameRequestUrl()

--- a/auth-web/src/components/auth/home/NameRequestButton.vue
+++ b/auth-web/src/components/auth/home/NameRequestButton.vue
@@ -2,11 +2,10 @@
   <v-btn
     large
     color="#003366"
-    target="_blank"
-    rel="noopener noreferrer"
     class="btn-name-request white--text"
     :class="{'btn-name-request-wide': isWide}"
-    :href="nameRequestUrl">
+    @click="goToNameRequest()"
+  >
     <span class="btn-text">Request a Name</span>
   </v-btn>
 </template>
@@ -21,10 +20,12 @@ import LaunchDarklyService from 'sbc-common-components/src/services/launchdarkly
 export default class NameRequestButton extends Vue {
   @Prop() isWide: boolean
 
-  private get nameRequestUrl (): string {
-    return LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)
-      ? ConfigHelper.getNameRequestUrl()
-      : ConfigHelper.getNroUrl()
+  goToNameRequest (): void {
+    if (LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)) {
+      window.location.href = ConfigHelper.getNameRequestUrl()
+    } else {
+      window.location.href = ConfigHelper.getNroUrl()
+    }
   }
 }
 </script>

--- a/auth-web/src/views/auth/home/RequestNameView.vue
+++ b/auth-web/src/views/auth/home/RequestNameView.vue
@@ -25,8 +25,7 @@
         <div class="request-name-info-btns mt-5">
           <name-request-button />
           <p class="mt-5">Have an existing Name Request?
-            <a :href="nameRequestExistingUrl"
-              target="_blank" rel="noopener noreferrer" class="status-link">
+            <a class="status-link" @click="goToNameRequestExisting()">
               Check your Name Request Status
             </a>
           </p>
@@ -37,9 +36,13 @@
       </v-col>
       <!-- Image Column -->
       <v-col cols="12" md="6">
-        <a :href="nameRequestUrl" target="_blank">
-          <v-img src="../../../assets/img/Step2_NameRequest_x2.png" aspect-ratio="1.2" contain></v-img>
-        </a>
+        <v-img
+          src="../../../assets/img/Step2_NameRequest_x2.png"
+          aspect-ratio="1.2"
+          contain
+          class="cursor-pointer"
+          @click="goToNameRequest()"
+        />
       </v-col>
     </v-row>
   </v-container>
@@ -69,16 +72,19 @@ export default class RequestNameView extends Vue {
     { text: 'If your name is approved, you can use it to incorporate or register your business.' }
   ]
 
-  private get nameRequestExistingUrl () {
-    return LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)
-      ? `${ConfigHelper.getNameRequestUrl()}existing`
-      : `${ConfigHelper.getNroUrl()}nro.htm?_flowId=anonymous-monitor-flow&_flowExecutionKey=e1s1`
+  goToNameRequestExisting (): void {
+    if (LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)) {
+      window.location.href = `${ConfigHelper.getNameRequestUrl()}existing`
+    } else {
+      window.location.href = `${ConfigHelper.getNroUrl()}nro.htm?_flowId=anonymous-monitor-flow&_flowExecutionKey=e1s1`
+    }
   }
-
-  private get nameRequestUrl (): string {
-    return LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)
-      ? ConfigHelper.getNameRequestUrl()
-      : ConfigHelper.getNroUrl()
+  goToNameRequest (): void {
+    if (LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)) {
+      window.location.href = ConfigHelper.getNameRequestUrl()
+    } else {
+      window.location.href = ConfigHelper.getNroUrl()
+    }
   }
 }
 </script>
@@ -126,6 +132,7 @@ export default class RequestNameView extends Vue {
     .status-link {
       font-size: 1rem;
       color: $BCgoveBueText1;
+      text-decoration: underline;
     }
 
     .status-link:hover {

--- a/auth-web/src/views/auth/home/RequestNameView.vue
+++ b/auth-web/src/views/auth/home/RequestNameView.vue
@@ -72,6 +72,7 @@ export default class RequestNameView extends Vue {
     { text: 'If your name is approved, you can use it to incorporate or register your business.' }
   ]
 
+  // open Name Request in current tab to retain current account and user
   goToNameRequestExisting (): void {
     if (LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)) {
       window.location.href = `${ConfigHelper.getNameRequestUrl()}existing`
@@ -79,6 +80,8 @@ export default class RequestNameView extends Vue {
       window.location.href = `${ConfigHelper.getNroUrl()}nro.htm?_flowId=anonymous-monitor-flow&_flowExecutionKey=e1s1`
     }
   }
+
+  // open Name Request in current tab to retain current account and user
   goToNameRequest (): void {
     if (LaunchDarklyService.getFlag(LDFlags.LinkToNewNameRequestApp)) {
       window.location.href = ConfigHelper.getNameRequestUrl()

--- a/auth-web/tests/unit/views/RequestNameView.spec.ts
+++ b/auth-web/tests/unit/views/RequestNameView.spec.ts
@@ -50,17 +50,17 @@ describe('RequestNameView.vue', () => {
   })
 
   it('renders the name request button', () => {
-    const nameRequestBtn = wrapper.vm.$el.querySelector('.v-btn')
+    const nameRequestBtn = wrapper.find('.btn-name-request')
 
     expect(nameRequestBtn).toBeDefined()
-    expect(nameRequestBtn.textContent).toContain('Request a Name')
+    expect(nameRequestBtn.text()).toContain('Request a Name')
   })
 
-  it('renders the name request link', () => {
-    const nameRequestLink = wrapper.vm.$el.querySelectorAll('a')
+  it('renders the name request status link', () => {
+    const statusLink = wrapper.find('.status-link')
 
-    expect(nameRequestLink[1]).toBeDefined()
-    expect(nameRequestLink[1].textContent).toContain('Check your Name Request Status')
+    expect(statusLink).toBeDefined()
+    expect(statusLink.text()).toContain('Check your Name Request Status')
   })
 
   it('renders the correct text and number of bullet points', () => {


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/7304

*Description of changes:*
- open NR UI in current tab instead of in new (blank) tab (3 places)
- it is hoped this will retain all session/cookie data so that account + user are retained from sbc-auth to NR UI
- also fixed/updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
