### PR TITLE
added encoding since idir usernames has backslashes

### DIFF
--- a/auth-web/src/services/user.services.ts
+++ b/auth-web/src/services/user.services.ts
@@ -8,7 +8,7 @@ import { axios } from '@/util/http-util.ts'
 
 export default class UserService {
   static async getUserProfile (identifier: string): Promise<AxiosResponse<User>> {
-    return axios.get(`${ConfigHelper.getAuthAPIUrl()}/users/${identifier}`)
+    return axios.get(`${ConfigHelper.getAuthAPIUrl()}/users/${encodeURIComponent(identifier)}`)
   }
 
   static async getRoles (): Promise<AxiosResponse<RoleInfo[]>> {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6895

*Description of changes:*

While testing its found out that since idir has backslashes , the network call to user endpoint fails.Added a url encode for this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
