### PR TITLE
7417 - pending tasks in asc order

### DIFF
--- a/auth-api/src/auth_api/models/task.py
+++ b/auth-api/src/auth_api/models/task.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import relationship
 
 from .base_model import BaseModel
 from .db import db
+from ..utils.enums import TaskRelationshipStatus
 
 
 class Task(BaseModel):
@@ -54,7 +55,11 @@ class Task(BaseModel):
         if task_status:
             query = query.filter(Task.status == task_status)
         if task_relationship_status:
-            query = query.filter(Task.relationship_status == task_relationship_status)
+            if task_relationship_status == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value:
+                query = query.filter(Task.relationship_status == task_relationship_status).order_by(
+                    Task.date_submitted.asc())
+            else:
+                query = query.filter(Task.relationship_status == task_relationship_status)
 
         # Add pagination
         pagination = query.paginate(per_page=limit, page=page)

--- a/auth-api/tests/unit/models/test_task.py
+++ b/auth-api/tests/unit/models/test_task.py
@@ -116,3 +116,32 @@ def test_task_model_account_id(session):
     assert task.id is not None
     assert task.name == 'TEST'
     assert task.account_id == 10
+
+
+def test_fetch_pending_tasks_descending(session):  # pylint:disable=unused-argument
+    """Assert that we can fetch all tasks."""
+    user = factory_user_model()
+    task = TaskModel(name='TEST 1', date_submitted=datetime.now(),
+                     relationship_type=TaskRelationshipType.ORG.value,
+                     relationship_id=10, type=TaskTypePrefix.NEW_ACCOUNT_STAFF_REVIEW.value,
+                     status=TaskStatus.OPEN.value,
+                     related_to=user.id,
+                     relationship_status=TaskRelationshipStatus.PENDING_STAFF_REVIEW.value)
+    task.save()
+    task = TaskModel(name='TEST 2', date_submitted=datetime(2021, 5, 25),
+                     relationship_type=TaskRelationshipType.ORG.value,
+                     relationship_id=10, type=TaskTypePrefix.NEW_ACCOUNT_STAFF_REVIEW.value,
+                     status=TaskStatus.OPEN.value,
+                     related_to=user.id,
+                     relationship_status=TaskRelationshipStatus.PENDING_STAFF_REVIEW.value)
+    task.save()
+    task_type = TaskTypePrefix.NEW_ACCOUNT_STAFF_REVIEW.value
+
+    found_tasks, count = TaskModel.fetch_tasks(
+        task_relationship_status=TaskRelationshipStatus.PENDING_STAFF_REVIEW.value,
+        task_type=task_type,
+        task_status=TaskStatus.OPEN.value, page=1, limit=2)
+    assert found_tasks
+    assert found_tasks[0].name == 'TEST 2'
+    assert found_tasks[1].name == 'TEST 1'
+    assert count == 2


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/7417

*Description of changes:*

- Updated task model fetch_tasks logic to order pending tasks by ascending order
- Added a test case for that


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
