### PR TITLE
PAD confirmation mail/BCEID flow fix

### DIFF
--- a/auth-api/src/auth_api/services/task.py
+++ b/auth-api/src/auth_api/services/task.py
@@ -62,19 +62,13 @@ class Task:  # pylint: disable=too-many-instance-attributes
         return obj
 
     @staticmethod
-    def create_task(task_info: dict, do_commit: bool = True, user: UserModel = None, origin_url: str = None):
+    def create_task(task_info: dict, do_commit: bool = True):
         """Create a new task record."""
         current_app.logger.debug('<create_task ')
         task_model = TaskModel(**camelback2snake(task_info))
         task_model.flush()
         if do_commit:  # Task mostly comes as a part of parent transaction.So do not commit unless asked.
             db.session.commit()
-
-        # Send task creation mail to staff for review
-        task_relationship_type = task_info.get('relationshipType')
-        if task_relationship_type == TaskRelationshipType.ORG.value:
-            from auth_api.services import Org as OrgService  # pylint:disable=cyclic-import, import-outside-toplevel
-            OrgService.send_staff_review_account_reminder(user, task_model.id, origin_url)
 
         current_app.logger.debug('>create_task ')
         return Task(task_model)

--- a/auth-api/src/auth_api/utils/user_context.py
+++ b/auth-api/src/auth_api/utils/user_context.py
@@ -46,6 +46,7 @@ class UserContext:  # pylint: disable=too-many-instance-attributes
         self._user_name: str = getattr(user_model, 'username',
                                        token_info.get('username', token_info.get('preferred_username', None)))
         self._first_name: str = token_info.get('firstname', None)
+        self._last_name: str = token_info.get('lastname', None)
         self._bearer_token: str = _get_token()
         self._roles: list = token_info.get('realm_access', None).get('roles', None) if 'realm_access' in token_info \
             else None
@@ -56,12 +57,17 @@ class UserContext:  # pylint: disable=too-many-instance-attributes
     @property
     def user_name(self) -> str:
         """Return the user_name."""
-        return self._user_name.upper() if self._user_name else None
+        return self._user_name if self._user_name else None
 
     @property
     def first_name(self) -> str:
-        """Return the user_name."""
+        """Return the user_first_name."""
         return self._first_name
+
+    @property
+    def last_name(self) -> str:
+        """Return the user_last_name."""
+        return self._last_name
 
     @property
     def user_id(self) -> str:


### PR DESCRIPTION
- PAD confirmation mail not working because of wrong case

     Auth api was sending the user name is upper case.Which made the DB look up for user name to fail.Changed user context not to upper case the user name

- Fix for BCEID status not setting
   
    Separated the mailing part so that mails are being sent after transaction is commited.
    Moved bcied status change before org.commit so that it gets commited to DB.



*Issue #:*
https://github.com/bcgov/entity/issues/7533
https://github.com/bcgov/entity/issues/7393

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
