### PR TITLE
Feature/6921-duplicate accounts view-page reload

### DIFF
--- a/auth-web/src/store/modules/user.ts
+++ b/auth-web/src/store/modules/user.ts
@@ -261,7 +261,18 @@ export default class UserModule extends VuexModule {
   public async getUserAccountSettings () {
     const response = await UserService.getUserAccountSettings(this.context.state['userProfile'].keycloakGuid)
     if (response && response.data) {
-      const orgs = response.data.filter(userSettings => (userSettings.type === 'ACCOUNT'))
+      // filter by account type and sort by name
+      const orgs = response.data.filter(userSettings => (userSettings.type === 'ACCOUNT')).sort((a, b) => {
+        var accountAName = a.label.toUpperCase() // ignore upper and lowercase
+        var accountBName = b.label.toUpperCase() // ignore upper and lowercase
+        if (accountAName < accountBName) {
+          return -1
+        }
+        if (accountAName > accountBName) {
+          return 1
+        }
+        return 0
+      })
       return orgs
     }
     return []

--- a/auth-web/src/store/modules/user.ts
+++ b/auth-web/src/store/modules/user.ts
@@ -261,18 +261,8 @@ export default class UserModule extends VuexModule {
   public async getUserAccountSettings () {
     const response = await UserService.getUserAccountSettings(this.context.state['userProfile'].keycloakGuid)
     if (response && response.data) {
-      // filter by account type and sort by name
-      const orgs = response.data.filter(userSettings => (userSettings.type === 'ACCOUNT')).sort((a, b) => {
-        var accountAName = a.label.toUpperCase() // ignore upper and lowercase
-        var accountBName = b.label.toUpperCase() // ignore upper and lowercase
-        if (accountAName < accountBName) {
-          return -1
-        }
-        if (accountAName > accountBName) {
-          return 1
-        }
-        return 0
-      })
+      // filter by account type and sort by name(label)
+      const orgs = response.data.filter(userSettings => (userSettings.type === 'ACCOUNT')).sort((a, b) => a.label.localeCompare(b.label))
       return orgs
     }
     return []

--- a/auth-web/src/views/auth/create-account/DuplicateAccountWarningView.vue
+++ b/auth-web/src/views/auth/create-account/DuplicateAccountWarningView.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 import { OrgWithAddress, Organization } from '@/models/Organization'
 import { Address } from '@/models/address'
 import { Pages } from '@/util/constants'
@@ -66,23 +66,32 @@ export default class DuplicateAccountWarningView extends Vue {
     @OrgModule.State('currentOrganization') private currentOrganization!: Organization
     @OrgModule.Action('addOrgSettings') private addOrgSettings!: (currentOrganization: Organization) => Promise<UserSettings>
     @OrgModule.Action('syncOrganization') private syncOrganization!: (orgId: number) => Promise<Organization>
+    @UserModule.Action('getUserAccountSettings') private getUserAccountSettings!: () => Promise<any>
     private orgsOfUser: OrgWithAddress[] = []
     private isLoading: boolean = false
     @Prop({ default: '' }) redirectToUrl !: string
 
     private async mounted () {
+      if (!Array.isArray(this.currentUserAccountSettings) || !this.currentUserAccountSettings.length) {
+        await this.getUserAccountSettings()
+      }
+    }
+    @Watch('currentUserAccountSettings', { immediate: true })
+    private onCurrentUserAccountSettings (): void {
       try {
-        this.isLoading = true
-        this.currentUserAccountSettings.map(async (accountsetting: UserSettings) => {
-          const orgId = parseInt(accountsetting.id)
-          const orgAdminContact = await this.getOrgAdminContact(orgId)
-          const orgOfUser: OrgWithAddress = {
-            id: orgId,
-            name: accountsetting.label,
-            addressLine: `${orgAdminContact.street} ${orgAdminContact.city} ${orgAdminContact.region} ${orgAdminContact.postalCode} ${orgAdminContact.country}`
-          }
-          this.orgsOfUser.push(orgOfUser)
-        })
+        if (Array.isArray(this.currentUserAccountSettings) && this.currentUserAccountSettings.length) {
+          this.isLoading = true
+          this.currentUserAccountSettings.map(async (accountsetting: UserSettings) => {
+            const orgId = parseInt(accountsetting.id)
+            const orgAdminContact = await this.getOrgAdminContact(orgId)
+            const orgOfUser: OrgWithAddress = {
+              id: orgId,
+              name: accountsetting.label,
+              addressLine: `${orgAdminContact.street} ${orgAdminContact.city} ${orgAdminContact.region} ${orgAdminContact.postalCode} ${orgAdminContact.country}`
+            }
+            this.orgsOfUser.push(orgOfUser)
+          })
+        }
       } catch (err) {
         // eslint-disable-next-line no-console
         console.log(`Error while loading duplicate accounts ${err}`)

--- a/auth-web/src/views/auth/create-account/DuplicateAccountWarningView.vue
+++ b/auth-web/src/views/auth/create-account/DuplicateAccountWarningView.vue
@@ -72,16 +72,16 @@ export default class DuplicateAccountWarningView extends Vue {
     @Prop({ default: '' }) redirectToUrl !: string
 
     private async mounted () {
-      if (!Array.isArray(this.currentUserAccountSettings) || !this.currentUserAccountSettings.length) {
+      if (!this.currentUserAccountSettings?.length) {
         await this.getUserAccountSettings()
       }
     }
     @Watch('currentUserAccountSettings', { immediate: true })
-    private onCurrentUserAccountSettings (): void {
+    private async onCurrentUserAccountSettings (): Promise<void> {
       try {
-        if (Array.isArray(this.currentUserAccountSettings) && this.currentUserAccountSettings.length) {
+        if (this.currentUserAccountSettings?.length) {
           this.isLoading = true
-          this.currentUserAccountSettings.map(async (accountsetting: UserSettings) => {
+          this.orgsOfUser = await Promise.all(this.currentUserAccountSettings.map(async (accountsetting: UserSettings) => {
             const orgId = parseInt(accountsetting.id)
             const orgAdminContact = await this.getOrgAdminContact(orgId)
             const orgOfUser: OrgWithAddress = {
@@ -89,8 +89,8 @@ export default class DuplicateAccountWarningView extends Vue {
               name: accountsetting.label,
               addressLine: `${orgAdminContact.street} ${orgAdminContact.city} ${orgAdminContact.region} ${orgAdminContact.postalCode} ${orgAdminContact.country}`
             }
-            this.orgsOfUser.push(orgOfUser)
-          })
+            return orgOfUser
+          }))
         }
       } catch (err) {
         // eslint-disable-next-line no-console

--- a/auth-web/src/views/auth/create-account/DuplicateAccountWarningView.vue
+++ b/auth-web/src/views/auth/create-account/DuplicateAccountWarningView.vue
@@ -94,6 +94,7 @@ export default class DuplicateAccountWarningView extends Vue {
     private async navigateToRedirectUrl (accountId: number): Promise<void> {
       await this.syncOrganization(accountId)
       await this.addOrgSettings(this.currentOrganization)
+      this.$store.commit('updateHeader')
       if (this.redirectToUrl) {
         window.location.assign(this.redirectToUrl.toString())
       } else {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6921

*Description of changes:*
- On page reload, load existing accounts in duplicate account screen


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
