### PR TITLE
changes to url encode the account creation route

### DIFF
--- a/auth-api/src/auth_api/config.py
+++ b/auth-api/src/auth_api/config.py
@@ -151,8 +151,11 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     # url for the front end app
     WEB_APP_URL = os.getenv('WEB_APP_URL')
+
     # url for the front end app
-    BCEID_ACCOUNT_SETUP_ROUTE = os.getenv('BCEID_ACCOUNT_SETUP_ROUTE', 'signin/bceid/setup-non-bcsc-account')
+    BCEID_SIGNIN_ROUTE = os.getenv('BCEID_ACCOUNT_SETUP_ROUTE', 'signin/bceid')
+    # url for the front end app
+    BCEID_ACCOUNT_SETUP_ROUTE = os.getenv('BCEID_ACCOUNT_SETUP_ROUTE', 'setup-non-bcsc-account')
 
     try:
         MAX_NUMBER_OF_ORGS = int(os.getenv('MAX_NUMBER_OF_ORGS'))

--- a/auth-api/src/auth_api/services/task.py
+++ b/auth-api/src/auth_api/services/task.py
@@ -15,10 +15,11 @@
 
 This module manages the tasks.
 """
+import urllib
 from datetime import datetime
 from typing import Dict
 
-from flask import current_app, g
+from flask import current_app
 from jinja2 import Environment, FileSystemLoader
 from sbc_common_components.tracing.service_tracing import ServiceTracing  # noqa: I001
 
@@ -150,8 +151,9 @@ class Task:  # pylint: disable=too-many-instance-attributes
             'applicationDate': f"{task_model.created.strftime('%m/%d/%Y')}",
             'accountId': task_model.relationship_id,
             'emailAddresses': admin_email,
-            'contextUrl': f"{g.get('origin_url','')}/{current_app.config.get('WEB_APP_URL')}"
-                          f"/{current_app.config.get('BCEID_ACCOUNT_SETUP_ROUTE')}/{org.id}"
+            'contextUrl': f"{current_app.config.get('WEB_APP_URL')}"
+                          f"/{current_app.config.get('BCEID_SIGNIN_ROUTE')}/"
+                          f"{urllib.parse.quote_plus({current_app.config.get('BCEID_ACCOUNT_SETUP_ROUTE')}/{org.id})}"
         }
         try:
             publish_to_mailer('resubmitBceidOrg', org_id=org.id, data=data)

--- a/auth-api/src/auth_api/services/task.py
+++ b/auth-api/src/auth_api/services/task.py
@@ -146,6 +146,8 @@ class Task:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def _notify_admin_about_hold(org, task_model):
         admin_email = ContactLinkModel.find_by_user_id(org.members[0].user.id).contact.email
+        create_account_signin_route = urllib.parse.quote_plus(f"{current_app.config.get('BCEID_ACCOUNT_SETUP_ROUTE')}/"
+                                                              f'{org.id}')
         data = {
             'reason': task_model.remarks,
             'applicationDate': f"{task_model.created.strftime('%m/%d/%Y')}",
@@ -153,7 +155,7 @@ class Task:  # pylint: disable=too-many-instance-attributes
             'emailAddresses': admin_email,
             'contextUrl': f"{current_app.config.get('WEB_APP_URL')}"
                           f"/{current_app.config.get('BCEID_SIGNIN_ROUTE')}/"
-                          f"{urllib.parse.quote_plus({current_app.config.get('BCEID_ACCOUNT_SETUP_ROUTE')}/{org.id})}"
+                          f'{create_account_signin_route}'
         }
         try:
             publish_to_mailer('resubmitBceidOrg', org_id=org.id, data=data)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/7781

*Description of changes:*
Need to make the url after signin route to be encoded


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
