### PR TITLE
Bug/7928

### DIFF
--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -113,6 +113,7 @@
                 :address="baseAddress"
                 @update:address="updateAddress"
                 @valid="checkBaseAddressValidity"
+                :key="baseAddress.postalCode"
               />
             </div>
           </template>

--- a/auth-web/src/components/auth/common/ConfirmCancelButton.vue
+++ b/auth-web/src/components/auth/common/ConfirmCancelButton.vue
@@ -68,10 +68,10 @@ export default class ConfirmCancelButton extends Vue {
   }
 
   private async confirmDialogResponse (response) {
-    this.$refs.confirmCancelDialog.close()
     if (response) {
-      await this.clickConfirm()
+      this.clickConfirm()
     }
+    this.$refs.confirmCancelDialog.close()
   }
 
   private async clickConfirm () {

--- a/auth-web/src/components/auth/common/ConfirmCancelButton.vue
+++ b/auth-web/src/components/auth/common/ConfirmCancelButton.vue
@@ -60,7 +60,7 @@ export default class ConfirmCancelButton extends Vue {
   // for not to clear current org values [for account change , while clicking on cancel , current org has to stay]
   @Prop({ default: true }) clearCurrentOrg: boolean
 
-  @OrgModule.Action('setCurrentOrganizationFromUserAccountSettings') private setCurrentOrganizationFromUserAccountSettings!: () => Promise<any>
+  @OrgModule.Action('setCurrentOrganizationFromUserAccountSettings') private setCurrentOrganizationFromUserAccountSettings!: () => Promise<void>
   @OrgModule.Action('resetAccountSetupProgress') private resetAccountSetupProgress!: () => Promise<void>
 
   $refs: {

--- a/auth-web/src/components/auth/common/ConfirmCancelButton.vue
+++ b/auth-web/src/components/auth/common/ConfirmCancelButton.vue
@@ -38,15 +38,13 @@ import { Component, Emit, Prop } from 'vue-property-decorator'
 import ModalDialog from '@/components/auth/common/ModalDialog.vue'
 import Vue from 'vue'
 import { mapActions } from 'vuex'
+import { namespace } from 'vuex-class'
+
+const OrgModule = namespace('org')
 
 @Component({
   components: {
     ModalDialog
-  },
-  methods: {
-    ...mapActions('org', [
-      'resetAccountSetupProgress'
-    ])
   }
 })
 export default class ConfirmCancelButton extends Vue {
@@ -62,27 +60,36 @@ export default class ConfirmCancelButton extends Vue {
   // for not to clear current org values [for account change , while clicking on cancel , current org has to stay]
   @Prop({ default: true }) clearCurrentOrg: boolean
 
-  private readonly resetAccountSetupProgress!: () => Promise<void>
+  @OrgModule.Action('setCurrentOrganizationFromUserAccountSettings') private setCurrentOrganizationFromUserAccountSettings!: () => Promise<any>
+  @OrgModule.Action('resetAccountSetupProgress') private resetAccountSetupProgress!: () => Promise<void>
 
   $refs: {
       confirmCancelDialog: ModalDialog
   }
 
-  private confirmDialogResponse (response) {
-    if (response) {
-      this.clickConfirm()
-    }
+  private async confirmDialogResponse (response) {
     this.$refs.confirmCancelDialog.close()
+    if (response) {
+      await this.clickConfirm()
+    }
   }
 
   private async clickConfirm () {
-    if (this.clearCurrentOrg) {
-      await this.resetAccountSetupProgress()
-    }
-    if (this.isEmit) {
-      this.emitClickConfirm()
-    } else {
-      this.$router.push(this.targetRoute)
+    try {
+      if (this.clearCurrentOrg) {
+        await this.resetAccountSetupProgress()
+        await this.setCurrentOrganizationFromUserAccountSettings()
+        // Update header
+        await this.$store.commit('updateHeader')
+      }
+      if (this.isEmit) {
+        this.emitClickConfirm()
+      } else {
+        this.$router.push(this.targetRoute)
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log('Error while cancelling account creation flow', err)
     }
   }
 

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -1096,7 +1096,7 @@ export default class OrgModule extends VuexModule {
     return response
   }
 
-  // Check if user has any accounts, if any, default the first opne as the selected org.
+  // Check if user has any accounts, if any, default the first returned value as the selected org.
   @Action({ rawError: true })
   public async setCurrentOrganizationFromUserAccountSettings (): Promise<void> {
     const response = await UserService.getUserAccountSettings(this.context.rootState.user.userProfile?.keycloakGuid)

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -1095,4 +1095,20 @@ export default class OrgModule extends VuexModule {
     const response = await OrgService.getContactForOrg(orgId)
     return response
   }
+
+  // Check if user has any accounts, if any, default the first opne as the selected org.
+  @Action({ rawError: true })
+  public async setCurrentOrganizationFromUserAccountSettings (): Promise<void> {
+    const response = await UserService.getUserAccountSettings(this.context.rootState.user.userProfile?.keycloakGuid)
+    if (response && response.data) {
+      // filter by account type and default first returned value as the current organization
+      const orgs = response.data.filter(userSettings => (userSettings.type === 'ACCOUNT'))
+      if (orgs && orgs.length) {
+        const orgId = +orgs[0].id
+        // sync org and add to session
+        await this.syncOrganization(orgId)
+        await this.addOrgSettings(this.context.state['currentOrganization'])
+      }
+    }
+  }
 }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/7928

*Description of changes:*

- When cancelling account setup, we check if there is an existing account linked with user, we select the first value and syn as current org in store.
- refresh account address in accoutn info page


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
