### PR TITLE
account staff review fix

### DIFF
--- a/auth-api/src/auth_api/models/task.py
+++ b/auth-api/src/auth_api/models/task.py
@@ -16,7 +16,7 @@
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
-from ..utils.enums import TaskRelationshipStatus
+from ..utils.enums import TaskRelationshipStatus, TaskStatus
 from .base_model import BaseModel
 from .db import db
 
@@ -69,3 +69,11 @@ class Task(BaseModel):
     def find_by_task_id(cls, task_id):
         """Find a task instance that matches the provided id."""
         return db.session.query(Task).filter_by(id=task_id).first()
+
+    @classmethod
+    def find_by_task_relationship_id(cls, relationship_id: int, task_relationship_type: str,
+                                     task_status: str = TaskStatus.OPEN.value):
+        """Find a task instance that related to the relationship id ( may be an ORG or a PRODUCT."""
+        return db.session.query(Task).filter(Task.relationship_id == relationship_id,
+                                             Task.relationship_type == task_relationship_type,
+                                             task_status == task_status).first()

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -838,7 +838,7 @@ class Org:  # pylint: disable=too-many-public-methods
             'userLastName': last_name
         }
         try:
-            publish_to_mailer('staffReviewAccount', data=data)
+            publish_to_mailer('staffReviewAccount', org_id=relationship_id, data=data)
             current_app.logger.debug('<send_staff_review_account_reminder')
         except Exception as e:  # noqa=B901
             current_app.logger.error('<send_staff_review_account_reminder failed')

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -29,6 +29,7 @@ from auth_api.models import ContactLink as ContactLinkModel
 from auth_api.models import Membership as MembershipModel
 from auth_api.models import Org as OrgModel
 from auth_api.models import User as UserModel
+from auth_api.models import Task as TaskModel
 from auth_api.models.affidavit import Affidavit as AffidavitModel
 from auth_api.schemas import ContactSchema, InvitationSchema, OrgSchema
 from auth_api.services.validators.access_type import validate as access_type_validate
@@ -52,7 +53,6 @@ from .products import Product as ProductService
 from .rest_service import RestService
 from .task import Task as TaskService
 from .validators.validator_response import ValidatorResponse
-
 
 ENV = Environment(loader=FileSystemLoader('.'), autoescape=True)
 
@@ -133,7 +133,7 @@ class Org:  # pylint: disable=too-many-public-methods
         # Send an email to staff to remind review the pending account
         is_bceid_status_handling_needed = access_type in (AccessType.EXTRA_PROVINCIAL.value,
                                                           AccessType.REGULAR_BCEID.value) \
-            and not AffidavitModel.find_approved_by_user_id(user_id=user_id)
+                                          and not AffidavitModel.find_approved_by_user_id(user_id=user_id)
         if is_bceid_status_handling_needed:
             Org._handle_bceid_status_and_notification(org)
 
@@ -815,11 +815,15 @@ class Org:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     @user_context
-    def send_staff_review_account_reminder(org_id, origin_url, **kwargs):
+    def send_staff_review_account_reminder(org_id, origin_url, task_relationship_type=TaskRelationshipType.ORG.value,
+                                           **kwargs):
         """Send staff review account reminder notification."""
         current_app.logger.debug('<send_staff_review_account_reminder')
         recipient = current_app.config.get('STAFF_ADMIN_EMAIL')
-        context_path = f'review-account/{org_id}'
+        # Get task id that is related with the task. Task Relationship Type can be ORG or PRODUCT.
+        task = TaskModel.find_by_task_relationship_id(task_relationship_type=task_relationship_type,
+                                                      relationship_id=org_id)
+        context_path = f'review-account/{task.id}'
         app_url = '{}/{}'.format(origin_url, current_app.config.get('AUTH_WEB_TOKEN_CONFIRM_PATH'))
         review_url = '{}/{}'.format(app_url, context_path)
         user_from_context: UserContext = kwargs['user_context']
@@ -827,14 +831,14 @@ class Org:  # pylint: disable=too-many-public-methods
         last_name = user_from_context.last_name
 
         data = {
-            'accountId': org_id,
+            'accountId': task.id,
             'emailAddresses': recipient,
             'contextUrl': review_url,
             'userFirstName': first_name,
             'userLastName': last_name
         }
         try:
-            publish_to_mailer('staffReviewAccount', org_id=org_id, data=data)
+            publish_to_mailer('staffReviewAccount', org_id=task.id, data=data)
             current_app.logger.debug('<send_staff_review_account_reminder')
         except Exception as e:  # noqa=B901
             current_app.logger.error('<send_staff_review_account_reminder failed')

--- a/auth-api/tests/unit/models/test_task.py
+++ b/auth-api/tests/unit/models/test_task.py
@@ -145,3 +145,22 @@ def test_fetch_pending_tasks_descending(session):  # pylint:disable=unused-argum
     assert found_tasks[0].name == 'TEST 2'
     assert found_tasks[1].name == 'TEST 1'
     assert count == 2
+
+
+def test_finding_task_by_relationship_id(session):  # pylint:disable=unused-argument
+    """Assert that we can fetch all tasks."""
+    user = factory_user_model()
+    task = TaskModel(name='TEST 1', date_submitted=datetime.now(),
+                     relationship_type=TaskRelationshipType.ORG.value,
+                     relationship_id=10, type=TaskTypePrefix.NEW_ACCOUNT_STAFF_REVIEW.value,
+                     status=TaskStatus.OPEN.value,
+                     related_to=user.id,
+                     relationship_status=TaskRelationshipStatus.PENDING_STAFF_REVIEW.value)
+    task.save()
+
+    found_task = TaskModel.find_by_task_relationship_id(
+        task_relationship_type=TaskRelationshipType.ORG.value, relationship_id=10)
+    assert found_task
+    assert found_task.name == 'TEST 1'
+    assert found_task.relationship_id == 10
+    assert found_task.status == TaskStatus.OPEN.value


### PR DESCRIPTION
*Issue #:*

- Staff accoutn mailer takes org_id rather than the related task id

*Description of changes:*

- extract task id in current method and send to mailer.
- add find task by relationship id in task model


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
