### PR TITLE
Fix the urls in deactivate page

### DIFF
--- a/auth-web/src/views/auth/AccountDeactivate.vue
+++ b/auth-web/src/views/auth/AccountDeactivate.vue
@@ -65,7 +65,7 @@
               depressed
               align="right"
               class="cancel-btn"
-              @click="closeConfirmModal()"
+              :to="accountInfoUrl"
               color="default"
               data-test="cancel-button"
               >Cancel
@@ -224,7 +224,7 @@ export default class AccountDeactivate extends Vue {
   }
 
   private get accountInfoUrl (): string {
-    return `/account/${this.currentOrganization?.id}`
+    return `/account/${this.currentOrganization?.id}/settings`
   }
 
   private async closeConfirmModal () {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/6270

*Description of changes:*

Fixed the cancel button urls to point to account info


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
