### PR TITLE
address save not working - fixed

### DIFF
--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -323,6 +323,7 @@ export default class AccountInfo extends Mixins(AccountChangeMixin, AccountMixin
   private isSuspensionReasonFormValid: boolean = false
   private addressChanged = false
   private readonly isBusinessAccount!: boolean
+  private originalAddress : Address // store the original address..do not modify it afterwards
 
   private readonly updateOrg!: (
     requestBody: CreateRequestBody
@@ -362,6 +363,7 @@ export default class AccountInfo extends Mixins(AccountChangeMixin, AccountMixin
     await this.syncAddress()
     // show this part only account is not anon
     if (!this.anonAccount) {
+      this.originalAddress = this.currentOrgAddress
       if (Object.keys(this.currentOrgAddress).length === 0) {
         this.isCompleteAccountInfo = false
         this.errorMessage = this.isAddressEditable ? 'Your account info is incomplete. Please enter your address in order to proceed.'
@@ -426,6 +428,7 @@ export default class AccountInfo extends Mixins(AccountChangeMixin, AccountMixin
   private updateAddress (address: Address) {
     this.addressChanged = true
     this.enableBtn()
+    this.setCurrentOrganizationAddress(address)
   }
 
   private async showSuspendAccountDialog (status) {
@@ -486,7 +489,7 @@ export default class AccountInfo extends Mixins(AccountChangeMixin, AccountMixin
 
     let createRequestBody: CreateRequestBody = {
     }
-    if (this.baseAddress && this.addressChanged && JSON.stringify(this.baseAddress) !== JSON.stringify(this.currentOrgAddress)) {
+    if (this.baseAddress && this.addressChanged && JSON.stringify(this.originalAddress) !== JSON.stringify(this.currentOrgAddress)) {
       createRequestBody.mailingAddress = { ...this.baseAddress }
     }
     if (this.branchName !== this.currentOrganization.branchName) {

--- a/auth-web/src/routes/index.ts
+++ b/auth-web/src/routes/index.ts
@@ -145,7 +145,7 @@ router.beforeEach((to, from, next) => {
           case LoginSource.BCEID:
             return next({ path: `/${Pages.CREATE_NON_BCSC_ACCOUNT}` })
         }
-      } else if ((store.state as any)?.org?.needMissingBusinessDetailsRedirect) {
+      } else if (store.getters['org/needMissingBusinessDetailsRedirect']) {
         return next({ path: `/${Pages.UPDATE_ACCOUNT}` })
       }
     }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/8306

*Description of changes:*

Earlier , every click on SAVE , address payload was going..I improved that login in previous ticket..But that didnt work.
So i capture the original first address in a variable and compare against the final address


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
