### PR TITLE
8572 Old Manage business dashboard updates

### DIFF
--- a/auth-web/src/assets/scss/theme.scss
+++ b/auth-web/src/assets/scss/theme.scss
@@ -66,3 +66,4 @@ $BCgovFontColorInverted: #ffffff;
 // App Colors
 $app-blue: #1669bb; // same as the Vuetify theme primary
 $app-lt-blue: #01336626; // LOW OPACITY PRIMARY BLUE
+$app-background-blue: #E4EDF7 // Hover Background Blue

--- a/auth-web/src/components/auth/manage-business/AddNameRequestForm.vue
+++ b/auth-web/src/components/auth/manage-business/AddNameRequestForm.vue
@@ -156,32 +156,10 @@ export default class AddNameRequestForm extends Vue {
           email: this.applicantEmail
         })
         if (nrResponse?.status === 201) {
-          // update the legal api if the status is success
-          const filingBody: BusinessRequest = {
-            filing: {
-              header: {
-                name: FilingTypes.INCORPORATION_APPLICATION,
-                accountId: this.currentOrganization.id
-              },
-              business: {
-                legalType: LegalTypes.BCOMP
-              },
-              incorporationApplication: {
-                nameRequest: {
-                  legalType: LegalTypes.BCOMP,
-                  nrNumber: this.nrNumber
-                }
-              }
-            }
-          }
-
-          const filingResponse = await this.createNamedBusiness(filingBody)
-          if (filingResponse?.errorMsg) {
-            this.$emit('add-unknown-error')
-          } else {
-            // emit event to let parent know business added
-            this.$emit('add-success')
-          }
+          // emit event to let parent know business added
+          this.$emit('add-success')
+        } else {
+          this.$emit('add-unknown-error')
         }
       } catch (exception) {
         if (exception.response?.status === StatusCodes.BAD_REQUEST) {

--- a/auth-web/src/components/auth/manage-business/AffiliatedEntityList.vue
+++ b/auth-web/src/components/auth/manage-business/AffiliatedEntityList.vue
@@ -171,9 +171,12 @@ export default class AffiliatedEntityList extends Vue {
   }
 
   private isApprovedForIA (business: Business): boolean {
+    // Split string tokens into an array to avoid false string matching
+    const supportedEntityFlags = LaunchDarklyService.getFlag(LDFlags.IaSupportedEntities)?.split(' ')
+
     return this.isNameRequest(business.corpType.code) &&
       business.nameRequest?.state === NrState.APPROVED &&
-      LaunchDarklyService.getFlag(LDFlags.IaSupportedEntities)?.includes(business.nameRequest?.legalType)
+        supportedEntityFlags?.includes(business.nameRequest?.legalType)
   }
 
   private isTemporaryBusinessRegistration (corpType: string): boolean {

--- a/auth-web/src/components/auth/manage-business/AffiliatedEntityList.vue
+++ b/auth-web/src/components/auth/manage-business/AffiliatedEntityList.vue
@@ -72,7 +72,7 @@
                   </template>
                   <v-list>
                     <v-list-item
-                        v-if="isNameRequest(item.corpType.code) && isApprovedForIA(item)"
+                        v-if="isApprovedForIA(item)"
                         class="actions-dropdown_item"
                         data-test="use-name-request-button"
                         @click="createDraftGoToDashboard(item)"
@@ -171,8 +171,9 @@ export default class AffiliatedEntityList extends Vue {
   }
 
   private isApprovedForIA (business: Business): boolean {
-    return business.nameRequest?.state === NrState.APPROVED &&
-        LaunchDarklyService.getFlag(LDFlags.IaSupportedEntities)?.includes(business.nameRequest?.legalType)
+    return this.isNameRequest(business.corpType.code) &&
+      business.nameRequest?.state === NrState.APPROVED &&
+      LaunchDarklyService.getFlag(LDFlags.IaSupportedEntities)?.includes(business.nameRequest?.legalType)
   }
 
   private isTemporaryBusinessRegistration (corpType: string): boolean {

--- a/auth-web/src/components/auth/manage-business/AffiliatedEntityList.vue
+++ b/auth-web/src/components/auth/manage-business/AffiliatedEntityList.vue
@@ -107,10 +107,11 @@
 <script lang="ts">
 import { Business, BusinessRequest, NameRequest } from '@/models/business'
 import { Component, Emit, Vue } from 'vue-property-decorator'
-import { CorpType, FilingTypes, LegalTypes, NrState, SessionStorageKeys } from '@/util/constants'
+import { CorpType, FilingTypes, LDFlags, LegalTypes, NrState, SessionStorageKeys } from '@/util/constants'
 import { Member, MembershipStatus, MembershipType, Organization, RemoveBusinessPayload } from '@/models/Organization'
 import { mapActions, mapMutations, mapState } from 'vuex'
 import ConfigHelper from '@/util/config-helper'
+import LaunchDarklyService from 'sbc-common-components/src/services/launchdarkly.services'
 import OrgModule from '@/store/modules/org'
 import TeamManagement from '@/components/auth/account-settings/team-management/TeamManagement.vue'
 import { getModule } from 'vuex-module-decorators'
@@ -170,7 +171,8 @@ export default class AffiliatedEntityList extends Vue {
   }
 
   private isApprovedForIA (business: Business): boolean {
-    return business.nameRequest?.state === NrState.APPROVED && business.nameRequest?.legalType === CorpType.BCOMP
+    return business.nameRequest?.state === NrState.APPROVED &&
+        LaunchDarklyService.getFlag(LDFlags.IaSupportedEntities)?.includes(business.nameRequest?.legalType)
   }
 
   private isTemporaryBusinessRegistration (corpType: string): boolean {

--- a/auth-web/src/components/auth/manage-business/AffiliatedEntityList.vue
+++ b/auth-web/src/components/auth/manage-business/AffiliatedEntityList.vue
@@ -29,7 +29,7 @@
             <div class="meta">
               <v-list-item-title v-if="isNumberedIncorporationApplication(item)">Numbered Benefit Company</v-list-item-title>
               <v-list-item-title v-if="!isNumberedIncorporationApplication(item)">{{ item.name }}</v-list-item-title>
-              <v-list-item-title v-if="!item.name && isNameRequest(item.corpType.code)">{{ item.nameRequest.names[0].name }}</v-list-item-title>
+              <v-list-item-title v-if="!item.name && isNameRequest(item.corpType.code)">{{ getApprovedName(item) }}</v-list-item-title>
               <v-list-item-subtitle v-if="isIncorporationNumber(item.corpType.code)">Incorporation Number: {{ item.businessIdentifier }}</v-list-item-subtitle>
               <v-list-item-subtitle v-if="isNameRequest(item.corpType.code)">Name Request ({{ item.businessIdentifier }})</v-list-item-subtitle>
               <v-list-item-subtitle v-if="isTemporaryBusinessRegistration(item.corpType.code)">Incorporation Application</v-list-item-subtitle>
@@ -182,8 +182,20 @@ export default class AffiliatedEntityList extends Vue {
   private isTemporaryBusinessRegistration (corpType: string): boolean {
     return corpType === CorpType.NEW_BUSINESS
   }
+
   private isNumberedIncorporationApplication (item: Business): boolean {
     return item.corpType.code === CorpType.NEW_BUSINESS && item.name === item.businessIdentifier
+  }
+
+  private getApprovedName (item: Business): any {
+    const approvedName = item => {
+      for (const nameItem of item.nameRequest?.names) {
+        if (nameItem.state === NrState.APPROVED) {
+          return nameItem.name
+        }
+      }
+    }
+    return approvedName(item) || item.nameRequest.names[0].name // Return first name if DRAFT (None Approved)
   }
 
   private customSort (items, index, isDescending) {

--- a/auth-web/src/components/auth/manage-business/EntityManagement.vue
+++ b/auth-web/src/components/auth/manage-business/EntityManagement.vue
@@ -91,6 +91,7 @@
         <AffiliatedEntityList
             @add-business="showAddBusinessModal()"
             @remove-business="showPasscodeResetOptionsModal($event)"
+            @add-failed-show-msg="showNRErrorModal"
         />
       </template>
 

--- a/auth-web/src/models/business.ts
+++ b/auth-web/src/models/business.ts
@@ -58,7 +58,7 @@ export interface NameRequest {
     applicantPhone?: string
 }
 
-// Names interface to match external data provided from namex.
+// Names interface to match external data provided from lear.
 export interface Names {
     /* eslint-disable camelcase */
     decision_text: string,

--- a/auth-web/src/models/business.ts
+++ b/auth-web/src/models/business.ts
@@ -23,7 +23,8 @@ export interface Business {
     name?: string
     contacts?: Contact[]
     corpType: CorpType,
-    folioNumber: string
+    folioNumber: string,
+    nameRequest?: NameRequest
 }
 
 export interface BusinessSearchResultDto {
@@ -48,8 +49,24 @@ export interface UpdateBusinessNamePayload {
 
 // see https://github.com/bcgov/business-schemas/blob/master/src/registry_schemas/schemas/name_request.json
 export interface NameRequest {
+    names?: Array<Names>
+    id?: number,
     legalType: string,
-    nrNumber?: string
+    nrNumber?: string,
+    state?: string,
+    applicantEmail?: string,
+    applicantPhone?: string
+}
+
+// Names interface to match external data provided from namex.
+export interface Names {
+    /* eslint-disable camelcase */
+    decision_text: string,
+    name_type_cd: string,
+    designation: string,
+    name: string,
+    state: string
+    /* eslint-disable camelcase */
 }
 
 export interface BusinessRequest {

--- a/auth-web/src/services/business.services.ts
+++ b/auth-web/src/services/business.services.ts
@@ -51,4 +51,8 @@ export default class BusinessService {
   static async resetBusinessPasscode (passcodeResetLoad: PasscodeResetLoad): Promise<AxiosResponse<any>> {
     return axios.patch(`${ConfigHelper.getAuthAPIUrl()}/entities/${passcodeResetLoad.businessIdentifier}`, { businessIdentifier: passcodeResetLoad.businessIdentifier, passcodeResetEmail: passcodeResetLoad.passcodeResetEmail, resetPasscode: passcodeResetLoad.resetPasscode })
   }
+
+  static async getNrData (nrNumber: string): Promise<AxiosResponse<any>> {
+    return axios.get(`${ConfigHelper.getLegalAPIUrl()}/nameRequests/${nrNumber}`)
+  }
 }

--- a/auth-web/src/store/modules/business.ts
+++ b/auth-web/src/store/modules/business.ts
@@ -44,14 +44,10 @@ export default class BusinessModule extends VuexModule {
           await BusinessService.getNrData(entity.businessIdentifier)
             .then(response => {
               if (response?.status >= 200 && response?.status < 300) {
-                // entity.name = response.data.names[0].name
-
                 BusinessService.updateBusinessName({
                   businessIdentifier: entity.businessIdentifier,
                   name: response.data.names[0].name
                 })
-                // eslint-disable-next-line no-console
-                console.log(response)
                 entity.nameRequest = {
                   names: response.data.names,
                   id: response.data.id,
@@ -69,8 +65,7 @@ export default class BusinessModule extends VuexModule {
         }
       }
     }
-    // eslint-disable-next-line no-console
-    console.log(response.data.entities)
+
     return response.data.entities
   }
 

--- a/auth-web/src/util/config-helper.ts
+++ b/auth-web/src/util/config-helper.ts
@@ -1,6 +1,7 @@
 import { Account, PaymentTypes, SessionStorageKeys } from '@/util/constants'
 
 import Axios from 'axios'
+import { NameRequest } from '@/models/business'
 
 /**
  * the configs are used since process.env doesnt play well when we hae only one build config and multiple deployments..so going for this
@@ -135,5 +136,12 @@ export default class ConfigHelper {
       [Account.PREMIUM]: [ PaymentTypes.PAD, PaymentTypes.BCOL ],
       [Account.UNLINKED_PREMIUM]: [ PaymentTypes.PAD ]
     }
+  }
+
+  static async setNrCredentials (nameRequest: NameRequest) {
+    // Set name request applicant info to retrieve on redirect
+    sessionStorage.setItem('BCREG-nrNum', nameRequest.nrNumber)
+    sessionStorage.setItem('BCREG-emailAddress', nameRequest.applicantEmail)
+    sessionStorage.setItem('BCREG-phoneNumber', nameRequest.applicantPhone)
   }
 }

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -176,7 +176,8 @@ export enum LDFlags {
     EnableGovmInvite = 'enable-govm-account-invite',
     HideProductPackage = 'hide-product-packages',
     EnableOrgNameAutoComplete = 'enable-org-name-auto-complete',
-    EnableBusinessTable = 'enable-business-table'
+    EnableBusinessTable = 'enable-business-table',
+    IaSupportedEntities = 'ia-supported-entities'
 }
 
 export enum DateFilterCodes {

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -128,6 +128,11 @@ export enum CorpType {
     NAME_REQUEST = 'NR'
 }
 
+export enum NrState {
+    APPROVED = 'APPROVED',
+    DRAFT = 'DRAFT',
+}
+
 export enum AccessType {
     REGULAR = 'REGULAR',
     EXTRA_PROVINCIAL = 'EXTRA_PROVINCIAL',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8572

*Description of changes:*
- Open button redirects to the Name Request app and queries Name Request for Display.

- Adds a button called "Use this name request" in drop down for Incorporations and this will launch draft IA. This button is not shown for unsupported NRs and BEN change of name/alteration (ie, only show for BEN IAs). Set Using a FF.

- "Remove" button relocated into Drop down menu.

 - We are using the combo button design. Open/drop down menu including remove and the 'Use this name Request' conditionally and "Remove"

 - Makes request to retrieve and populate Name Request data for any affiliation of NR Type.

 - Removes auto draft creation upon manually affiliating a name request and does so ONLY when selecting "Use this Name Request"

- Open action to open businesses regularly OR navigate to Name Request for NR affiliations.

- Set FF for controlling IA creations.

- When navigating to the NAME REQUEST - pass parameters required to pull up Existing NR Summary. ** stretch goal.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
