### PR TITLE
changes for supporting user role for revocation of api key

### DIFF
--- a/auth-api/src/auth_api/resources/org_api_keys.py
+++ b/auth-api/src/auth_api/resources/org_api_keys.py
@@ -25,7 +25,6 @@ from auth_api.tracer import Tracer
 from auth_api.utils.roles import Role
 from auth_api.utils.util import cors_preflight
 
-
 API = Namespace('keys', description='Endpoints for API Keys management')
 TRACER = Tracer.get_instance()
 
@@ -69,7 +68,7 @@ class OrgKey(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_jwt.has_one_of_roles([Role.SYSTEM.value])
+    @_jwt.has_one_of_roles([Role.SYSTEM.value, Role.STAFF_MANAGE_ACCOUNTS.value, Role.ACCOUNT_HOLDER.value])
     def delete(org_id, key):
         """Revoke API Key."""
         try:

--- a/auth-api/src/auth_api/resources/org_api_keys.py
+++ b/auth-api/src/auth_api/resources/org_api_keys.py
@@ -37,7 +37,7 @@ class OrgKeys(Resource):
     @staticmethod
     @TRACER.trace()
     @cors.crossdomain(origin='*')
-    @_jwt.has_one_of_roles([Role.SYSTEM.value])
+    @_jwt.has_one_of_roles([Role.SYSTEM.value, Role.STAFF_MANAGE_ACCOUNTS.value, Role.ACCOUNT_HOLDER.value])
     def get(org_id):
         """Get all API keys for the account."""
         return ApiGatewayService.get_api_keys(org_id), http_status.HTTP_200_OK

--- a/auth-api/src/auth_api/services/api_gateway.py
+++ b/auth-api/src/auth_api/services/api_gateway.py
@@ -103,7 +103,7 @@ class ApiGateway:
         current_app.logger.debug('<get_api_keys ')
         consumer_endpoint: str = current_app.config.get('API_GW_CONSUMERS_API_URL')
         gw_api_key: str = current_app.config.get('API_GW_KEY')
-
+        check_auth(one_of_roles=(ADMIN, STAFF), org_id=org_id)
         email_id = cls._get_email_id(org_id)
         try:
             consumers_response = RestService.get(

--- a/auth-api/src/auth_api/services/api_gateway.py
+++ b/auth-api/src/auth_api/services/api_gateway.py
@@ -19,10 +19,12 @@ from flask import current_app
 from requests.exceptions import HTTPError
 
 from auth_api.models.org import Org as OrgModel
+from auth_api.services.authorization import check_auth
 from auth_api.services.keycloak import KeycloakService
 from auth_api.services.rest_service import RestService
 from auth_api.utils.api_gateway import generate_client_representation
 from auth_api.utils.constants import GROUP_ACCOUNT_HOLDERS, GROUP_API_GW_USERS
+from auth_api.utils.roles import ADMIN, STAFF
 
 
 class ApiGateway:
@@ -83,6 +85,7 @@ class ApiGateway:
     def revoke_key(cls, org_id: int, api_key: str):
         """Revoke api key."""
         current_app.logger.debug('<revoke_key ')
+        check_auth(one_of_roles=(ADMIN, STAFF), org_id=org_id)
         consumer_endpoint: str = current_app.config.get('API_GW_CONSUMERS_API_URL')
         gw_api_key: str = current_app.config.get('API_GW_KEY')
         email_id = cls._get_email_id(org_id)

--- a/auth-api/tests/unit/api/test_org_api_keys.py
+++ b/auth-api/tests/unit/api/test_org_api_keys.py
@@ -79,7 +79,7 @@ def test_list_api_keys(client, jwt, session, keycloak_mock):  # pylint:disable=u
 def test_revoke_api_key(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that api keys can be revoked."""
     # First create an account
-    user_headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
+    user_headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_account_holder_user)
     rv = client.post('/api/v1/users', headers=user_headers, content_type='application/json')
     rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1), headers=user_headers,
                      content_type='application/json')

--- a/auth-api/tests/unit/api/test_org_api_keys.py
+++ b/auth-api/tests/unit/api/test_org_api_keys.py
@@ -52,9 +52,9 @@ def test_create_api_keys(client, jwt, session, keycloak_mock):  # pylint:disable
 def test_list_api_keys(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that api keys can be listed."""
     # First create an account
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
-    rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
-    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1), headers=headers,
+    user_header = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_account_holder_user)
+    client.post('/api/v1/users', headers=user_header, content_type='application/json')
+    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1), headers=user_header,
                      content_type='application/json')
     org_id = rv.json.get('id')
 
@@ -73,6 +73,9 @@ def test_list_api_keys(client, jwt, session, keycloak_mock):  # pylint:disable=u
                      }))
 
     rv = client.get(f'/api/v1/orgs/{org_id}/api-keys', headers=headers, content_type='application/json')
+    assert rv.json['consumer']['consumerKey']
+
+    rv = client.get(f'/api/v1/orgs/{org_id}/api-keys', headers=user_header, content_type='application/json')
     assert rv.json['consumer']['consumerKey']
 
 

--- a/auth-api/tests/unit/api/test_org_api_keys.py
+++ b/auth-api/tests/unit/api/test_org_api_keys.py
@@ -79,9 +79,9 @@ def test_list_api_keys(client, jwt, session, keycloak_mock):  # pylint:disable=u
 def test_revoke_api_key(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
     """Assert that api keys can be revoked."""
     # First create an account
-    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
-    rv = client.post('/api/v1/users', headers=headers, content_type='application/json')
-    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1), headers=headers,
+    user_headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
+    rv = client.post('/api/v1/users', headers=user_headers, content_type='application/json')
+    rv = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org1), headers=user_headers,
                      content_type='application/json')
     org_id = rv.json.get('id')
 
@@ -97,4 +97,7 @@ def test_revoke_api_key(client, jwt, session, keycloak_mock):  # pylint:disable=
     key = '7SmDGL4233wnp2dyXGSGGq7xutYlTzIN'  # from mock
 
     rv = client.delete(f'/api/v1/orgs/{org_id}/api-keys/{key}', headers=headers, content_type='application/json')
+    assert rv.status_code == 200
+
+    rv = client.delete(f'/api/v1/orgs/{org_id}/api-keys/{key}', headers=user_headers, content_type='application/json')
     assert rv.status_code == 200


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/7071

*Description of changes:*

Just added staff and user role to api key delete end point


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
