### PR TITLE
Changes for creating different keycloak clients for sandbox and prod consumers

### DIFF
--- a/auth-api/migrations/versions/be4475027882_rename_tables.py
+++ b/auth-api/migrations/versions/be4475027882_rename_tables.py
@@ -73,9 +73,7 @@ def upgrade():
     for table in tables:
         if table in skip_table or table.endswith(VERSION):
             continue
-        print('<<<<Processing starting for table', table)
         _rename_obj(inspector, metadata, table, table_mapping, tables)
-        print('Processing ended for table>>>', table)
 
 
 def downgrade():
@@ -88,16 +86,13 @@ def downgrade():
     for table in tables:
         if table in skip_table or table.endswith(VERSION):
             continue
-        print('<<<<Processing starting for table', table)
         _rename_obj(inspector, metadata, table, table_mapping_reversed, tables)
-        print('Processing ended for table>>>', table)
 
 
 def _rename_obj(inspector, metadata, table: str, name_dict, tables):
     _rename_fks(inspector, table, table_mapping)
     new_table_name: str = name_dict.get(table, '')
     if new_table_name:
-        print(f'New name found for Table : {table} to {new_table_name}')
         _rename_indexes(inspector, new_table_name, table)
         _rename_pk(inspector, new_table_name, table)
         _rename_sequence(metadata, new_table_name, table)
@@ -108,7 +103,6 @@ def _rename_obj(inspector, metadata, table: str, name_dict, tables):
             _rename_indexes(inspector, versioned_table_new_name, versioned_table_name)
             _rename_table(versioned_table_name, versioned_table_new_name)
 
-        print(f'Renaming Table Done for: {table} to {new_table_name}')
 
 
 def _suffix_version(table):
@@ -116,9 +110,7 @@ def _suffix_version(table):
 
 
 def _rename_table(table, new_table_name):
-    print(f'\t<<<<<<<<Renaming Table : {table} to {new_table_name} ')
     op.rename_table(table, new_table_name)
-    print(f'\tRenaming Done for Table : {table} to {new_table_name} >>>>>>>>>')
 
 
 def _rename_sequence(m, new_table_name, table):
@@ -130,9 +122,7 @@ def _rename_sequence(m, new_table_name, table):
         seq_name = re.search("nextval\(\'(.*)\'::regclass", seq).group(1)
         new_seq_name = seq_name.replace(table, new_table_name, 1)
         if seq_name != new_seq_name:
-            print(f'\t<<<<<<<<<Renaming PK : {seq_name} to {new_seq_name} of table {table}')
             op.execute(f'ALTER sequence {seq_name} RENAME TO {new_seq_name}')
-            print(f'\tRenaming PK : {seq_name} to {new_seq_name} of table {table}>>>>>>>>>>>')
 
 
 def _rename_pk(inspector, new_table_name, table):
@@ -140,9 +130,7 @@ def _rename_pk(inspector, new_table_name, table):
     pk_name = inspector.get_pk_constraint(table).get('name')
     new_pk_name = pk_name.replace(table, new_table_name, 1)
     if pk_name != new_pk_name:
-        print(f'\t<<<<<<<<<<Renaming PK : {pk_name} to {new_pk_name} of table {table}')
         op.execute(f'ALTER index {pk_name} RENAME TO {new_pk_name}')
-        print(f'\tRenaming Done for PK : {pk_name} to {new_pk_name} of table {table}>>>>>>>>>')
 
 
 def _rename_indexes(inspector, new_table_name, table):
@@ -151,9 +139,7 @@ def _rename_indexes(inspector, new_table_name, table):
         old_index_name = index.get('name')
         new_index_name = old_index_name.replace(table, new_table_name, 1)
         if old_index_name != new_index_name:
-            print(f'\t<<<<<<Renaming Index : {old_index_name} to {new_index_name} of table {table}')
             op.execute(f'ALTER index {old_index_name} RENAME TO {new_index_name}')
-            print(f'\tRenaming Index Done for: {old_index_name} to {new_index_name} of table {table}>>>>>>>>')
 
 
 def _rename_fks(inspector, table: str, name_dict):
@@ -171,6 +157,4 @@ def _rename_fks(inspector, table: str, name_dict):
         if referred_table_new_name:
             new_fk_name = fk_name.replace(referred_table, referred_table_new_name)
             if fk_name != new_fk_name:
-                print(f'\t<<<<<<<<<<Renaming Foriegn Key : {fk_name} to {new_fk_name} of table {table}')
                 op.execute(f'ALTER table "{table}" RENAME CONSTRAINT {fk_name} TO {new_fk_name}')
-                print(f'\tRenaming done for Foriegn Key : {fk_name} to {new_fk_name} of table {table}>>>>>>>>>>')

--- a/auth-api/src/auth_api/services/api_gateway.py
+++ b/auth-api/src/auth_api/services/api_gateway.py
@@ -18,12 +18,13 @@ from typing import Dict, List
 from flask import current_app
 from requests.exceptions import HTTPError
 
+from auth_api.exceptions import BusinessException, Error
 from auth_api.models.org import Org as OrgModel
 from auth_api.services.authorization import check_auth
 from auth_api.services.keycloak import KeycloakService
 from auth_api.services.rest_service import RestService
 from auth_api.utils.api_gateway import generate_client_representation
-from auth_api.utils.constants import GROUP_ACCOUNT_HOLDERS, GROUP_API_GW_USERS
+from auth_api.utils.constants import GROUP_ACCOUNT_HOLDERS, GROUP_API_GW_SANDBOX_USERS, GROUP_API_GW_USERS
 from auth_api.utils.roles import ADMIN, STAFF
 
 
@@ -32,41 +33,29 @@ class ApiGateway:
 
     @classmethod
     def create_key(cls, org_id: int, request_json: Dict[str, str]):
-        """Create a key for the account."""
+        """Create a key for the account.
+
+        Steps:
+        A - If consumer doesn't exist,
+        1 - Create a consumer for PROD and one for SANDBOX
+        2 - Keycloak Client created for Sandbox consumer added to sandbox group (new role for sandbox)
+        3 - Keycloak client created for PROD consumer added to prod group
+        B - If consumer already exists,
+        1 - Create key for specific environment.
+        """
         current_app.logger.debug('<create_key ')
         env = request_json.get('environment', 'sandbox')
         name = request_json.get('keyName')
         org: OrgModel = OrgModel.find_by_id(org_id)
         # first find if there is a consumer created for this account.
         consumer_endpoint: str = current_app.config.get('API_GW_CONSUMERS_API_URL')
-        gw_api_key = current_app.config.get('API_GW_KEY') if env == 'prod' else current_app.config.get(
-            'API_GW_NON_PROD_KEY')
-        email = cls._get_email_id(org_id)
-
-        if not org.has_api_access:  # If the account doesn't have api access, add it
-            client_rep = generate_client_representation(org_id, current_app.config.get('API_GW_KC_CLIENT_ID_PATTERN'))
-            KeycloakService.create_client(client_rep)
-            service_account = KeycloakService.get_service_account_user(client_rep.get('id'))
-            KeycloakService.add_user_to_group(service_account.get('id'), GROUP_API_GW_USERS)
-            KeycloakService.add_user_to_group(service_account.get('id'), GROUP_ACCOUNT_HOLDERS)
-
-            # Create a consumer with the keycloak client id and secret
-            create_consumer_payload = dict(email=email,
-                                           firstName=org.name,
-                                           lastName=org.branch_name or 'BCR',
-                                           userName=org.name,
-                                           clientId=client_rep.get('clientId'),
-                                           clientSecret=client_rep.get('secret'),
-                                           apiAccess=['ALL_API'],
-                                           apiKeyName=name)
-            api_key_response = RestService.post(
-                f'{consumer_endpoint}/mc/v1/consumers',
-                additional_headers={'x-apikey': gw_api_key},
-                data=create_consumer_payload,
-                generate_token=False
-            )
+        gw_api_key = ApiGateway._get_api_gw_key(env)
+        email = cls._get_email_id(org_id, env)
+        if not cls._consumer_exists(email):  # If the account doesn't have api access, add it
+            cls._create_consumer(name, org, env=env)
             org.has_api_access = True
             org.save()
+            response = cls.get_api_keys(org_id)
         else:
             # Create additional API Key if a consumer exists
             api_key_response = RestService.post(
@@ -78,8 +67,44 @@ class ApiGateway:
                 ),
                 generate_token=False
             )
+            response = api_key_response.json()
 
-        return api_key_response.json()
+        return response
+
+    @classmethod
+    def _get_api_gw_key(cls, env):
+        return current_app.config.get('API_GW_KEY') if env == 'prod' else current_app.config.get(
+            'API_GW_NON_PROD_KEY')
+
+    @classmethod
+    def _create_consumer(cls, name, org, env):
+        """Create an API Gateway consumer."""
+        consumer_endpoint: str = current_app.config.get('API_GW_CONSUMERS_API_URL')
+        gw_api_key = cls._get_api_gw_key(env)
+        email = cls._get_email_id(org.id, env)
+        client_rep = generate_client_representation(org.id, current_app.config.get('API_GW_KC_CLIENT_ID_PATTERN'), env)
+        KeycloakService.create_client(client_rep)
+        service_account = KeycloakService.get_service_account_user(client_rep.get('id'))
+
+        KeycloakService.add_user_to_group(service_account.get('id'),
+                                          GROUP_API_GW_USERS if env == 'prod' else GROUP_API_GW_SANDBOX_USERS)
+        KeycloakService.add_user_to_group(service_account.get('id'), GROUP_ACCOUNT_HOLDERS)
+        # Create a consumer with the keycloak client id and secret
+        create_consumer_payload = dict(email=email,
+                                       firstName=org.name,
+                                       lastName=org.branch_name or 'BCR',
+                                       userName=org.name,
+                                       clientId=client_rep.get('clientId'),
+                                       clientSecret=client_rep.get('secret'),
+                                       apiAccess=['ALL_API'],
+                                       apiKeyName=name)
+        api_key_response = RestService.post(
+            f'{consumer_endpoint}/mc/v1/consumers',
+            additional_headers={'x-apikey': gw_api_key},
+            data=create_consumer_payload,
+            generate_token=False
+        )
+        return api_key_response
 
     @classmethod
     def revoke_key(cls, org_id: int, api_key: str):
@@ -88,7 +113,16 @@ class ApiGateway:
         check_auth(one_of_roles=(ADMIN, STAFF), org_id=org_id)
         consumer_endpoint: str = current_app.config.get('API_GW_CONSUMERS_API_URL')
         gw_api_key: str = current_app.config.get('API_GW_KEY')
-        email_id = cls._get_email_id(org_id)
+        env = None
+        # Find the environment for this key, based on it consumer changes.
+        for key in cls.get_api_keys(org_id)['consumer']['consumerKey']:
+            if key['apiKey'] == api_key:
+                env = 'prod' if key['environment'] == 'prod' else 'sandbox'
+                break
+        if not env:
+            raise BusinessException(Error.DATA_NOT_FOUND, Exception())
+
+        email_id = cls._get_email_id(org_id, env)
 
         RestService.patch(
             f'{consumer_endpoint}/mc/v1/consumers/{email_id}/apikeys/{api_key}?action=revoke',
@@ -104,26 +138,55 @@ class ApiGateway:
         consumer_endpoint: str = current_app.config.get('API_GW_CONSUMERS_API_URL')
         gw_api_key: str = current_app.config.get('API_GW_KEY')
         check_auth(one_of_roles=(ADMIN, STAFF), org_id=org_id)
-        email_id = cls._get_email_id(org_id)
-        try:
-            consumers_response = RestService.get(
-                f'{consumer_endpoint}/mc/v1/consumers/{email_id}',
-                additional_headers={'x-apikey': gw_api_key}
-            )
-            api_keys = consumers_response.json()
-        except HTTPError as exc:
-            if exc.response.status_code == 404:
-                api_keys = {}
-            else:
-                raise exc
+        api_keys_response = {'consumer': {'consumerKey': []}}
+        for email in cls._get_email_id(org_id, 'sandbox'), cls._get_email_id(org_id, 'prod'):
 
-        return api_keys
+            try:
+                consumers_response = RestService.get(
+                    f'{consumer_endpoint}/mc/v1/consumers/{email}',
+                    additional_headers={'x-apikey': gw_api_key}
+                )
+                keys = consumers_response.json()['consumer']['consumerKey']
+                cls._filter_and_add_keys(api_keys_response, keys)
+            except HTTPError as exc:
+                if exc.response.status_code != 404:  # If consumer doesn't exist
+                    raise exc
+
+        return api_keys_response
 
     @classmethod
-    def _get_email_id(cls, org_id) -> str:
+    def _filter_and_add_keys(cls, api_keys_response, keys):
+        if isinstance(keys, dict):
+            if keys['keyStatus'] == 'approved':
+                api_keys_response['consumer']['consumerKey'].append(keys)
+        elif isinstance(keys, list):
+            for key in keys:
+                if key['keyStatus'] == 'approved':
+                    api_keys_response['consumer']['consumerKey'].append(key)
+
+    @classmethod
+    def _get_email_id(cls, org_id, env) -> str:
         if current_app.config.get('API_GW_CONSUMER_EMAIL', None) is not None:
             return current_app.config.get('API_GW_CONSUMER_EMAIL')
 
         api_gw_email_suffix: str = current_app.config.get('API_GW_EMAIL_SUFFIX')
-        email_id = f'{org_id}@{api_gw_email_suffix}'
+        id_suffix = '' if env == 'prod' else '-sandbox'
+        email_id = f'{org_id}{id_suffix}@{api_gw_email_suffix}'
         return email_id
+
+    @classmethod
+    def _consumer_exists(cls, email):
+        """Return if customer exists with this email."""
+        consumer_endpoint: str = current_app.config.get('API_GW_CONSUMERS_API_URL')
+        gw_api_key: str = current_app.config.get('API_GW_KEY')
+        try:
+            RestService.get(
+                f'{consumer_endpoint}/mc/v1/consumers/{email}',
+                additional_headers={'x-apikey': gw_api_key}
+            )
+        except HTTPError as exc:
+            if exc.response.status_code == 404:  # If consumer doesn't exist
+                return False
+            raise exc
+
+        return True

--- a/auth-api/src/auth_api/services/keycloak.py
+++ b/auth-api/src/auth_api/services/keycloak.py
@@ -297,7 +297,17 @@ class KeycloakService:
             'Authorization': f'Bearer {admin_token}'
         }
         response = requests.get(get_group_url, headers=headers)
-        return response.json()[0].get('id')
+        return KeycloakService._find_group_or_subgroup_id(response.json(), group_name)
+
+    @staticmethod
+    def _find_group_or_subgroup_id(groups: list, group_name: str):
+        """Return group id by searching main and sub groups."""
+        for group in groups:
+            if group['name'] == group_name:
+                return group['id']
+            if group_id := KeycloakService._find_group_or_subgroup_id(group['subGroups'], group_name):
+                return group_id
+        return None
 
     @staticmethod
     def _reset_otp(user_id: str):

--- a/auth-api/src/auth_api/utils/api_gateway.py
+++ b/auth-api/src/auth_api/utils/api_gateway.py
@@ -16,10 +16,12 @@ import secrets
 import uuid
 
 
-def generate_client_representation(account_id: int, client_id_pattern: str):
+def generate_client_representation(account_id: int, client_id_pattern: str, env: str) -> dict:
     """Return dictionary for api gateway client user."""
     _id = str(uuid.uuid4())
     _secret = secrets.token_urlsafe(36)
+    if env != 'prod':
+        client_id_pattern += '-sandbox'
     _client_id = client_id_pattern.format(account_id=account_id)
 
     client_json: dict = {

--- a/auth-api/src/auth_api/utils/constants.py
+++ b/auth-api/src/auth_api/utils/constants.py
@@ -19,6 +19,7 @@ GROUP_ACCOUNT_HOLDERS = 'account_holders'
 GROUP_ANONYMOUS_USERS = 'anonymous_users'
 GROUP_GOV_ACCOUNT_USERS = 'gov_account_users'
 GROUP_API_GW_USERS = 'api_gateway_users'
+GROUP_API_GW_SANDBOX_USERS = 'api_gateway_sandbox_users'
 
 # Affidavit folder
 AFFIDAVIT_FOLDER_NAME = 'Affidavits'

--- a/auth-api/tests/docker/setup/demo-realm.json
+++ b/auth-api/tests/docker/setup/demo-realm.json
@@ -60,6 +60,13 @@
         "containerId": "demo"
       },
       {
+        "name": "sandbox",
+        "description": "Role to distinguish sandbox keys",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "demo"
+      },
+      {
         "name": "gov_account_user",
         "composite": false,
         "clientRole": false,
@@ -303,8 +310,9 @@
       "path": "/public_users",
       "attributes": {},
       "realmRoles": [
-        "edit",
-        "public_user"
+        "ppr",
+        "public_user",
+        "edit"
       ],
       "clientRoles": {},
       "subGroups": [
@@ -313,6 +321,16 @@
           "path": "/public_users/api_gateway_users",
           "attributes": {},
           "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": []
+        },
+        {
+          "name": "api_gateway_sandbox_users",
+          "path": "/public_users/api_gateway_sandbox_users",
+          "attributes": {},
+          "realmRoles": [
+            "sandbox"
+          ],
           "clientRoles": {},
           "subGroups": []
         }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/9799

*Description of changes:*
- Create 2 consumers. 1 For PROD and 1 for Sandbox
- Add the sandbox consumer's keycloak client to a different group, to yield a different role for applications to distinguish


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
