### PR TITLE
9439 - user name settings for staff send notification for affidavit r…

### DIFF
--- a/auth-api/src/auth_api/services/affidavit.py
+++ b/auth-api/src/auth_api/services/affidavit.py
@@ -119,7 +119,8 @@ class Affidavit:  # pylint: disable=too-many-instance-attributes
 
                 # Send notification mail to staff review task
                 from auth_api.services import Org as OrgService  # pylint:disable=cyclic-import, import-outside-toplevel
-                OrgService.send_staff_review_account_reminder(relationship_id=org.id)
+                user = UserModel.find_by_jwt_token()
+                OrgService.send_staff_review_account_reminder(relationship_id=org.id, user=user)
 
                 remarks = [f'User Uploaded New affidavit .Created New task id: {new_task.identifier}']
                 TaskService.close_task(task_model.id, remarks)

--- a/auth-api/src/auth_api/services/affidavit.py
+++ b/auth-api/src/auth_api/services/affidavit.py
@@ -119,8 +119,7 @@ class Affidavit:  # pylint: disable=too-many-instance-attributes
 
                 # Send notification mail to staff review task
                 from auth_api.services import Org as OrgService  # pylint:disable=cyclic-import, import-outside-toplevel
-                user = UserModel.find_by_jwt_token()
-                OrgService.send_staff_review_account_reminder(relationship_id=org.id, user=user)
+                OrgService.send_staff_review_account_reminder(relationship_id=org.id)
 
                 remarks = [f'User Uploaded New affidavit .Created New task id: {new_task.identifier}']
                 TaskService.close_task(task_model.id, remarks)

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -802,11 +802,13 @@ class Org:  # pylint: disable=too-many-public-methods
         return Org(org)
 
     @staticmethod
+    @user_context
     def send_staff_review_account_reminder(relationship_id,
-                                           task_relationship_type=TaskRelationshipType.ORG.value):
+                                           task_relationship_type=TaskRelationshipType.ORG.value,
+                                           **kwargs):  # pylint: disable=too-many-locals
         """Send staff review account reminder notification."""
         current_app.logger.debug('<send_staff_review_account_reminder')
-        user = UserModel.find_by_jwt_token()
+        user_from_context: UserContext = kwargs['user_context']
         recipient = current_app.config.get('STAFF_ADMIN_EMAIL')
         # Get task id that is related with the task. Task Relationship Type can be ORG or PRODUCT.
         task = TaskModel.find_by_task_relationship_id(task_relationship_type=task_relationship_type,
@@ -814,8 +816,8 @@ class Org:  # pylint: disable=too-many-public-methods
         context_path = f'review-account/{task.id}'
         app_url = f"{g.get('origin_url', '')}/{current_app.config.get('AUTH_WEB_TOKEN_CONFIRM_PATH')}"
         review_url = f'{app_url}/{context_path}'
-        first_name = getattr(user, 'firstname', '')
-        last_name = getattr(user, 'lastname', '')
+        first_name = user_from_context.first_name
+        last_name = user_from_context.last_name
 
         data = {
             'emailAddresses': recipient,

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -141,7 +141,7 @@ class Org:  # pylint: disable=too-many-public-methods
         org.commit()
 
         if is_bceid_status_handling_needed:
-            Org.send_staff_review_account_reminder(relationship_id=org.id, user=user)
+            Org.send_staff_review_account_reminder(relationship_id=org.id)
 
         current_app.logger.info(f'<created_org org_id:{org.id}')
 
@@ -802,10 +802,11 @@ class Org:  # pylint: disable=too-many-public-methods
         return Org(org)
 
     @staticmethod
-    def send_staff_review_account_reminder(relationship_id, user: UserModel = None,
+    def send_staff_review_account_reminder(relationship_id,
                                            task_relationship_type=TaskRelationshipType.ORG.value):
         """Send staff review account reminder notification."""
         current_app.logger.debug('<send_staff_review_account_reminder')
+        user = UserModel.find_by_jwt_token()
         recipient = current_app.config.get('STAFF_ADMIN_EMAIL')
         # Get task id that is related with the task. Task Relationship Type can be ORG or PRODUCT.
         task = TaskModel.find_by_task_relationship_id(task_relationship_type=task_relationship_type,


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/9439

*Description of changes:*

- Get user details from user json token and pass to account mailer for staff reupload affidavit mail


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
