### PR TITLE
10255 - Refactoring Orgs Patch to accept status and access types

### DIFF
--- a/auth-api/src/auth_api/exceptions/errors.py
+++ b/auth-api/src/auth_api/exceptions/errors.py
@@ -82,6 +82,7 @@ class Error(Enum):
     NOT_ACTIVE_ACCOUNT = 'Account is not active.', http_status.HTTP_400_BAD_REQUEST
     PAY_ACCOUNT_DEACTIVATE_ERROR = 'An error occurred while attempting to deactivate your account.Please try again', \
                                    http_status.HTTP_400_BAD_REQUEST
+    PATCH_INVALID_ACTION = 'PATCH_INVALID_ACTION', http_status.HTTP_400_BAD_REQUEST
 
     def __new__(cls, message, status_code):
         """Attributes for the enum."""

--- a/auth-api/src/auth_api/resources/org.py
+++ b/auth-api/src/auth_api/resources/org.py
@@ -31,8 +31,8 @@ from auth_api.services import User as UserService
 from auth_api.tracer import Tracer
 from auth_api.utils.enums import AccessType, NotificationType, PatchActions
 from auth_api.utils.enums import Status
+from auth_api.utils.roles import ALL_ALLOWED_ROLES, CLIENT_ADMIN_ROLES, STAFF, USER, Role  # noqa: I005
 from auth_api.utils.role_validator import validate_roles
-from auth_api.utils.roles import ALL_ALLOWED_ROLES, CLIENT_ADMIN_ROLES, STAFF, USER, Role
 from auth_api.utils.util import cors_preflight
 
 API = Namespace('orgs', description='Endpoints for organization management')
@@ -446,8 +446,8 @@ class OrgMember(Resource):
 
             membership = MembershipService.find_membership_by_id(membership_id)
 
-            is_own_membership = membership.as_dict()['user']['username'] == \
-                                UserService.find_by_jwt_token().as_dict()['username']
+            is_own_membership = \
+                membership.as_dict()['user']['username'] == UserService.find_by_jwt_token().as_dict()['username']
             if not membership:
                 response, status = {'message': 'The requested membership record could not be found.'}, \
                                    http_status.HTTP_404_NOT_FOUND

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -39,7 +39,7 @@ from auth_api.services.validators.bcol_credentials import validate as bcol_crede
 from auth_api.services.validators.duplicate_org_name import validate as duplicate_org_name_validate
 from auth_api.services.validators.payment_type import validate as payment_type_validate
 from auth_api.utils.enums import (
-    AccessType, AffidavitStatus, LoginSource, OrgStatus, OrgType, PaymentAccountStatus, PaymentMethod,
+    AccessType, AffidavitStatus, LoginSource, OrgStatus, OrgType, PatchActions, PaymentAccountStatus, PaymentMethod,
     Status, TaskRelationshipStatus, TaskRelationshipType, TaskStatus, TaskTypePrefix, TaskAction)
 from auth_api.utils.roles import ADMIN, EXCLUDED_FIELDS, STAFF, VALID_STATUSES, Role  # noqa: I005
 from auth_api.utils.util import camelback2snake
@@ -740,8 +740,7 @@ class Org:  # pylint: disable=too-many-public-methods
 
         return False
 
-    @staticmethod
-    def change_org_status(org_id: int, status_code, suspension_reason_code):
+    def change_org_status(self, status_code, suspension_reason_code):
         """Update the status of the org.
 
         Used now for suspending/activate account.
@@ -753,10 +752,8 @@ class Org:  # pylint: disable=too-many-public-methods
         """
         current_app.logger.debug('<change_org_status ')
 
-        org_model: OrgModel = OrgModel.find_by_org_id(org_id)
-
         user: UserModel = UserModel.find_by_jwt_token()
-        current_app.logger.debug('<setting org status to  ')
+        org_model = self._model
         org_model.status_code = status_code
         org_model.decision_made_by = user.username  # not sure if a new field is needed for this.
         if status_code == OrgStatus.SUSPENDED.value:
@@ -882,3 +879,33 @@ class Org:  # pylint: disable=too-many-public-methods
         except Exception as e:  # noqa=B901
             current_app.logger.error('<send_approved_rejected_govm_govn_notification failed')
             raise BusinessException(Error.FAILED_NOTIFICATION, None) from e
+
+    def change_org_access_type(self, access_type):
+        """Update the access type of the org."""
+        current_app.logger.debug('<change_org_access_type ')
+        org_model = self._model
+        org_model.access_type = access_type
+        org_model.save()
+        current_app.logger.debug('change_org_access_type>')
+        return Org(org_model)
+
+    def patch_org(self, action: str = None, request_json: Dict[str, any] = None):
+        """Update Org."""
+        if (patch_action := PatchActions.from_value(action)) is None:
+            raise BusinessException(Error.PATCH_INVALID_ACTION, None)
+
+        if patch_action == PatchActions.UPDATE_STATUS:
+            status_code = request_json.get('statusCode', None)
+            suspension_reason_code = request_json.get('suspensionReasonCode', None)
+            if status_code is None:
+                raise BusinessException(Error.INVALID_INPUT, None)
+            if status_code == OrgStatus.SUSPENDED.value and suspension_reason_code is None:
+                raise BusinessException(Error.INVALID_INPUT, None)
+            return self.change_org_status(status_code, suspension_reason_code).as_dict()
+        elif patch_action == PatchActions.UPDATE_ACCESS_TYPE:
+            access_type = request_json.get('accessType', None)
+            # Currently, only accounts with the following access types can be updated
+            if access_type is None or access_type not in [AccessType.REGULAR.value, AccessType.REGULAR_BCEID.value,
+                                                          AccessType.EXTRA_PROVINCIAL.value, AccessType.GOVN.value]:
+                raise BusinessException(Error.INVALID_INPUT, None)
+            return self.change_org_access_type(access_type).as_dict()

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -902,10 +902,11 @@ class Org:  # pylint: disable=too-many-public-methods
             if status_code == OrgStatus.SUSPENDED.value and suspension_reason_code is None:
                 raise BusinessException(Error.INVALID_INPUT, None)
             return self.change_org_status(status_code, suspension_reason_code).as_dict()
-        elif patch_action == PatchActions.UPDATE_ACCESS_TYPE:
+        if patch_action == PatchActions.UPDATE_ACCESS_TYPE:
             access_type = request_json.get('accessType', None)
             # Currently, only accounts with the following access types can be updated
             if access_type is None or access_type not in [AccessType.REGULAR.value, AccessType.REGULAR_BCEID.value,
                                                           AccessType.EXTRA_PROVINCIAL.value, AccessType.GOVN.value]:
                 raise BusinessException(Error.INVALID_INPUT, None)
             return self.change_org_access_type(access_type).as_dict()
+        return None

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -132,7 +132,7 @@ class AccessType(Enum):
     EXTRA_PROVINCIAL = 'EXTRA_PROVINCIAL'
     ANONYMOUS = 'ANONYMOUS'
     GOVM = 'GOVM'  # for govt ministry
-    GOVN = 'GOVN'  # for govt ministry
+    GOVN = 'GOVN'  # for govt non-ministry
 
 
 class Status(Enum):
@@ -284,3 +284,15 @@ class ActivityAction(Enum):
     RESET_PASSCODE = 'Reset Passcode'
     GENERATED_PASSCODE = 'Generated Passcode'
     CREATE_AFFILIATION = 'Created Affiliation'
+
+
+class PatchActions(Enum):
+    """Patch Actions."""
+
+    UPDATE_STATUS = 'updateStatus'
+    UPDATE_ACCESS_TYPE = 'updateAccessType'
+
+    @classmethod
+    def from_value(cls, value):
+        """Return instance from value of the enum."""
+        return PatchActions(value) if value in cls._value2member_map_ else None  # pylint: disable=no-member

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -1799,8 +1799,6 @@ def test_org_patch_validate_request_json(client, jwt, session, keycloak_mock):  
     org_response = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org_with_mailing_address()),
                                headers=public_headers,
                                content_type='application/json')
-    dictionary = json.loads(org_response.data)
-    org_id = dictionary['id']
     assert org_response.status_code == http_status.HTTP_201_CREATED
 
     # Validate public Bcol user cannot do patch
@@ -1846,7 +1844,6 @@ def test_org_patch_access_type(client, jwt, session, keycloak_mock):  # pylint:d
     org_response = client.post('/api/v1/orgs', data=json.dumps(TestOrgInfo.org_with_mailing_address()),
                                headers=public_headers,
                                content_type='application/json')
-    dictionary = json.loads(org_response.data)
     assert org_response.status_code == http_status.HTTP_201_CREATED
 
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.bcol_admin_role)

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -1792,7 +1792,7 @@ def test_delete_affiliation_payload_no_mail(client, jwt, session, keycloak_mock)
 
 
 def test_org_patch_validate_request_json(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
-    """Assert that an org can be retrieved via GET."""
+    """Validate patch org endpoints based on different input."""
     public_headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_bceid_user)
     client.post('/api/v1/users', headers=public_headers, content_type='application/json')
 
@@ -1837,7 +1837,7 @@ def test_org_patch_validate_request_json(client, jwt, session, keycloak_mock):  
 
 
 def test_org_patch_access_type(client, jwt, session, keycloak_mock):  # pylint:disable=unused-argument
-    """Assert that an org can be retrieved via GET."""
+    """Assert patch Org endpoint for access type."""
     public_headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_bceid_user)
     client.post('/api/v1/users', headers=public_headers, content_type='application/json')
 

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -186,7 +186,8 @@ def test_search_org_by_client_multiple_status(client, jwt, session, keycloak_moc
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.bcol_admin_role)
 
     org_patch_response = client.patch('/api/v1/orgs/{}'.format(org_response.json.get('id')),
-                                      data=json.dumps({'statusCode': OrgStatus.SUSPENDED.value}),
+                                      data=json.dumps({'statusCode': OrgStatus.SUSPENDED.value,
+                                                       'suspensionReasonCode': SuspensionReasonCode.OWNER_CHANGE.name}),
                                       headers=headers, content_type='application/json')
     assert org_patch_response.json.get('orgStatus') == OrgStatus.SUSPENDED.value
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/10255
*Description of changes:*

- Update Org endpoint to add patch that accept org status and access type
- Remove Org status patch
- unit test cases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
