### PR TITLE
10135 : Adding verified flag for BCeID affidavit approved users

### DIFF
--- a/auth-api/migrations/versions/342ec8814181_update_verified_flag.py
+++ b/auth-api/migrations/versions/342ec8814181_update_verified_flag.py
@@ -1,0 +1,32 @@
+"""update_verified_flag
+
+Revision ID: 342ec8814181
+Revises: 9f3450623765
+Create Date: 2022-01-13 16:12:10.256555
+
+"""
+from typing import List
+
+from alembic import op
+
+from auth_api.models import Affidavit
+
+# revision identifiers, used by Alembic.
+revision = '342ec8814181'
+down_revision = '9f3450623765'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Find approved BCeID affidavit users.
+    conn = op.get_bind()
+    affidavits: List[Affidavit] = conn.execute("select * from affidavits where status_code='APPROVED' ").fetchall()
+    for affidavit in affidavits:
+        op.execute(f"update users set verified=true where id = {affidavit.user_id};")
+
+    op.execute("update users set verified=true where login_source='BCSC'")
+
+
+def downgrade():
+    pass

--- a/auth-api/src/auth_api/services/task.py
+++ b/auth-api/src/auth_api/services/task.py
@@ -151,6 +151,12 @@ class Task:  # pylint: disable=too-many-instance-attributes
                 # Send mail to admin about hold with reasons
                 Task._notify_admin_about_hold(user=user, task_model=task_model, is_new_bceid_admin_request=True,
                                               membership_id=membership.id)
+
+        # If action is affidavit review, mark the user as verified.
+        if is_approved and task_model.action == TaskAction.AFFIDAVIT_REVIEW.value and task_model.user:
+            task_model.user.verified = True
+            task_model.user.save()
+
         current_app.logger.debug('>update_task_relationship ')
 
     @staticmethod
@@ -208,7 +214,6 @@ class Task:  # pylint: disable=too-many-instance-attributes
 
         # Update user
         user: UserModel = UserModel.find_by_id(user_id)
-        user.verified = is_approved
         user.status = Status.ACTIVE.value if is_approved else Status.INACTIVE.value
 
         # Update membership

--- a/auth-api/tests/unit/services/test_task.py
+++ b/auth-api/tests/unit/services/test_task.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 from auth_api.models import ProductCode as ProductCodeModel
+from auth_api.models import User as UserModel
 from auth_api.models import Task as TaskModel
 from auth_api.services import Affidavit as AffidavitService
 from auth_api.services import Org as OrgService
@@ -127,8 +128,10 @@ def test_update_task(session, keycloak_mock, monkeypatch):  # pylint:disable=unu
 
     task = TaskService.update_task(TaskService(task), task_info=task_info)
     dictionary = task.as_dict()
+    user = UserModel.find_by_id(user.id)
     assert dictionary['status'] == TaskStatus.COMPLETED.value
     assert dictionary['relationship_status'] == TaskRelationshipStatus.ACTIVE.value
+    assert user.verified
 
 
 def test_hold_task(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/10135

*Description of changes:*
- Adding verified flag for BCeID affidavit approved users


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
