### PR TITLE
10012_nr_affliation_emailcase

### DIFF
--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -210,7 +210,8 @@ class Affiliation:
             if status == NRStatus.CONDITIONAL.value and nr_json.get('consentFlag', None) not in (None, 'R', 'N'):
                 raise BusinessException(Error.NR_NOT_APPROVED, None)
 
-            if (phone and phone != nr_phone) or (email and email != nr_email):
+            if (phone and phone != nr_phone) or (email and email.casefold() != nr_email.casefold()):
+                current_app.logger.debug(f'NR Applicants Email:{nr_email.casefold()}; verification:{email.casefold()}')
                 raise BusinessException(Error.NR_INVALID_CONTACT, None)
 
             # Create an entity with the Name from NR if entity doesn't exist

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -211,7 +211,6 @@ class Affiliation:
                 raise BusinessException(Error.NR_NOT_APPROVED, None)
 
             if (phone and phone != nr_phone) or (email and email.casefold() != nr_email.casefold()):
-                current_app.logger.debug(f'NR Applicants Email:{nr_email.casefold()}; verification:{email.casefold()}')
                 raise BusinessException(Error.NR_INVALID_CONTACT, None)
 
             # Create an entity with the Name from NR if entity doesn't exist

--- a/auth-api/src/auth_api/version.py
+++ b/auth-api/src/auth_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '0.1.0a0.dev'  # pylint: disable=invalid-name
+__version__ = '0.2.0a0'  # pylint: disable=invalid-name

--- a/auth-api/src/auth_api/version.py
+++ b/auth-api/src/auth_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '0.2.0a0'  # pylint: disable=invalid-name
+__version__ = '0.1.0a0.dev'  # pylint: disable=invalid-name

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -342,18 +342,24 @@ def test_create_new_business(session, auth_mock, nr_mock):  # pylint:disable=unu
     org_dictionary = org_service.as_dict()
     org_id = org_dictionary['id']
     business_identifier = 'NR 1234567'
-    business_identifier_2 = 'NR 1234568'
 
     affiliation = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier,
                                                                      email='test@test.com', phone='1112223333')
     assert affiliation
     assert affiliation.as_dict()['business']['business_identifier'] == business_identifier
 
-    affiliation_uc = AffiliationService.create_new_business_affiliation(org_id,
-                                                                        business_identifier=business_identifier_2,
-                                                                        email='TEST@TEST.COM', phone='1112223334')
-    assert affiliation_uc
-    assert affiliation_uc.as_dict()['business']['business_identifier'] == business_identifier
+
+def test_create_new_business_email_case(session, auth_mock, nr_mock):  # pylint:disable=unused-argument
+    """Assert that an new business can be created."""
+    org_service = factory_org_service()
+    org_dictionary = org_service.as_dict()
+    org_id = org_dictionary['id']
+    business_identifier = 'NR 1234567'
+
+    affiliation = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier,
+                                                                     email='TEST@TEST.COM', phone='1112223333')
+    assert affiliation
+    assert affiliation.as_dict()['business']['business_identifier'] == business_identifier
 
 
 def test_create_new_business_invalid_contact(session, auth_mock, nr_mock):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -349,7 +349,8 @@ def test_create_new_business(session, auth_mock, nr_mock):  # pylint:disable=unu
     assert affiliation
     assert affiliation.as_dict()['business']['business_identifier'] == business_identifier
 
-    affiliation_uc = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier_2,
+    affiliation_uc = AffiliationService.create_new_business_affiliation(org_id,
+                                                                        business_identifier=business_identifier_2,
                                                                         email='TEST@TEST.COM', phone='1112223334')
     assert affiliation_uc
     assert affiliation_uc.as_dict()['business']['business_identifier'] == business_identifier

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -344,7 +344,7 @@ def test_create_new_business(session, auth_mock, nr_mock):  # pylint:disable=unu
     business_identifier = 'NR 1234567'
 
     affiliation = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier,
-                                                                     email='test@test.com', phone='1112223333')
+                                                                     email='TEST@test.com', phone='1112223333')
     assert affiliation
     assert affiliation.as_dict()['business']['business_identifier'] == business_identifier
 

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -344,10 +344,14 @@ def test_create_new_business(session, auth_mock, nr_mock):  # pylint:disable=unu
     business_identifier = 'NR 1234567'
 
     affiliation = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier,
-                                                                     email='TEST@test.com', phone='1112223333')
+                                                                     email='test@test.com', phone='1112223333')
     assert affiliation
     assert affiliation.as_dict()['business']['business_identifier'] == business_identifier
 
+    affiliation_uc = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier,
+                                                                     email='TEST@TEST.COM', phone='1112223333')
+    assert affiliation_uc
+    assert affiliation_uc.as_dict()['business']['business_identifier'] == business_identifier
 
 def test_create_new_business_invalid_contact(session, auth_mock, nr_mock):  # pylint:disable=unused-argument
     """Assert that an new business can be created."""

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -342,14 +342,15 @@ def test_create_new_business(session, auth_mock, nr_mock):  # pylint:disable=unu
     org_dictionary = org_service.as_dict()
     org_id = org_dictionary['id']
     business_identifier = 'NR 1234567'
+    business_identifier_2 = 'NR 1234568'
 
     affiliation = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier,
                                                                      email='test@test.com', phone='1112223333')
     assert affiliation
     assert affiliation.as_dict()['business']['business_identifier'] == business_identifier
 
-    affiliation_uc = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier,
-                                                                        email='TEST@TEST.COM', phone='1112223333')
+    affiliation_uc = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier_2,
+                                                                        email='TEST@TEST.COM', phone='1112223334')
     assert affiliation_uc
     assert affiliation_uc.as_dict()['business']['business_identifier'] == business_identifier
 

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -349,9 +349,10 @@ def test_create_new_business(session, auth_mock, nr_mock):  # pylint:disable=unu
     assert affiliation.as_dict()['business']['business_identifier'] == business_identifier
 
     affiliation_uc = AffiliationService.create_new_business_affiliation(org_id, business_identifier=business_identifier,
-                                                                     email='TEST@TEST.COM', phone='1112223333')
+                                                                        email='TEST@TEST.COM', phone='1112223333')
     assert affiliation_uc
     assert affiliation_uc.as_dict()['business']['business_identifier'] == business_identifier
+
 
 def test_create_new_business_invalid_contact(session, auth_mock, nr_mock):  # pylint:disable=unused-argument
     """Assert that an new business can be created."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/10012

*Description of changes:*

add casefold function to both the applicants email and the verification email in business affiliation logic.
