### PR TITLE
11263 - API Documentation Link on Developer Access page not working

### DIFF
--- a/auth-web/devops/vaults.json
+++ b/auth-web/devops/vaults.json
@@ -46,7 +46,8 @@
             "bceid",
             "fas-ui",
             "ppr-ui",
-            "registry"
+            "registry",
+            "api-document"
         ]
     },
     {

--- a/auth-web/public/config/configuration.json
+++ b/auth-web/public/config/configuration.json
@@ -27,6 +27,6 @@
   "ONE_STOP_URL": "https://dev.onestop.gov.bc.ca/",
   "CORPORATE_ONLINE_URL": "https://dev.corponline.gov.bc.ca/",
   "FAS_WEB_URL": "https://fas-dev.apps.silver.devops.gov.bc.ca/",
-  "API_DOCUMENTATION_URL": "https://developer.bcregistry.daxiom.ca/",
+  "API_DOCUMENTATION_URL": "https://developer.bcregistry.daxiom.ca/apis-summary/",
   "PPR_WEB_URL": "https://ppr-ui-dev.apps.silver.devops.gov.bc.ca/ppr/"
 }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/11263

*Description of changes:*
- Update local configuration to point at correct url.
- Update /devops/vaults.json to include 'api-document'.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
