### PR TITLE
10111 - Auth home page doesn't show in IE11

### DIFF
--- a/auth-web/vue.config.js
+++ b/auth-web/vue.config.js
@@ -10,7 +10,7 @@ module.exports = {
     }
   },
   publicPath: process.env.VUE_APP_PATH,
-  transpileDependencies: ['vuetify', 'vuex-persist'],
+  transpileDependencies: ['vuetify', 'vuex-persist', 'fas-ui', 'clickout-event', 'vue-plugin-helper-decorator'],
   devServer: {
     overlay: {
       warnings: true,


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/10111

*Description of changes:*
Auth home page doesn't show in IE11, change transpileDependencies so it works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
