### PR TITLE
10296 - AUTH API: Handle new state property

### DIFF
--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -297,3 +297,12 @@ class PatchActions(Enum):
     def from_value(cls, value):
         """Return instance from value of the enum."""
         return PatchActions(value) if value in cls._value2member_map_ else None  # pylint: disable=no-member
+
+
+# This is from LEAR.
+class EntityStatus(Enum):
+    """Entity statuses."""
+
+    ACTIVE = 'ACTIVE'
+    HISTORICAL = 'HISTORICAL'
+    LIQUIDATION = 'LIQUIDATION'

--- a/auth-web/src/components/auth/manage-business/AffiliatedEntityTable.vue
+++ b/auth-web/src/components/auth/manage-business/AffiliatedEntityTable.vue
@@ -689,11 +689,3 @@ export default class AffiliatedEntityTable extends Mixins(DateMixin) {
   }
 }
 </style>
-
-function capitalizeFirstLetter(status: BusinessState): string {
-  throw new Error('Function not implemented.')
-}
-
-function formatTitle(status: BusinessState): string {
-  throw new Error('Function not implemented.')
-}

--- a/auth-web/src/components/auth/manage-business/AffiliatedEntityTable.vue
+++ b/auth-web/src/components/auth/manage-business/AffiliatedEntityTable.vue
@@ -269,6 +269,8 @@ export default class AffiliatedEntityTable extends Mixins(DateMixin) {
         return NrDisplayStates[NrState[item.nameRequest.state]]
       case this.isTemporaryBusinessRegistration(item.corpType.code):
         return BusinessState.DRAFT
+      case !!item.status:
+        return item.status
       default:
         return BusinessState.ACTIVE
     }

--- a/auth-web/src/components/auth/manage-business/AffiliatedEntityTable.vue
+++ b/auth-web/src/components/auth/manage-business/AffiliatedEntityTable.vue
@@ -137,6 +137,7 @@ import { Component, Emit, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { CorpTypeCd, GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module'
 import { Organization, RemoveBusinessPayload } from '@/models/Organization'
 import { mapActions, mapState } from 'vuex'
+import CommonUtils from '@/util/common-util'
 import ConfigHelper from '@/util/config-helper'
 import DateMixin from '@/components/auth/mixins/DateMixin.vue'
 import LaunchDarklyService from 'sbc-common-components/src/services/launchdarkly.services'
@@ -270,7 +271,7 @@ export default class AffiliatedEntityTable extends Mixins(DateMixin) {
       case this.isTemporaryBusinessRegistration(item.corpType.code):
         return BusinessState.DRAFT
       case !!item.status:
-        return item.status
+        return CommonUtils.formatTitle(item.status)
       default:
         return BusinessState.ACTIVE
     }
@@ -688,3 +689,11 @@ export default class AffiliatedEntityTable extends Mixins(DateMixin) {
   }
 }
 </style>
+
+function capitalizeFirstLetter(status: BusinessState): string {
+  throw new Error('Function not implemented.')
+}
+
+function formatTitle(status: BusinessState): string {
+  throw new Error('Function not implemented.')
+}

--- a/auth-web/src/models/business.ts
+++ b/auth-web/src/models/business.ts
@@ -1,4 +1,4 @@
-import { LearFilingTypes, NrTargetTypes } from '@/util/constants'
+import { BusinessState, LearFilingTypes, NrTargetTypes } from '@/util/constants'
 import { Contact } from './contact'
 
 export interface LoginPayload {
@@ -30,6 +30,7 @@ export interface Business {
     modifiedBy?: string
     nameRequest?: NameRequest
     nrNumber?: string
+    status?: BusinessState
 }
 
 export interface BusinessSearchResultDto {

--- a/auth-web/src/util/common-util.ts
+++ b/auth-web/src/util/common-util.ts
@@ -255,4 +255,8 @@ export default class CommonUtils {
     const stringIndexValue: string = index.toString()
     return stringIndexValue.padStart(2, '0')
   }
+
+  static formatTitle (str: string): string {
+    return str ? str[0]?.toUpperCase() + str.slice(1)?.toLowerCase() : str
+  }
 }

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -219,6 +219,7 @@ export enum NrEntityType {
 
 export enum BusinessState {
     ACTIVE = 'Active',
+    HISTORICAL = 'Historical',
     DRAFT = 'Draft'
 }
 

--- a/queue_services/business-events-listener/app.py
+++ b/queue_services/business-events-listener/app.py
@@ -19,7 +19,7 @@ import asyncio
 import random
 from copy import deepcopy
 
-from business_events_listener.worker import APP_CONFIG, cb_nr_subscription_handler, qsm
+from business_events_listener.worker import APP_CONFIG, cb_subscription_handler, qsm
 
 
 if __name__ == '__main__':
@@ -33,7 +33,7 @@ if __name__ == '__main__':
         """Run both nr and entity tasks."""
         nr_task = qsm.run(loop=event_loop,
                           config=APP_CONFIG,
-                          callback=cb_nr_subscription_handler)
+                          callback=cb_subscription_handler)
 
         subscriber_coroutines = [nr_task]
 

--- a/queue_services/business-events-listener/requirements.txt
+++ b/queue_services/business-events-listener/requirements.txt
@@ -6,7 +6,7 @@ asyncio-nats-client==0.11.5
 asyncio-nats-streaming==0.4.0
 attrs==21.4.0
 blinker==1.4
-certifi==2021.10.8
+certifi==2022.5.18.1
 click==8.1.3
 importlib-resources==5.7.1
 itsdangerous==2.0.1
@@ -18,7 +18,7 @@ pycountry==22.3.5
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 python-dotenv==0.20.0
-sentry-sdk==1.5.11
+sentry-sdk==1.5.12
 six==1.16.0
 threadloop==1.0.2
 thrift==0.16.0

--- a/queue_services/business-events-listener/src/business_events_listener/worker.py
+++ b/queue_services/business-events-listener/src/business_events_listener/worker.py
@@ -76,7 +76,7 @@ async def process_business_events(message_type: str, event_message: Dict[str, an
 
     1. Check if entity exists and dissolution has occured.
        - Update the status to HISTORICAL.
-    2. **Unimplemented ** Check if entity exists and dissolution has reversed (via correction).
+    2. **Unimplemented** Check if entity exists and dissolution has reversed (via correction).
        - Update the status to ACTIVE.
 
     Args:

--- a/queue_services/business-events-listener/src/business_events_listener/worker.py
+++ b/queue_services/business-events-listener/src/business_events_listener/worker.py
@@ -105,10 +105,10 @@ async def process_business_events(message_type: str, event_message: Dict[str, an
     entity_identifier = event_message.get('identifier')
     entity = EntityModel.find_by_business_identifier(entity_identifier)
     if entity is None:
-        logger.warn('process_business_events - Couldn''t find Entity : '
-                    f'{entity_identifier} to update entity.status.')
+        logger.error('process_business_events - Couldn''t find Entity : '
+                     '%s to update entity.status.', entity_identifier)
     elif message_type == 'bc.registry.business.dissolution':
-        logger.info(f'Setting Entity :{entity_identifier} status to HISTORICAL')
+        logger.info('Setting Entity : %s status to HISTORICAL', entity_identifier)
         entity.status = EntityStatus.HISTORICAL
         entity.save()
     elif message_type == 'bc.registry.business.correction':

--- a/queue_services/business-events-listener/src/business_events_listener/worker.py
+++ b/queue_services/business-events-listener/src/business_events_listener/worker.py
@@ -109,7 +109,7 @@ async def process_business_events(message_type: str, event_message: Dict[str, an
                      '%s to update entity.status.', entity_identifier)
     elif message_type == 'bc.registry.business.dissolution':
         logger.info('Setting Entity : %s status to HISTORICAL', entity_identifier)
-        entity.status = EntityStatus.HISTORICAL
+        entity.status = 'HISTORICAL'
         entity.save()
     elif message_type == 'bc.registry.business.correction':
         pass  # TODO unimplemented currently.

--- a/queue_services/business-events-listener/src/business_events_listener/worker.py
+++ b/queue_services/business-events-listener/src/business_events_listener/worker.py
@@ -44,7 +44,7 @@ from flask import Flask  # pylint: disable=wrong-import-order
 from business_events_listener import config
 
 
-async def cb_nr_subscription_handler(msg: nats.aio.client.Msg):
+async def cb_subscription_handler(msg: nats.aio.client.Msg):
     """Use Callback to process Queue Msg objects."""
     try:
         logger.info('Received raw message seq:%s, data=  %s', msg.sequence, msg.data.decode())

--- a/queue_services/business-events-listener/src/business_events_listener/worker.py
+++ b/queue_services/business-events-listener/src/business_events_listener/worker.py
@@ -35,7 +35,7 @@ from auth_api.models import Entity as EntityModel
 from auth_api.models import Org as OrgModel
 from auth_api.models import db
 from auth_api.services.rest_service import RestService
-from auth_api.utils.enums import AccessType, CorpType, EntityStatus
+from auth_api.utils.enums import AccessType, CorpType
 from dateutil import parser
 from entity_queue_common.service import QueueServiceManager
 from entity_queue_common.service_utils import QueueException, logger

--- a/queue_services/business-events-listener/tests/integration/test_worker_queue.py
+++ b/queue_services/business-events-listener/tests/integration/test_worker_queue.py
@@ -155,6 +155,6 @@ async def test_business_events_queue(app, session, stan_server, event_loop, clie
     # add an event to queue
     await helper_add_business_dissolution_to_queue(events_stan, 'test_subject', 'CP9992256', 9)
 
-    entity: EntityModel = EntityModel.find_by_business_identifier(entity.id)
+    entity: EntityModel = EntityModel.find_by_business_identifier('CP9992256')
     assert entity
     assert entity.state == 'HISTORICAL'

--- a/queue_services/business-events-listener/tests/integration/test_worker_queue.py
+++ b/queue_services/business-events-listener/tests/integration/test_worker_queue.py
@@ -21,7 +21,7 @@ from auth_api.models import Entity as EntityModel
 from auth_api.models import Org as OrgModel
 from auth_api.models import OrgStatus as OrgStatusModel
 from auth_api.models import OrgType as OrgTypeModel
-from auth_api.utils.enums import AccessType, EntityStatus
+from auth_api.utils.enums import AccessType
 from entity_queue_common.service_utils import subscribe_to_queue
 from requests.models import Response
 
@@ -157,4 +157,4 @@ async def test_business_events_queue(app, session, stan_server, event_loop, clie
 
     entity: EntityModel = EntityModel.find_by_business_identifier(entity.id)
     assert entity
-    assert entity.state == EntityStatus.HISTORICAL
+    assert entity.state == 'HISTORICAL'

--- a/queue_services/business-events-listener/tests/integration/test_worker_queue.py
+++ b/queue_services/business-events-listener/tests/integration/test_worker_queue.py
@@ -153,7 +153,7 @@ async def test_business_events_queue(app, session, stan_server, event_loop, clie
                              cb_subscription_handler)
 
     # add an event to queue
-    await helper_add_business_dissolution_to_queue(events_stan, 'test_subject')
+    await helper_add_business_dissolution_to_queue(events_stan, 'test_subject', 'CP9992256', 9)
 
     entity: EntityModel = EntityModel.find_by_business_identifier(entity.id)
     assert entity

--- a/queue_services/business-events-listener/tests/integration/test_worker_queue.py
+++ b/queue_services/business-events-listener/tests/integration/test_worker_queue.py
@@ -132,8 +132,7 @@ async def test_events_listener_queue(app, session, stan_server, event_loop, clie
 
 
 @pytest.mark.asyncio
-async def test_business_events_queue(app, session, stan_server, event_loop, client_id, events_stan, future,
-                                     monkeypatch, access_type, is_auto_affiliate_expected):
+async def test_business_events_queue(app, session, stan_server, event_loop, client_id, events_stan, future):
     """Assert that business events can be retrieved and decoded from the Queue."""
     # Call back for the subscription
     from business_events_listener.worker import cb_subscription_handler

--- a/queue_services/business-events-listener/tests/integration/test_worker_queue.py
+++ b/queue_services/business-events-listener/tests/integration/test_worker_queue.py
@@ -142,6 +142,7 @@ async def test_business_events_queue(app, session, stan_server, event_loop, clie
     entity = EntityModel(
         name='Test',
         business_identifier='CP9992256',
+        corp_type_code='SP'
     ).save()
 
     # register the handler to test it
@@ -156,4 +157,4 @@ async def test_business_events_queue(app, session, stan_server, event_loop, clie
 
     entity: EntityModel = EntityModel.find_by_business_identifier('CP9992256')
     assert entity
-    assert entity.state == 'HISTORICAL'
+    assert entity.status == 'HISTORICAL'

--- a/queue_services/business-events-listener/tests/integration/utils.py
+++ b/queue_services/business-events-listener/tests/integration/utils.py
@@ -24,7 +24,7 @@ async def helper_add_names_event_to_queue(stan_client: stan.aio.client.Client,
                                     nr_number: str,
                                     new_state: str,
                                     old_state: str):
-    """Add event to the Queue."""
+    """Add names event to the Queue."""
     payload = {
         'specversion': '1.0.1',
         'type': 'bc.registry.names.events',
@@ -52,9 +52,9 @@ def get_random_number():
 
 
 async def helper_add_business_dissolution_to_queue(stan_client: stan.aio.client.Client,
-                                       subject: str,
-                                       business_identifier: str,
-                                       filing_id: str):
+                                                   subject: str,
+                                                   business_identifier: str,
+                                                   filing_id: str):
     """Add dissolution event to Queue."""
     payload = {
         'specversion': '1.x-wip',

--- a/queue_services/business-events-listener/tests/integration/utils.py
+++ b/queue_services/business-events-listener/tests/integration/utils.py
@@ -60,7 +60,7 @@ async def helper_add_business_dissolution_to_queue(stan_client: stan.aio.client.
         'specversion': '1.x-wip',
         'type': 'bc.registry.business.dissolution',
         'source': f'/business/{business_identifier}/filing/{filing_id}',
-        'id': id,
+        'id': 1234,
         'time': '',
         'datacontenttype': 'application/json',
         'identifier': business_identifier,
@@ -68,7 +68,7 @@ async def helper_add_business_dissolution_to_queue(stan_client: stan.aio.client.
             'filing': {
                 'header': {
                             'filingId': filing_id,
-                            'effectiveDate': datetime.utcnow().isoformat()
+                            'effectiveDate': str(datetime.now())
                             },
                 'business': {'identifier': business_identifier},
                 'legalFilings': ['dissolution']

--- a/queue_services/business-events-listener/tests/integration/utils.py
+++ b/queue_services/business-events-listener/tests/integration/utils.py
@@ -19,7 +19,7 @@ from random import randint
 import stan
 
 
-async def helper_add_event_to_queue(stan_client: stan.aio.client.Client,
+async def helper_add_names_event_to_queue(stan_client: stan.aio.client.Client,
                                     subject: str,
                                     nr_number: str,
                                     new_state: str,
@@ -49,3 +49,31 @@ async def helper_add_event_to_queue(stan_client: stan.aio.client.Client,
 def get_random_number():
     """Generate a random and return."""
     return randint(100000000, 999999999)
+
+
+async def helper_add_business_dissolution_to_queue(stan_client: stan.aio.client.Client,
+                                       subject: str,
+                                       business_identifier: str,
+                                       filing_id: str):
+    """Add dissolution event to Queue."""
+    payload = {
+        'specversion': '1.x-wip',
+        'type': 'bc.registry.business.dissolution',
+        'source': f'/business/{business_identifier}/filing/{filing_id}',
+        'id': id,
+        'time': '',
+        'datacontenttype': 'application/json',
+        'identifier': business_identifier,
+        'data': {
+            'filing': {
+                'header': {
+                            'filingId': filing_id,
+                            'effectiveDate': datetime.utcnow().isoformat()
+                            },
+                'business': {'identifier': business_identifier},
+                'legalFilings': ['dissolution']
+            }
+        }
+    }
+    await stan_client.publish(subject=subject,
+                              payload=json.dumps(payload).encode('utf-8'))

--- a/queue_services/business-events-listener/tests/integration/utils.py
+++ b/queue_services/business-events-listener/tests/integration/utils.py
@@ -20,10 +20,10 @@ import stan
 
 
 async def helper_add_names_event_to_queue(stan_client: stan.aio.client.Client,
-                                    subject: str,
-                                    nr_number: str,
-                                    new_state: str,
-                                    old_state: str):
+                                          subject: str,
+                                          nr_number: str,
+                                          new_state: str,
+                                          old_state: str):
     """Add names event to the Queue."""
     payload = {
         'specversion': '1.0.1',


### PR DESCRIPTION
**Note: this is merging into test_queues branch, will create a PR into main when I've tested it on DEV.**

*Issue #:*
https://github.com/bcgov/entity/issues/10296

*Description of changes:*
Add in EntityStatus from LEAR.
Add in case for entity.Status.
Update business_events_listener/worker.py to handle business events.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
