### PR TITLE
11741 - Transition from BCOL to PAD - Changes based on feedback 

### DIFF
--- a/auth-web/src/components/auth/account-settings/payment/AccountPaymentMethods.vue
+++ b/auth-web/src/components/auth/account-settings/payment/AccountPaymentMethods.vue
@@ -12,6 +12,7 @@
       v-if="selectedPaymentMethod"
       :currentOrgType="savedOrganizationType"
       :currentOrganization="currentOrganization"
+      :currentOrgPaymentType="currentOrgPaymentType"
       :currentSelectedPaymentMethod="selectedPaymentMethod"
       :isChangeView="true"
       :isAcknowledgeNeeded="isAcknowledgeNeeded"
@@ -175,7 +176,6 @@ export default class AccountPaymentMethods extends Mixins(AccountChangeMixin) {
 
   private disableSaveButtonForBCOL () {
     return (this.selectedPaymentMethod === PaymentTypes.BCOL &&
-            this.selectedPaymentMethod === this.currentOrgPaymentType &&
            (this.bcolInfo?.password === undefined || this.bcolInfo?.password === ''))
   }
 

--- a/auth-web/src/components/auth/common/LinkedBCOLBanner.vue
+++ b/auth-web/src/components/auth/common/LinkedBCOLBanner.vue
@@ -66,12 +66,14 @@ import BcolLogin from '@/components/auth/create-account/BcolLogin.vue'
 export default class LinkedBCOLBanner extends Vue {
   @Prop({ default: false }) showUnlinkAccountBtn: boolean
   @Prop({ default: false }) showEditBtn: boolean
+  @Prop({ default: false }) forceEditMode: boolean
   @Prop({ default: '' }) bcolAccountName: string
   @Prop({ default: () => ({} as BcolAccountDetails) }) bcolAccountDetails: BcolAccountDetails
   private editMode: boolean = false // user can edit the bcol details
 
   private async mounted () {
-    this.editMode = false
+    this.editMode = this.forceEditMode || false
+    this.emitBcolInfo({})
     this.emitBcolInfo({})
   }
   @Emit()

--- a/auth-web/src/components/auth/common/LinkedBCOLBanner.vue
+++ b/auth-web/src/components/auth/common/LinkedBCOLBanner.vue
@@ -74,7 +74,6 @@ export default class LinkedBCOLBanner extends Vue {
   private async mounted () {
     this.editMode = this.forceEditMode || false
     this.emitBcolInfo({})
-    this.emitBcolInfo({})
   }
   @Emit()
   private unlinkAccount () {

--- a/auth-web/src/components/auth/common/PaymentMethods.vue
+++ b/auth-web/src/components/auth/common/PaymentMethods.vue
@@ -64,6 +64,7 @@
                     :bcolAccountName="currentOrganization.bcolAccountName"
                     :bcolAccountDetails="currentOrganization.bcolAccountDetails"
                     :show-edit-btn="true"
+                    :force-edit-mode="forceEditModeBCOL"
                     @emit-bcol-info="getBcolInfo"
                   ></LinkedBCOLBanner>
                 </div>
@@ -175,6 +176,7 @@ export default class PaymentMethods extends Vue {
   @Prop({ default: '' }) currentOrgType: string
   @Prop({ default: undefined }) currentOrganization: Organization
   @Prop({ default: '' }) currentSelectedPaymentMethod: string
+  @Prop({ default: undefined }) currentOrgPaymentType: string
   @Prop({ default: false }) isChangeView: boolean
   @Prop({ default: true }) isAcknowledgeNeeded: boolean
   @Prop({ default: false }) isTouchedUpdate: boolean
@@ -203,6 +205,12 @@ export default class PaymentMethods extends Vue {
       })
     }
     return paymentMethods
+  }
+
+  private get forceEditModeBCOL () {
+    return this.currentSelectedPaymentMethod === PaymentTypes.BCOL &&
+           this.currentOrgPaymentType !== undefined &&
+           this.currentOrgPaymentType !== PaymentTypes.BCOL
   }
 
   private get isPADOnly () {

--- a/auth-web/src/components/auth/create-account/BcolLogin.vue
+++ b/auth-web/src/components/auth/create-account/BcolLogin.vue
@@ -89,12 +89,12 @@ export default class BcolLogin extends Vue {
     this.password = ''
   }
 
-  @Watch('password', { deep: true })
+  @Watch('password')
   onPasswordChange () {
     this.emitBcolInfo()
   }
 
-  @Watch('username', { deep: true })
+  @Watch('username')
   onUsernameChange () {
     this.emitBcolInfo()
   }

--- a/auth-web/src/components/auth/create-account/BcolLogin.vue
+++ b/auth-web/src/components/auth/create-account/BcolLogin.vue
@@ -94,6 +94,11 @@ export default class BcolLogin extends Vue {
     this.emitBcolInfo()
   }
 
+  @Watch('username', { deep: true })
+  onUsernameChange () {
+    this.emitBcolInfo()
+  }
+
   private isFormValid (): boolean {
     return !!this.username && !!this.password
   }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/11741

*Description of changes:*
- Remove this.currentOrgPaymentType from BCOL check.
- Add in watch for username.
- Implement a force edit mode, which will automatically go into edit mode when the organization's payment method changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
