### PR TITLE
11656 - Fix for duplicate affidavits.

### DIFF
--- a/auth-api/src/auth_api/models/affidavit.py
+++ b/auth-api/src/auth_api/models/affidavit.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This manages an Affidavit record in the Auth service."""
-from operator import and_
-
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 

--- a/auth-api/src/auth_api/models/affidavit.py
+++ b/auth-api/src/auth_api/models/affidavit.py
@@ -51,7 +51,8 @@ class Affidavit(VersionedModel):
         return db.session.query(Affidavit) \
             .join(Membership, Membership.user_id == Affidavit.user_id) \
             .join(Org, Org.id == Membership.org_id) \
-            .filter(and_(Org.id == org_id, Affidavit.status_code not in filtered_affidavit_statuses)) \
+            .filter(Org.id == org_id) \
+            .filter(Affidavit.status_code.notin_(filtered_affidavit_statuses))
             .one_or_none()  # There should be only one record at most, else throw error
 
     @classmethod

--- a/auth-api/src/auth_api/models/affidavit.py
+++ b/auth-api/src/auth_api/models/affidavit.py
@@ -52,7 +52,7 @@ class Affidavit(VersionedModel):
             .join(Membership, Membership.user_id == Affidavit.user_id) \
             .join(Org, Org.id == Membership.org_id) \
             .filter(Org.id == org_id) \
-            .filter(Affidavit.status_code.notin_(filtered_affidavit_statuses))
+            .filter(Affidavit.status_code.notin_(filtered_affidavit_statuses)) \
             .one_or_none()  # There should be only one record at most, else throw error
 
     @classmethod

--- a/auth-api/tests/unit/services/test_affidavit.py
+++ b/auth-api/tests/unit/services/test_affidavit.py
@@ -47,8 +47,12 @@ def test_create_affidavit_duplicate(session, keycloak_mock, monkeypatch):  # pyl
 
     assert affidavit.as_dict().get('status', None) == AffidavitStatus.PENDING.value
     new_affidavit_info = TestAffidavit.get_test_affidavit_with_contact()
-    AffidavitService.create_affidavit(affidavit_info=new_affidavit_info)
-
+    affidavit2 = AffidavitService.create_affidavit(affidavit_info=new_affidavit_info)
+    new_affidavit_info_2 = TestAffidavit.get_test_affidavit_with_contact()
+    affidavit3 = AffidavitService.create_affidavit(affidavit_info=new_affidavit_info_2)
+    assert affidavit.as_dict().get('status', None) == AffidavitStatus.INACTIVE.value
+    assert affidavit2.as_dict().get('status', None) == AffidavitStatus.INACTIVE.value
+    assert affidavit3.as_dict().get('status', None) == AffidavitStatus.PENDING.value
 
 def test_approve_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Affidavit can be approved."""
@@ -101,7 +105,14 @@ def test_reject_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unus
     patch_token_info(token_info, monkeypatch)
 
     affidavit_info = TestAffidavit.get_test_affidavit_with_contact()
-    AffidavitService.create_affidavit(affidavit_info=affidavit_info)
+    affidavit1 = AffidavitService.create_affidavit(affidavit_info=affidavit_info)
+
+    affidavit_info = TestAffidavit.get_test_affidavit_with_contact()
+    affidavit = AffidavitService.create_affidavit(affidavit_info=affidavit_info)
+
+    assert affidavit1.as_dict().get('status', None) == AffidavitStatus.INACTIVE.value
+    assert affidavit.as_dict().get('status', None) == AffidavitStatus.PENDING.value
+
     org = OrgService.create_org(TestOrgInfo.org_with_mailing_address(), user_id=user.id)
     org_dict = org.as_dict()
     assert org_dict['org_status'] == OrgStatus.PENDING_STAFF_REVIEW.value

--- a/auth-api/tests/unit/services/test_affidavit.py
+++ b/auth-api/tests/unit/services/test_affidavit.py
@@ -54,6 +54,7 @@ def test_create_affidavit_duplicate(session, keycloak_mock, monkeypatch):  # pyl
     assert affidavit2.as_dict().get('status', None) == AffidavitStatus.INACTIVE.value
     assert affidavit3.as_dict().get('status', None) == AffidavitStatus.PENDING.value
 
+
 def test_approve_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Affidavit can be approved."""
     user = factory_user_model_with_contact(user_info=TestUserInfo.user_bceid_tester)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/11656

*Description of changes:*
Change query for affidavit code, so it filters correctly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
