### PR TITLE
Bug 12602 Wrong login URL

### DIFF
--- a/queue_services/account-mailer/src/account_mailer/auth_utils.py
+++ b/queue_services/account-mailer/src/account_mailer/auth_utils.py
@@ -32,5 +32,5 @@ def get_login_url():
     """Get application login url."""
     origin = current_app.config.get('WEB_APP_URL')
     context_path = current_app.config.get('AUTH_WEB_TOKEN_CONFIRM_PATH')
-    login_url = f'{origin}/{context_path}'
+    login_url = f'{origin}'
     return login_url


### PR DESCRIPTION
*Issue #:*
https://app.zenhub.com/workspaces/relationships-team-space-61435c47e483c4000f08e9f6/issues/bcgov/entity/12602

*Description of changes:*
Login URL was not formed correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
