### PR TITLE
12792 Auth UI: Enhancements to Affiliate

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/src/components/auth/manage-business/AddBusinessForm.vue
+++ b/auth-web/src/components/auth/manage-business/AddBusinessForm.vue
@@ -39,7 +39,6 @@
       <v-expand-transition>
         <Certify
           v-if="isBusinessIdentifierValid && isFirm"
-          :legalName="passcode"
           :clause="certifyClause"
           entity="registered entity"
           @update:isCertified="isCertified = $event"
@@ -225,6 +224,7 @@ export default class AddBusinessForm extends Vue {
   }
 
   protected async add (): Promise<void> {
+    this.$refs.addBusinessForm.validate()
     if (this.isFormValid) {
       this.isLoading = true
       try {

--- a/auth-web/src/components/auth/manage-business/AddBusinessForm.vue
+++ b/auth-web/src/components/auth/manage-business/AddBusinessForm.vue
@@ -88,7 +88,6 @@
         <v-btn
           large color="primary"
           id="add-button"
-          :disabled="!isFormValid"
           :loading="isLoading"
           @click="add()"
         >

--- a/auth-web/src/components/auth/manage-business/Certify.vue
+++ b/auth-web/src/components/auth/manage-business/Certify.vue
@@ -22,15 +22,15 @@
 
 <script lang="ts">
 import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
-import { User } from '@/models/user'
-import { mapState } from 'vuex'
+import { KCUserProfile } from 'sbc-common-components/src/models/KCUserProfile'
+import { namespace } from 'vuex-class'
 
-@Component({
-  computed: {
-    ...mapState('user', ['userProfile'])
-  }
-})
+const UserModule = namespace('user')
+
+@Component({})
 export default class Certify extends Vue {
+  @UserModule.State('currentUser') private currentUser!: KCUserProfile
+
   /** Entity name. */
   @Prop({ default: 'business' })
   readonly entity: string
@@ -41,10 +41,9 @@ export default class Certify extends Vue {
 
   // local variable
   protected isCertified = false
-  protected readonly userProfile!: User
 
   get currentUserName (): string {
-    return this.userProfile.lastname + ', ' + this.userProfile.firstname
+    return this.currentUser.lastName + ', ' + this.currentUser.firstName
   }
 
   /** Emits an event to update the Is Certified prop. */

--- a/auth-web/src/components/auth/manage-business/Certify.vue
+++ b/auth-web/src/components/auth/manage-business/Certify.vue
@@ -43,7 +43,7 @@ export default class Certify extends Vue {
   protected isCertified = false
 
   get currentUserName (): string {
-    return this.currentUser.lastName + ', ' + this.currentUser.firstName
+    return `${this.currentUser.lastName}, ${this.currentUser.firstName}`
   }
 
   /** Emits an event to update the Is Certified prop. */

--- a/auth-web/src/components/auth/manage-business/Certify.vue
+++ b/auth-web/src/components/auth/manage-business/Certify.vue
@@ -29,7 +29,7 @@ const UserModule = namespace('user')
 
 @Component({})
 export default class Certify extends Vue {
-  @UserModule.State('currentUser') private currentUser!: KCUserProfile
+  @UserModule.State('currentUser') readonly currentUser!: KCUserProfile
 
   /** Entity name. */
   @Prop({ default: 'business' })

--- a/auth-web/src/components/auth/manage-business/Certify.vue
+++ b/auth-web/src/components/auth/manage-business/Certify.vue
@@ -11,7 +11,7 @@
         <span>
           <strong>{{ legalName || '[Legal Name]' }}</strong>
           certifies that they have relevant knowledge of the {{ entity }} and is authorized
-          to make this filing.
+          to act on behalf of this business.
         </span>
       </template>
     </v-checkbox>

--- a/auth-web/src/components/auth/manage-business/Certify.vue
+++ b/auth-web/src/components/auth/manage-business/Certify.vue
@@ -9,7 +9,7 @@
     >
       <template slot="label">
         <span>
-          <strong>{{ legalName || '[Legal Name]' }}</strong>
+          <strong>{{ currentUserName }}</strong>
           certifies that they have relevant knowledge of the {{ entity }} and is authorized
           to act on behalf of this business.
         </span>
@@ -22,13 +22,15 @@
 
 <script lang="ts">
 import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
+import { User } from '@/models/user'
+import { mapState } from 'vuex'
 
-@Component({})
+@Component({
+  computed: {
+    ...mapState('user', ['userProfile'])
+  }
+})
 export default class Certify extends Vue {
-  /** Entity name. */
-  @Prop({ required: true })
-  readonly legalName: string
-
   /** Entity name. */
   @Prop({ default: 'business' })
   readonly entity: string
@@ -39,6 +41,11 @@ export default class Certify extends Vue {
 
   // local variable
   protected isCertified = false
+  protected readonly userProfile!: User
+
+  get currentUserName (): string {
+    return this.userProfile.lastname + ', ' + this.userProfile.firstname
+  }
 
   /** Emits an event to update the Is Certified prop. */
   @Emit('update:isCertified')

--- a/auth-web/src/components/auth/manage-business/EntityManagement.vue
+++ b/auth-web/src/components/auth/manage-business/EntityManagement.vue
@@ -109,8 +109,8 @@
                 <li>For <strong>sole proprietorships and general partnerships</strong>,
                   enter the registration number and either
                   <span v-bind="attrs" v-on="on" activator class="underline-dotted">
-                    the name of the proprietor or a partner,
-                  </span>
+                    the name of the proprietor or a
+                    partner</span>.
                 </li>
               </ul>
             </template>

--- a/auth-web/src/components/auth/manage-business/EntityManagement.vue
+++ b/auth-web/src/components/auth/manage-business/EntityManagement.vue
@@ -106,11 +106,12 @@
               <ul class="add-business-unordered-list">
                 <li>For <strong>corporations</strong>, enter the incorporation number and the password.</li>
                 <li>For <strong>benefit companies</strong>, enter the incorporation number and the passcode.</li>
-                <li>For <strong>firms</strong>, enter the registration number and the
+                <li>For <strong>sole proprietorships and general partnerships</strong>,
+                  enter the registration number and either
                   <span v-bind="attrs" v-on="on" activator class="underline-dotted">
-                    name of the proprietor or a partner,
+                    the name of the proprietor or a partner,
                   </span>
-                  and the business number for firms doing business as.</li>
+                </li>
               </ul>
             </template>
             <span class="add-business-example-name">

--- a/auth-web/tests/unit/components/AddBusinessForm.spec.ts
+++ b/auth-web/tests/unit/components/AddBusinessForm.spec.ts
@@ -95,8 +95,12 @@ describe('Add Business Form', () => {
       expect(wrapper.find('.folio-number').attributes('label')).toBe('Folio or Reference Number (Optional)')
 
       // verify buttons
-      if (!test.certifyExists) expect(wrapper.find('#forgot-button').exists()).toBe(!!test.forgotButtonText)
-      if (test.forgotButtonText) expect(wrapper.find('#forgot-button span').text()).toBe(test.forgotButtonText)
+      if (!test.certifyExists) {
+        expect(wrapper.find('#forgot-button').exists()).toBe(!!test.forgotButtonText)
+      }
+      if (test.forgotButtonText) {
+        expect(wrapper.find('#forgot-button span').text()).toBe(test.forgotButtonText)
+      }
       expect(wrapper.find('#cancel-button span').text()).toBe('Cancel')
 
       // always enable add button

--- a/auth-web/tests/unit/components/AddBusinessForm.spec.ts
+++ b/auth-web/tests/unit/components/AddBusinessForm.spec.ts
@@ -95,12 +95,11 @@ describe('Add Business Form', () => {
       expect(wrapper.find('.folio-number').attributes('label')).toBe('Folio or Reference Number (Optional)')
 
       // verify buttons
-      expect(wrapper.find('#forgot-button').exists()).toBe(!!test.forgotButtonText)
-      if (test.forgotButtonText) {
-        expect(wrapper.find('#forgot-button span').text()).toBe(test.forgotButtonText)
-      }
+      if (!test.certifyExists) expect(wrapper.find('#forgot-button').exists()).toBe(!!test.forgotButtonText)
+      if (test.forgotButtonText) expect(wrapper.find('#forgot-button span').text()).toBe(test.forgotButtonText)
       expect(wrapper.find('#cancel-button span').text()).toBe('Cancel')
-      expect(wrapper.find('#add-button').attributes('disabled')).toBe('true')
+
+      // always enable add button
       expect(wrapper.find('#add-button span').text()).toBe('Add')
     })
   })

--- a/auth-web/tests/unit/components/Certify.spec.ts
+++ b/auth-web/tests/unit/components/Certify.spec.ts
@@ -3,25 +3,26 @@ import Certify from '@/components/auth/manage-business/Certify.vue'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import Vuex from 'vuex'
+import UserModule from '@/store/modules/user'
 
 Vue.use(Vuetify)
 const vuetify = new Vuetify({})
 
 describe('Add Business Form', () => {
-  let wrapper: Wrapper<Certify>
+  let wrapper: Wrapper<any>
   let userModule: any
 
   userModule = {
     namespaced: true,
     state: {
-      userProfile: {
-        firstname: 'Nadia',
-        lastname: 'Woodie'
+      currentUser: {
+        firstName: 'Nadia',
+        lastName: 'Woodie'
       }
     },
-    actions: {
-      getUserProfile: jest.fn()
-    }
+    actions: UserModule.actions,
+    mutations: UserModule.mutations,
+    getters: UserModule.getters
   }
 
   beforeAll(() => {
@@ -40,7 +41,6 @@ describe('Add Business Form', () => {
       localVue,
       vuetify,
       propsData: {
-        legalName: 'Legal Name',
         entity: 'entity',
         clause: 'Lorem ipsum dolor sit amet.'
       }

--- a/auth-web/tests/unit/components/Certify.spec.ts
+++ b/auth-web/tests/unit/components/Certify.spec.ts
@@ -1,16 +1,43 @@
-import { Wrapper, mount } from '@vue/test-utils'
+import { Wrapper, createLocalVue, mount } from '@vue/test-utils'
 import Certify from '@/components/auth/manage-business/Certify.vue'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
+import Vuex from 'vuex'
 
 Vue.use(Vuetify)
 const vuetify = new Vuetify({})
 
 describe('Add Business Form', () => {
-  let wrapper: Wrapper<any>
+  let wrapper: Wrapper<Certify>
+  let userModule: any
+
+  userModule = {
+    namespaced: true,
+    state: {
+      userProfile: {
+        firstname: 'Nadia',
+        lastname: 'Woodie'
+      }
+    },
+    actions: {
+      getUserProfile: jest.fn()
+    }
+  }
 
   beforeAll(() => {
+    const localVue = createLocalVue()
+    localVue.use(Vuex)
+
+    const store = new Vuex.Store({
+      strict: false,
+      modules: {
+        user: userModule
+      }
+    })
+
     wrapper = mount(Certify, {
+      store,
+      localVue,
       vuetify,
       propsData: {
         legalName: 'Legal Name',
@@ -30,7 +57,7 @@ describe('Add Business Form', () => {
     expect(wrapper.find('#certify').isVisible()).toBe(true)
 
     // verify checkbox
-    expect(wrapper.find('.certify-checkbox label').text()).toContain('Legal Name')
+    expect(wrapper.find('.certify-checkbox label').text()).toContain('Woodie, Nadia')
     expect(wrapper.find('.certify-checkbox label').text()).toContain('certifies that')
     expect(wrapper.find('.certify-checkbox label').text()).toContain('of the entity')
     expect(wrapper.find('.certify-clause').text()).toBe('Lorem ipsum dolor sit amet.')

--- a/auth-web/tests/unit/components/Certify.spec.ts
+++ b/auth-web/tests/unit/components/Certify.spec.ts
@@ -1,9 +1,9 @@
 import { Wrapper, createLocalVue, mount } from '@vue/test-utils'
 import Certify from '@/components/auth/manage-business/Certify.vue'
+import UserModule from '@/store/modules/user'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import Vuex from 'vuex'
-import UserModule from '@/store/modules/user'
 
 Vue.use(Vuetify)
 const vuetify = new Vuetify({})

--- a/auth-web/tests/unit/components/Certify.spec.ts
+++ b/auth-web/tests/unit/components/Certify.spec.ts
@@ -10,9 +10,8 @@ const vuetify = new Vuetify({})
 
 describe('Add Business Form', () => {
   let wrapper: Wrapper<any>
-  let userModule: any
 
-  userModule = {
+  const userModule: any = {
     namespaced: true,
     state: {
       currentUser: {
@@ -57,9 +56,10 @@ describe('Add Business Form', () => {
     expect(wrapper.find('#certify').isVisible()).toBe(true)
 
     // verify checkbox
-    expect(wrapper.find('.certify-checkbox label').text()).toContain('Woodie, Nadia')
-    expect(wrapper.find('.certify-checkbox label').text()).toContain('certifies that')
-    expect(wrapper.find('.certify-checkbox label').text()).toContain('of the entity')
+    const fmCertifyLabel = wrapper.find('.certify-checkbox label').text()
+    expect(fmCertifyLabel).toContain('Woodie, Nadia')
+    expect(fmCertifyLabel).toContain('certifies that')
+    expect(fmCertifyLabel).toContain('of the entity')
     expect(wrapper.find('.certify-clause').text()).toBe('Lorem ipsum dolor sit amet.')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "sbc-auth",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "sbc-auth",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/12792

*Description of changes:*
- [x] Corrected text: **either the name of the prorietor or a partner, and the business number for firms doing business as.** --> **either the name of the prorietor or a partner**
- [x] Corrected text: **they are authorized to make this filing** --> **they are authorized to act on behalf of this business.**
- [x] Corrected text: **For firms** --> **For sole proprietorships and general partnerships**
- [x] The certify statement pre-populates with the user ID (last name, first name) (removal of `legalName` in Certify.vue)
- [x] The primary button (the Add button) should be enabled at all times and trigger the validations.
- [x] Unit tests

Click for the [UI Design link](https://projects.invisionapp.com/share/H612PJX3F2KJ#/screens/467047952?browse)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
