### PR TITLE
Turn Sentry Off by using SENTRY_ENABLE FLAG instead of SENTRY_DSN#12422

### DIFF
--- a/auth-api/devops/vaults.json
+++ b/auth-api/devops/vaults.json
@@ -29,13 +29,18 @@
             "account-mailer"
         ]
     },
-    {
+	{
         "vault": "relationship",
         "application": [
             "postgres-auth",
             "auth-api",
-            "sentry",
             "jwt"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+             "relationship-api"
         ]
     },
     {

--- a/auth-api/docs/dotenv_template
+++ b/auth-api/docs/dotenv_template
@@ -32,6 +32,7 @@ SQLALCHEMY_ECHO=False
 # The sentry.io Data Source Name for the project. For local development this should always be blank, to prevent the
 # logging (and emailing) of errors. However it can be temporarily set when working with sentry itself.
 #
+SENTRY_ENABLE=False
 SENTRY_DSN=
 
 # keycloak settings

--- a/auth-api/src/auth_api/__init__.py
+++ b/auth-api/src/auth_api/__init__.py
@@ -44,11 +44,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app.config.from_object(config.CONFIGURATION[run_mode])
 
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
-        sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[FlaskIntegration()]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[FlaskIntegration()]
+            )
 
     from auth_api.resources import TEST_BLUEPRINT  # pylint: disable=import-outside-toplevel
     from auth_api.resources import API_BLUEPRINT, OPS_BLUEPRINT  # pylint: disable=import-outside-toplevel

--- a/auth-api/src/auth_api/config.py
+++ b/auth-api/src/auth_api/config.py
@@ -142,6 +142,7 @@ class _Config:  # pylint: disable=too-few-public-methods
     STAFF_ADMIN_EMAIL = os.getenv('STAFF_ADMIN_EMAIL')
 
     # Sentry Config
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     # front end serves this image in this name.can be moved to openshift config as well..

--- a/auth-web/src/main.ts
+++ b/auth-web/src/main.ts
@@ -38,7 +38,7 @@ ConfigHelper.saveConfigToSessionStorage().then(async (data) => {
   // addressCompleteKey is for canada post address lookup, which is to be used in sbc-common-components
   (<any>window).addressCompleteKey = ConfigHelper.getValue('ADDRESS_COMPLETE_KEY')
 
-  if (ConfigHelper.getValue('SENTRY_ENABLE') === 'true') {
+  if (ConfigHelper.getValue('SENTRY_ENABLE').lower() === 'true') {
     // initialize Sentry
     console.info('Initializing Sentry...') // eslint-disable-line no-console
     Sentry.init({

--- a/queue_services/account-mailer/devops/vaults.json
+++ b/queue_services/account-mailer/devops/vaults.json
@@ -32,8 +32,13 @@
         "application": [
             "postgres-auth",
             "account-mailer",
-            "sentry",
             "jwt"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+             "relationship-api"
         ]
     }
 ]

--- a/queue_services/account-mailer/src/account_mailer/config.py
+++ b/queue_services/account-mailer/src/account_mailer/config.py
@@ -63,6 +63,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     TESTING = False
     DEBUG = False
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/queue_services/activity-log-listener/devops/vaults.json
+++ b/queue_services/activity-log-listener/devops/vaults.json
@@ -9,8 +9,13 @@
     {
         "vault": "relationship",
         "application": [
-            "postgres-auth",
-            "sentry"
+            "postgres-auth"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+             "relationship-api"
         ]
     }
 ]

--- a/queue_services/activity-log-listener/src/activity_log_listener/config.py
+++ b/queue_services/activity-log-listener/src/activity_log_listener/config.py
@@ -60,6 +60,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/queue_services/business-events-listener/devops/vaults.json
+++ b/queue_services/business-events-listener/devops/vaults.json
@@ -9,8 +9,13 @@
     {
         "vault": "relationship",
         "application": [
-            "postgres-auth",
-            "sentry"
+            "postgres-auth"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+             "relationship-api"
         ]
     },
     {

--- a/queue_services/business-events-listener/src/business_events_listener/config.py
+++ b/queue_services/business-events-listener/src/business_events_listener/config.py
@@ -60,6 +60,7 @@ class _Config:  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/queue_services/events-listener/devops/vaults.json
+++ b/queue_services/events-listener/devops/vaults.json
@@ -9,8 +9,13 @@
     {
         "vault": "relationship",
         "application": [
-            "postgres-auth",
-            "sentry"
+            "postgres-auth"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+             "relationship-api"
         ]
     }
 ]

--- a/queue_services/events-listener/src/events_listener/config.py
+++ b/queue_services/events-listener/src/events_listener/config.py
@@ -60,6 +60,7 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN', None)
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/status-api/config.py
+++ b/status-api/config.py
@@ -53,6 +53,7 @@ class _Config(object):  # pylint: disable=too-few-public-methods
     """Base class configuration that should set reasonable defaults for all the other configurations. """
     PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
+    SENTRY_ENABLE = os.getenv('SENTRY_ENABLE', 'False')
     SENTRY_DSN = os.getenv('SENTRY_DSN')
 
     SERVICE_SCHEDULE = os.getenv('SERVICE_SCHEDULE')
@@ -71,6 +72,7 @@ class DevConfig(_Config):  # pylint: disable=too-few-public-methods
 
 class TestConfig(_Config):  # pylint: disable=too-few-public-methods
     """In support of testing only used by the py.test suite."""
+    SENTRY_ENABLE = False
     SENTRY_DSN = None
 
     schedule_json = [

--- a/status-api/devops/vaults.json
+++ b/status-api/devops/vaults.json
@@ -2,8 +2,13 @@
     {
         "vault": "relationship",
         "application": [
-            "status-api",
-            "sentry"
+            "status-api"
+        ]
+    },
+    {
+        "vault": "sentry",
+        "application": [
+             "relationship-api"
         ]
     }
 ]

--- a/status-api/docs/dotenv_template
+++ b/status-api/docs/dotenv_template
@@ -16,6 +16,7 @@ SQLALCHEMY_ECHO=False
 # The sentry.io Data Source Name for the project. For local development this should always be blank, to prevent the
 # logging (and emailing) of errors. However it can be temporarily set when working with sentry itself.
 #
+SENTRY_ENABLE=False
 SENTRY_DSN=
 
 SERVICE_SCHEDULE= '[

--- a/status-api/requirements/prod.txt
+++ b/status-api/requirements/prod.txt
@@ -9,3 +9,5 @@ requests
 sentry-sdk[flask]
 arrow
 Werkzeug<2
+Jinja2==3.0.3
+itsdangerous==2.0.1

--- a/status-api/setup.cfg
+++ b/status-api/setup.cfg
@@ -62,7 +62,7 @@ good-names=
 
 [pylint]
 ignore=migrations,test
-max_line_length=120
+max-line-length=120
 notes=FIXME,XXX,TODO
 ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
 ignored-classes=scoped_session
@@ -70,6 +70,15 @@ generated-members=Error # allows dynamically generated member references
 min-similarity-lines=15
 disable=C0301,W0511
 load-plugins=pylint_flask
+good-names=
+    b,
+    d,
+    i,
+    e,
+    f,
+    u,
+    rv,
+    logger,
 
 [isort]
 line_length = 120

--- a/status-api/src/status_api/__init__.py
+++ b/status-api/src/status_api/__init__.py
@@ -38,11 +38,12 @@ def create_app(run_mode=os.getenv('FLASK_ENV', 'production')):
     app.config.from_object(CONFIGURATION[run_mode])
 
     # Configure Sentry
-    if app.config.get('SENTRY_DSN', None):
-        sentry_sdk.init(
-            dsn=app.config.get('SENTRY_DSN'),
-            integrations=[FlaskIntegration()]
-        )
+    if str(app.config.get('SENTRY_ENABLE')).lower() == 'true':
+        if app.config.get('SENTRY_DSN', None):
+            sentry_sdk.init(
+                dsn=app.config.get('SENTRY_DSN'),
+                integrations=[FlaskIntegration()]
+            )
 
     from status_api.resources import API_BLUEPRINT, OPS_BLUEPRINT  # pylint: disable=import-outside-toplevel
 

--- a/status-api/src/status_api/resources/whatsnew.py
+++ b/status-api/src/status_api/resources/whatsnew.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Resource for Service status endpoints."""
-import json
 from http import HTTPStatus
 
 from flask import current_app


### PR DESCRIPTION
Signed-off-by: Chen <Steven.Chen@gov.bc.ca>

*Issue #:*
https://github.com/bcgov/entity/issues/12422>

*Description of changes:*
Turn Sentry Off by using SENTRY_ENABLE FLAG instead of SENTRY_DSN


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
