### PR TITLE
12877 - Add Account-Id to headers.

### DIFF
--- a/auth-web/src/services/payment.services.ts
+++ b/auth-web/src/services/payment.services.ts
@@ -25,8 +25,9 @@ export default class PaymentService {
     })
   }
 
-  static getInvoice (invoiceId: string): AxiosPromise<Invoice> {
-    return axios.get(`${ConfigHelper.getPayAPIURL()}/payment-requests/${invoiceId}`)
+  static getInvoice (invoiceId: string, accountId: number): AxiosPromise<Invoice> {
+    let headers = accountId ? { 'Account-Id': accountId } : {}
+    return axios.get(`${ConfigHelper.getPayAPIURL()}/payment-requests/${invoiceId}`, { headers: headers })
   }
 
   static updateInvoicePaymentMethodAsCreditCard (paymentId: string): AxiosPromise<any> {

--- a/auth-web/src/services/payment.services.ts
+++ b/auth-web/src/services/payment.services.ts
@@ -26,7 +26,7 @@ export default class PaymentService {
   }
 
   static getInvoice (invoiceId: string, accountId: number): AxiosPromise<Invoice> {
-    let headers = accountId ? { 'Account-Id': accountId } : {}
+    const headers = accountId ? { 'Account-Id': accountId } : {}
     return axios.get(`${ConfigHelper.getPayAPIURL()}/payment-requests/${invoiceId}`, { headers: headers })
   }
 

--- a/auth-web/src/store/modules/org.ts
+++ b/auth-web/src/store/modules/org.ts
@@ -949,8 +949,8 @@ export default class OrgModule extends VuexModule {
   }
 
   @Action({ rawError: true })
-  public async getInvoice (paymentId: string) {
-    const response = await PaymentService.getInvoice(paymentId)
+  public async getInvoice (invoicePayload) {
+    const response = await PaymentService.getInvoice(invoicePayload.invoiceId, invoicePayload.accountId)
     return response?.data || {}
   }
 

--- a/auth-web/src/views/pay/PaymentView.vue
+++ b/auth-web/src/views/pay/PaymentView.vue
@@ -88,7 +88,7 @@ export default class PaymentView extends Vue {
   private readonly updateInvoicePaymentMethodAsCreditCard!: (paymentId: string) => any
   private readonly downloadOBInvoice!: (paymentId: string) => any
   private readonly getOrgPayments!: (orgId: number) => OrgPaymentDetails
-  private readonly getInvoice!: (paymentId: string) => Invoice
+  private readonly getInvoice!: (invoicePayload) => Invoice
   private showLoading: boolean = true
   private showdownloadLoading: boolean = false
   private showOnlineBanking: boolean = false
@@ -111,7 +111,7 @@ export default class PaymentView extends Vue {
       if (this.isUserSignedIn && !!accountSettings) {
         // get the invoice and check for OB
         try {
-          const invoice: Invoice = await this.getInvoice(this.paymentId)
+          const invoice: Invoice = await this.getInvoice({ invoiceId: this.paymentId, accountId: accountSettings?.id })
           if (invoice?.paymentMethod === PaymentTypes.ONLINE_BANKING) {
             // get account data to show in the UI
             const paymentDetails: OrgPaymentDetails = await this.getOrgPayments(accountSettings?.id)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/12877

*Description of changes:*
12877 - Add Account-Id to headers.

If `Account-Id` isn't added to headers, it takes the business identifier auth route. But the business doesn't have an affiliation so it fails. The business gets an affiliation after name request has been paid. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
