### PR TITLE
13287 - ACTIVITY-LOG-LISTENER - InvalidRequestError: Can't reconnect until invalid transaction is rolled back

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ritvick @seeker25
+* @shabeeb-aot @ritvick @seeker25

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @shabeeb-aot @ritvick @seeker25
+* @ritvick @seeker25

--- a/queue_services/activity-log-listener/setup.cfg
+++ b/queue_services/activity-log-listener/setup.cfg
@@ -74,6 +74,23 @@ notes=FIXME,XXX,TODO
 ignored-modules=flask_sqlalchemy,sqlalchemy,SQLAlchemy,alembic,scoped_session
 ignored-classes=scoped_session
 disable=C0301,W0511,R0801,R0902
+good-names=
+    b,
+    d,
+    i,
+    e,
+    f,
+    k,
+    u,
+    v,
+    ar,
+    cb, #common shorthand for callback
+    nc,
+    rv,
+    sc,
+    event_loop,
+    logger,
+    loop,
 
 [isort]
 line_length = 120

--- a/queue_services/activity-log-listener/src/activity_log_listener/version.py
+++ b/queue_services/activity-log-listener/src/activity_log_listener/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.17.0'  # pylint: disable=invalid-name
+__version__ = '2.17.1'  # pylint: disable=invalid-name

--- a/queue_services/activity-log-listener/src/activity_log_listener/worker.py
+++ b/queue_services/activity-log-listener/src/activity_log_listener/worker.py
@@ -64,8 +64,12 @@ async def process_event(event_message, flask_app):
                                                             created=data.get('createdAt'),
                                                             org_id=data.get('orgId')
                                                             )
-        activity_model.save()
-        logger.debug('activity log saved')
+        try:
+            activity_model.save()
+            logger.debug('activity log saved')
+        except Exception as e:  # NOQA # pylint: disable=broad-except
+            logger.error('DB Error: %s', e)
+            activity_model.rollback()
 
 
 async def cb_subscription_handler(msg: nats.aio.client.Msg):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/13287

*Description of changes:*
Exception wrapping, to avoid InvalidRequestError: Can't reconnect until invalid transaction is rolled back

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
