### PR TITLE
13251 Auth Web - Move buttons

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/src/components/auth/manage-business/EntityManagement.vue
+++ b/auth-web/src/components/auth/manage-business/EntityManagement.vue
@@ -6,7 +6,7 @@
       </div>
     </v-fade-transition>
 
-    <v-container class="view-container">
+    <v-container justify class="view-container">
       <div class="view-header align-center">
         <h1 class="view-header__title">My Business Registry<br>
           <span class="subtitle">{{ $t('myBusinessDashSubtitle') }}</span>
@@ -26,7 +26,7 @@
       </div>
 
       <v-row no-gutters id="dashboard-actions" class="mb-n3">
-        <v-flex shrink class="mr-4">
+        <v-col cols="auto">
           <!-- Add Existing Name Request or Business -->
           <v-menu
             v-model="addAffiliationDropdown"
@@ -36,7 +36,7 @@
                 <template v-slot:activator="{ on: onTooltip }">
                   <v-btn
                     id="add-existing-btn"
-                    class="mt-2"
+                    class="mt-2 mr-4"
                     color="primary"
                     dark large
                     v-on="{ ...onMenu, ...onTooltip }"
@@ -61,13 +61,13 @@
               <v-list-item class="add-existing-item" @click="showAddNRModal()">Name Request</v-list-item>
             </v-list>
           </v-menu>
-        </v-flex>
-        <v-flex shrink>
+        </v-col>
+        <v-col cols="auto">
           <v-tooltip top max-width="361px" content-class="top-tooltip">
             <template v-slot:activator="{ on, attrs }">
               <v-btn
                 id="incorporate-numbered-btn"
-                class="mt-2"
+                class="mt-2 mr-4"
                 color="primary"
                 outlined dark large
                 v-bind="attrs"
@@ -80,8 +80,8 @@
             </template>
             <span>Start an incorporation application for a numbered benefit company in B.C.</span>
           </v-tooltip>
-        </v-flex>
-        <v-flex>
+        </v-col>
+        <v-col>
           <v-select
             dense filled multiple
             class="column-selector"
@@ -92,7 +92,7 @@
           >
             <template v-slot:selection></template>
           </v-select>
-        </v-flex>
+        </v-col>
       </v-row>
 
       <AffiliatedEntityTable
@@ -337,7 +337,7 @@ export default class EntityManagement extends Mixins(AccountChangeMixin, NextPag
   }
 
   // create a numbered company
-  async startNumberedCompany () {
+  protected async startNumberedCompany () {
     await this.createNumberedBusiness(this.currentAccountSettings.id)
     await this.syncBusinesses()
   }

--- a/auth-web/src/components/auth/manage-business/EntityManagement.vue
+++ b/auth-web/src/components/auth/manage-business/EntityManagement.vue
@@ -26,24 +26,29 @@
       </div>
 
       <v-row no-gutters id="dashboard-actions" class="mb-n3">
-        <v-col cols="9">
+        <v-flex shrink class="mr-4">
           <!-- Add Existing Name Request or Business -->
           <v-menu
             v-model="addAffiliationDropdown"
           >
-            <template v-slot:activator="{ on }">
-              <v-btn
-                id="add-existing-btn"
-                class="mt-2"
-                color="primary"
-                dark
-                large
-                v-on="on"
-              >
-                <v-icon>mdi-plus</v-icon>
-                <span><strong>Add an Existing Business or Name Request</strong></span>
-                <v-icon class="ml-2 mr-n2">{{ addAffiliationDropdown ? 'mdi-menu-up' : 'mdi-menu-down' }}</v-icon>
-              </v-btn>
+            <template v-slot:activator="{ on: onMenu }">
+              <v-tooltip top content-class="top-tooltip">
+                <template v-slot:activator="{ on: onTooltip }">
+                  <v-btn
+                    id="add-existing-btn"
+                    class="mt-2"
+                    color="primary"
+                    dark large
+                    v-on="{ ...onMenu, ...onTooltip }"
+                    @click="addAffiliationDropdown = !addAffiliationDropdown"
+                  >
+                    <v-icon>mdi-plus</v-icon>
+                    <span><strong>Add an Existing Business or Name Request</strong></span>
+                    <v-icon class="ml-2 mr-n2">{{ addAffiliationDropdown ? 'mdi-menu-up' : 'mdi-menu-down' }}</v-icon>
+                  </v-btn>
+                </template>
+                <span>To view and manage existing businesses and Name Requests, you can manually add them to your table.</span>
+              </v-tooltip>
             </template>
             <v-list>
               <v-list-item>
@@ -56,8 +61,27 @@
               <v-list-item class="add-existing-item" @click="showAddNRModal()">Name Request</v-list-item>
             </v-list>
           </v-menu>
-        </v-col>
-        <v-col>
+        </v-flex>
+        <v-flex shrink>
+          <v-tooltip top max-width="361px" content-class="top-tooltip">
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                id="incorporate-numbered-btn"
+                class="mt-2"
+                color="primary"
+                outlined dark large
+                v-bind="attrs"
+                v-on="on"
+                @click="startNumberedCompany()"
+              >
+                <v-icon>mdi-plus</v-icon>
+                <span><strong>Incorporate a Numbered Benefit Company</strong></span>
+              </v-btn>
+            </template>
+            <span>Start an incorporation application for a numbered benefit company in B.C.</span>
+          </v-tooltip>
+        </v-flex>
+        <v-flex>
           <v-select
             dense filled multiple
             class="column-selector"
@@ -68,7 +92,7 @@
           >
             <template v-slot:selection></template>
           </v-select>
-        </v-col>
+        </v-flex>
       </v-row>
 
       <AffiliatedEntityTable
@@ -312,6 +336,12 @@ export default class EntityManagement extends Mixins(AccountChangeMixin, NextPag
     window.location.href = appendAccountId(ConfigHelper.getNameRequestUrl())
   }
 
+  // create a numbered company
+  async startNumberedCompany () {
+    await this.createNumberedBusiness(this.currentAccountSettings.id)
+    await this.syncBusinesses()
+  }
+
   async showAddSuccessModal () {
     this.addBusinessDialog = false
     this.dialogTitle = 'Business Added'
@@ -490,6 +520,37 @@ export default class EntityManagement extends Mixins(AccountChangeMixin, NextPag
   opacity: 0.46;
   background-color: rgb(33, 33, 33); // grey darken-4
   border-color: rgb(33, 33, 33); // grey darken-4
+}
+
+.v-tooltip__content {
+  background-color: RGBA(73, 80, 87, 0.95) !important;
+  color: white !important;
+  border-radius: 4px;
+  font-size: 12px !important;
+  line-height: 18px !important;
+  padding: 15px !important;
+  letter-spacing: 0;
+  max-width: 360px !important;
+}
+
+.v-tooltip__content:after {
+  content: "" !important;
+  position: absolute !important;
+  top: 50% !important;
+  right: 100% !important;
+  margin-top: -10px !important;
+  border-top: 10px solid transparent !important;
+  border-bottom: 10px solid transparent !important;
+  border-right: 8px solid RGBA(73, 80, 87, .95) !important;
+}
+
+.top-tooltip:after {
+  top: 100% !important;
+  left: 45% !important;
+  margin-top: 0 !important;
+  border-right: 10px solid transparent !important;
+  border-left: 10px solid transparent !important;
+  border-top: 8px solid RGBA(73, 80, 87, 0.95) !important;
 }
 
 .view-header {

--- a/auth-web/src/locales/en.json
+++ b/auth-web/src/locales/en.json
@@ -197,7 +197,7 @@
   "removeRegistrationSuccessText": "You have successfully deleted a registration",
   "removeRegistrationConfirmTitle": "Delete Registration?",
   "removeRegistrationConfirmText": "Deleting this registration will remove the application from your Business Registry list. The business associated with this application will not be registered. If this registration was associated with a Name Request, the Name Request can still be used to register a business.",
-  "myBusinessDashSubtitle": "Start BC-based businesses and keep business records up to date.",
+  "myBusinessDashSubtitle": "Start B.C. based businesses and keep business records up to date.",
   "onHoldOrRejectModalText": "To place account on hold, please choose a reason. An email will be sent to the user to resolve the issue. Or choose \"Reject Account\"",
   "developerAccessSubtitle":"Enabling developer access would allow you to integrate the BC Registries API services to your system.<br />Learn more in the  <a href=\"{url}\">API documentation</a>.",
   "assetLauncherText": "Register or search for manufactured homes and register or search for legal claims on personal property.",

--- a/auth-web/tests/unit/components/EntityManagement.spec.ts
+++ b/auth-web/tests/unit/components/EntityManagement.spec.ts
@@ -33,7 +33,7 @@ function getPayLoad (type:string) {
 
 describe('Entity Management Component', () => {
   let wrapper: any
-  let mockedNrMethod:any
+  let mockedNrMethod: any
 
   beforeEach(() => {
     const localVue = createLocalVue()
@@ -113,5 +113,20 @@ describe('Entity Management Component', () => {
     wrapper.vm.showConfirmationOptionsModal(removeBusinessPayload)
     expect(mockedNrMethod).toHaveBeenCalledTimes(0)
     expect(mockedPasscodeResetMethod).toHaveBeenCalled()
+  })
+
+  it('all buttons, tooltips and v-menu selections exist', async () => {
+    // All buttons exist
+    expect(wrapper.find('#add-existing-btn').exists()).toBe(true)
+    expect(wrapper.find('#add-name-request-btn').exists()).toBe(true)
+    expect(wrapper.find('#incorporate-numbered-btn').exists()).toBe(true)
+
+    // Existing Business or NameRequest menu selections
+    wrapper.find('#add-existing-btn').trigger('click')
+    await Vue.nextTick()
+    expect(wrapper.findAll('.add-existing-item').length).toBe(2)
+
+    // tooltips exist
+    expect(wrapper.findAll('.top-tooltip').length).toBe(2)
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13251

*Description of changes:*
- Move incorporate numbered company from business marketing page, btn from HomeView in [13253](https://github.com/bcgov/sbc-auth/pull/2056)
- Add tooltips for "incorporate numbered company" and "Add an Existing Business or NR" btns
- typo correction
- unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
