### PR TITLE
13370 Fix Incorporate a numbered ben company btn and wrong color for login btn text

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/src/components/auth/manage-business/EntityManagement.vue
+++ b/auth-web/src/components/auth/manage-business/EntityManagement.vue
@@ -70,7 +70,7 @@
                 outlined dark large
                 v-bind="attrs"
                 v-on="on"
-                @click="goToManageBusinesses()"
+                @click="startNumberedCompany()"
               >
                 <v-icon>mdi-plus</v-icon>
                 <span><strong>Incorporate a Numbered Benefit Company</strong></span>
@@ -336,7 +336,7 @@ export default class EntityManagement extends Mixins(AccountChangeMixin, NextPag
 
   // create a numbered company
   protected async startNumberedCompany () {
-    await this.createNumberedBusiness(this.currentAccountSettings.id)
+    await this.createNumberedBusiness(this.currentOrganization.id)
     await this.syncBusinesses()
   }
 
@@ -506,12 +506,6 @@ export default class EntityManagement extends Mixins(AccountChangeMixin, NextPag
 
   close () {
     this.$refs.errorDialog.close()
-  }
-
-  private goToManageBusinesses (isNumberedCompanyRequest: boolean = true): void {
-    let manageBusinessUrl: any = { path: `/${Pages.MAIN}/${this.currentAccountSettings.id}` }
-    manageBusinessUrl.query = { isNumberedCompanyRequest }
-    this.$router.push(manageBusinessUrl)
   }
 }
 </script>

--- a/auth-web/src/views/auth/home/HomeView.vue
+++ b/auth-web/src/views/auth/home/HomeView.vue
@@ -565,8 +565,4 @@ export default class HomeView extends Vue {
     background-color: transparent;
   }
 
-  .hero-banner-login-btn {
-    color: #003366 !important;
-  }
-
 </style>


### PR DESCRIPTION

*Issue #:* /bcgov/entity#13370

*Description of changes:*
- Deleted unused function which did the same thing as startNumberedCompany
- changed account id fetching so it works for staff and users
- Make text white for Home log in btn
- App version = 1.1.2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
