### PR TITLE
13501 Invitation emails - add warning about which browsers are supported

### DIFF
--- a/queue_services/account-mailer/src/account_mailer/email_templates/business_invitation_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/business_invitation_email.html
@@ -29,6 +29,10 @@
                             <strong>{{ user_first_name }} {{ user_last_name }}</strong> has invited you to join the <strong>{{ account_name }}</strong> account at Business Registry. You will need to log in using your BC Services Card to join this account.
                         </p>
                         <div style="margin-top: 45px;">
+                            <p style="font-family: Verdana, Arial, sans-serif; font-size: 16px;">
+                                <strong> Note: </strong>
+                                All browsers will work, except for Internet Explorer.
+                             </p>
                             <!--[if mso]> <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ context_url }}" style="height:55px; v-text-anchor:middle; width:150px;" arcsize="10%" stroke="f" fillcolor="#003366" alias="CTA1">Join Team<w:anchorlock/> <center> <![endif]-->
                             <a style="display: inline-block; width: 150px; color: #ffffff; border: none; border-radius: 6px; background-color: #003366; line-height: 55px; text-align: center; text-decoration: none; font-size: 16px; font-weight: bold;"
                                href="{{ context_url }}">Join Account</a>

--- a/queue_services/account-mailer/src/account_mailer/email_templates/business_invitation_email_for_bceid.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/business_invitation_email_for_bceid.html
@@ -34,6 +34,10 @@
                             {% endif %}
                         </p>
                         <div style="margin-top: 45px;">
+                            <p style="font-family: Verdana, Arial, sans-serif; font-size: 16px;">
+                                <strong> Note: </strong>
+                                All browsers will work, except for Internet Explorer.
+                             </p>
                             <!--[if mso]> <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ context_url }}" style="height:55px; v-text-anchor:middle; width:150px;" arcsize="10%" stroke="f" fillcolor="#003366" alias="CTA1">Join Team<w:anchorlock/> <center> <![endif]-->
                             <a style="display: inline-block; width: 150px; color: #ffffff; border: none; border-radius: 6px; background-color: #003366; line-height: 55px; text-align: center; text-decoration: none; font-size: 16px; font-weight: bold;"
                                href="{{ context_url }}">Join Account</a>

--- a/queue_services/account-mailer/src/account_mailer/email_templates/dirsearch_business_invitation_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/dirsearch_business_invitation_email.html
@@ -28,6 +28,10 @@
                         <p style="margin-top: 25px; margin-bottom: 0; line-height: 24px; font-family: Verdana, Arial, sans-serif; font-size: 16px;">
                             BC Registries staff have approved your organization's account to search for active and historical directors. You are the account administrator.<br/> To complete the account setup, click the link below and create your Username and Password. Then login to your account and manage your team's access to Director Search.  </p>
                         <div style="margin-top: 45px;">
+                            <p style="font-family: Verdana, Arial, sans-serif; font-size: 16px;">
+                                <strong> Note: </strong>
+                                All browsers will work, except for Internet Explorer.
+                             </p>
                             <!--[if mso]> <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ context_url }}" style="height:55px; v-text-anchor:middle; width:150px;" arcsize="10%" stroke="f" fillcolor="#003366" alias="CTA1">Join Team<w:anchorlock/> <center> <![endif]-->
                             <a style="display: inline-block; width: 150px; color: #ffffff; border: none; border-radius: 6px; background-color: #003366; line-height: 55px; text-align: center; text-decoration: none; font-size: 16px; font-weight: bold;"
                                href="{{ context_url }}">Access Account</a>

--- a/queue_services/account-mailer/src/account_mailer/email_templates/govm_business_invitation_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/govm_business_invitation_email.html
@@ -1,44 +1,57 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <base href="/">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="referrer" content="origin-when-cross-origin"/>
+    <meta name="referrer" content="origin-when-cross-origin" />
     <meta name="author" content="BC Registries and Online Services">
     <title> {{ title }}</title>
     [[style.html]]
 </head>
+
 <body>
-<table style="width: 100%;" cellspacing="0" cellpadding="0">
-    <tr>
-        <td style="padding-left: 20px; padding-right: 20px;">
-            <table style="max-width: 640px; margin: 0 auto; border: 0; border-collapse: collapse; border-radius: 6px; background-color: #ffffff;"
-                   cellspacing="0" cellpadding="0">
-                <tr>
-                    <td style="padding-top: 30px; padding-bottom: 30px;">
-                        [[logo.html]]
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <h1 style="margin: 0; line-height: 34px; letter-spacing: -1px; font-family: Verdana, Arial, sans-serif; font-size: 24px; font-weight: 700;">
-                            You've been invited to create BC Registries account.
-                        </h1>
-                        <p style="margin-top: 25px; margin-bottom: 0; line-height: 24px; font-family: Verdana, Arial, sans-serif; font-size: 16px;">
-                            BC Registries staff have invited you to create a Business Registry account. You are the account administrator for the account {{ account_name }}.<br/> To complete the account setup, click the button below and create your account. Then login to your account and manage your team members.
-                        </p>
-                        <div style="margin-top: 45px;">
-                            <!--[if mso]> <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ context_url }}" style="height:55px; v-text-anchor:middle; width:150px;" arcsize="10%" stroke="f" fillcolor="#003366" alias="CTA1">Join Team<w:anchorlock/> <center> <![endif]-->
-                            <a style="display: inline-block; width: 150px; color: #ffffff; border: none; border-radius: 6px; background-color: #003366; line-height: 55px; text-align: center; text-decoration: none; font-size: 16px; font-weight: bold;"
-                               href="{{ context_url }}">Create Account</a>
-                            <!--[if mso]> </center> </v:roundrect> <![endif]-->
-                        </div>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
+    <table style="width: 100%;" cellspacing="0" cellpadding="0">
+        <tr>
+            <td style="padding-left: 20px; padding-right: 20px;">
+                <table
+                    style="max-width: 640px; margin: 0 auto; border: 0; border-collapse: collapse; border-radius: 6px; background-color: #ffffff;"
+                    cellspacing="0" cellpadding="0">
+                    <tr>
+                        <td style="padding-top: 30px; padding-bottom: 30px;">
+                            [[logo.html]]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <h1
+                                style="margin: 0; line-height: 34px; letter-spacing: -1px; font-family: Verdana, Arial, sans-serif; font-size: 24px; font-weight: 700;">
+                                You've been invited to create BC Registries account.
+                            </h1>
+                            <p
+                                style="margin-top: 25px; margin-bottom: 0; line-height: 24px; font-family: Verdana, Arial, sans-serif; font-size: 16px;">
+                                BC Registries staff have invited you to create a Business Registry account. You are the
+                                account administrator for the account {{ account_name }}.<br /> To complete the account
+                                setup, click the button below and create your account. Then login to your account and
+                                manage your team members.
+                            </p>
+                            <div style="margin-top: 45px;">
+                                <p style="font-family: Verdana, Arial, sans-serif; font-size: 16px;">
+                                    <strong> Note: </strong>
+                                    All browsers will work, except for Internet Explorer.
+                                 </p>
+                                <!--[if mso]> <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ context_url }}" style="height:55px; v-text-anchor:middle; width:150px;" arcsize="10%" stroke="f" fillcolor="#003366" alias="CTA1">Join Team<w:anchorlock/> <center> <![endif]-->
+                                <a style="display: inline-block; width: 150px; color: #ffffff; border: none; border-radius: 6px; background-color: #003366; line-height: 55px; text-align: center; text-decoration: none; font-size: 16px; font-weight: bold;"
+                                    href="{{ context_url }}">Create Account</a>
+                                <!--[if mso]> </center> </v:roundrect> <![endif]-->
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
 </body>
+
 </html>

--- a/queue_services/account-mailer/src/account_mailer/email_templates/govm_member_invitation_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/govm_member_invitation_email.html
@@ -31,6 +31,10 @@
                             Click “Join Account” and log on with your IDIR username and password to join the {{ account_name }} account.
                         </p>
                         <div style="margin-top: 45px;">
+                            <p style="font-family: Verdana, Arial, sans-serif; font-size: 16px;">
+                                <strong> Note: </strong>
+                                All browsers will work, except for Internet Explorer.
+                             </p>
                             <!--[if mso]> <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{ context_url }}" style="height:55px; v-text-anchor:middle; width:150px;" arcsize="10%" stroke="f" fillcolor="#003366" alias="CTA1">Join Team<w:anchorlock/> <center> <![endif]-->
                             <a style="display: inline-block; width: 150px; color: #ffffff; border: none; border-radius: 6px; background-color: #003366; line-height: 55px; text-align: center; text-decoration: none; font-size: 16px; font-weight: bold;"
                                href="{{ context_url }}">Join Account</a>


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/13501

*Description of changes:*

    - Added warning in invitation email templates to notify users that Internet Explorer is not supported.
    - Auto reformated govm_business_invitation file on accident

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
