### PR TITLE
13014 Auth Web: Affiliation modal dialog should not validate incorporation/registration number until focus leaves the field

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/src/components/auth/manage-business/AddBusinessDialog.vue
+++ b/auth-web/src/components/auth/manage-business/AddBusinessDialog.vue
@@ -42,7 +42,7 @@
           <v-form ref="addBusinessForm" lazy-validation class="mt-6">
             <!-- Business Identifier -->
             <v-text-field
-              filled req persistent-hint
+              filled req persistent-hint validate-on-blur
               label="Incorporation Number or Registration Number"
               hint="Example: BC1234567, CP1234567 or FM1234567"
               :rules="businessIdentifierRules"
@@ -173,12 +173,7 @@ export default class AddBusinessDialog extends Vue {
   protected folioNumber = ''
   protected isLoading = false
   protected isCertified = false // firms only
-
-  readonly businessIdentifierRules = [
-    v => !!v || 'Incorporation Number or Registration Number is required',
-    v => CommonUtils.validateIncorporationNumber(v) ||
-      'Incorporation Number or Registration Number is not valid'
-  ]
+  protected businessIdentifierRules = []
 
   readonly certifyClause = 'Note: It is an offence to make or assist in making a false or misleading ' +
     'statement in a record filed under the Partnership Act. A person who commits this offence is ' +
@@ -316,6 +311,11 @@ export default class AddBusinessDialog extends Vue {
   }
 
   protected formatBusinessIdentifier (): void {
+    this.businessIdentifierRules = [
+      v => !!v || 'Incorporation Number or Registration Number is required',
+      v => CommonUtils.validateIncorporationNumber(v) ||
+        'Incorporation Number or Registration Number is not valid'
+    ]
     this.businessIdentifier = CommonUtils.formatIncorporationNumber(this.businessIdentifier)
   }
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/13014

*Description of changes:*
- updated rules validation on blur only


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
