### PR TITLE
13622 - Ensure $1.05 is the only Service Fee selectable by BCOL Admin during account creation

### DIFF
--- a/auth-web/src/components/auth/account-settings/product/ProductPackage.vue
+++ b/auth-web/src/components/auth/account-settings/product/ProductPackage.vue
@@ -198,7 +198,7 @@ export default class ProductPackage extends Mixins(AccountChangeMixin) {
       productData = {
         'product': productCode,
         'applyFilingFees': true,
-        'serviceFeeCode': 'TRF01'
+        'serviceFeeCode': productCode === 'ESRA' ? 'TRF03' : 'TRF01'
       }
     }
 

--- a/auth-web/src/components/auth/common/Product.vue
+++ b/auth-web/src/components/auth/common/Product.vue
@@ -111,6 +111,7 @@
                 />
                 <div v-if="showProductFee">
                   <v-divider class="my-6"></v-divider>
+                  <!-- This links to ProductFeeViewEdit. -->
                   <ProductFee :orgProduct="orgProduct"
                   :orgProductFeeCodes="orgProductFeeCodes"
                   @save:saveProductFee="saveProductFee"

--- a/auth-web/src/components/auth/common/ProductFeeViewEdit.vue
+++ b/auth-web/src/components/auth/common/ProductFeeViewEdit.vue
@@ -22,7 +22,7 @@
         <div v-else class="d-flex w-100">
           <ProductFeeSelector
             :canSelect="true"
-            :orgProductFeeCodes="orgProductFeeCodes"
+            :orgProductFeeCodes="getOrgProductFeeCodesForProduct(orgProduct.product)"
             @update:updatedProductFee="updatedProductFee"
             :productCode="orgProduct.product"
             :selectedApplyFilingFees="existingFeeCodes"
@@ -131,6 +131,11 @@ export default class ProductFeeViewEdit extends Vue {
   @Emit('save:saveProductFee')
   private saveProductFee () {
     return this.selectedFee
+  }
+
+  // Only allow $1.05 fee code for ESRA aka Site Registry.
+  public getOrgProductFeeCodesForProduct (productCode: string) {
+    return this.orgProductFeeCodes.filter((fee) => fee.code === 'TRF03' || productCode !== 'ESRA')
   }
 
   get existingFeeCodes () {

--- a/auth-web/src/components/auth/common/ProductFeeViewEdit.vue
+++ b/auth-web/src/components/auth/common/ProductFeeViewEdit.vue
@@ -135,7 +135,7 @@ export default class ProductFeeViewEdit extends Vue {
 
   // Only allow $1.05 fee code for ESRA aka Site Registry.
   public getOrgProductFeeCodesForProduct (productCode: string) {
-    return this.orgProductFeeCodes.filter((fee) => fee.code === 'TRF03' || productCode !== 'ESRA')
+    return this.orgProductFeeCodes?.filter((fee) => fee.code === 'TRF03' || productCode !== 'ESRA')
   }
 
   get existingFeeCodes () {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/13622

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
