### PR TITLE
13269 - Allow staff the ability to create new business affiliation - Part 1

### DIFF
--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -207,7 +207,7 @@ class Affiliation:
             raise BusinessException(Error.NR_INVALID_CONTACT, None)
 
         # Validate if org_id is valid by calling Org Service.
-        org = OrgService.find_by_org_id(org_id, allowed_roles=CLIENT_AUTH_ROLES)
+        org = OrgService.find_by_org_id(org_id, allowed_roles=(*CLIENT_AUTH_ROLES, STAFF))
         if org is None:
             raise BusinessException(Error.DATA_NOT_FOUND, None)
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/13269

Part 1

GIVEN I am a BC registries staff user (IDIR) completing an SP/GP reg
WHEN I look up the client’s NR in Name Request
THEN I am able to link into the registration flow
AND the NR is affiliated to my org behind the scenes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
