### PR TITLE
imported LD flag service into queue_services

### DIFF
--- a/queue_services/account-mailer/devops/vaults.json
+++ b/queue_services/account-mailer/devops/vaults.json
@@ -40,5 +40,11 @@
         "application": [
              "relationship-api"
         ]
+    },
+    {
+        "vault": "launchdarkly",
+        "application": [
+            "auth"
+        ]
     }
 ]

--- a/queue_services/account-mailer/requirements.txt
+++ b/queue_services/account-mailer/requirements.txt
@@ -8,20 +8,28 @@ attrs==22.1.0
 blinker==1.5
 certifi==2022.9.24
 click==8.1.3
+expiringdict==1.2.2
+importlib-resources==5.10.0
 itsdangerous==2.0.1
 jaeger-client==4.8.0
 jsonschema==4.16.0
+launchdarkly-server-sdk==7.5.1
 opentracing==2.4.0
+pkgutil_resolve_name==1.3.10
 protobuf==3.19.6
+pyRFC3339==1.1
 pycountry==22.3.5
 pyrsistent==0.18.1
 python-dotenv==0.21.0
+pytz==2022.4
+semver==2.13.0
 sentry-sdk==1.9.10
 six==1.16.0
 threadloop==1.0.2
 thrift==0.16.0
 tornado==6.2
 urllib3==1.26.12
+zipp==3.9.0
 -e git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python
 -e git+https://github.com/bcgov/sbc-auth.git#egg=auth-api&subdirectory=auth-api

--- a/queue_services/account-mailer/requirements/prod.txt
+++ b/queue_services/account-mailer/requirements/prod.txt
@@ -12,3 +12,4 @@ itsdangerous==2.0.1
 Jinja2==3.0.3
 markupsafe==2.0.1
 protobuf~=3.19.5
+launchdarkly-server-sdk

--- a/queue_services/account-mailer/src/account_mailer/config.py
+++ b/queue_services/account-mailer/src/account_mailer/config.py
@@ -68,6 +68,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    AUTH_LD_SDK_KEY = os.getenv('AUTH_LD_SDK_KEY', None)
+
     # POSTGRESQL
     DB_USER = os.getenv('DATABASE_USERNAME', '')
     DB_PASSWORD = os.getenv('DATABASE_PASSWORD', '')

--- a/queue_services/account-mailer/src/account_mailer/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/worker.py
@@ -31,6 +31,7 @@ from datetime import datetime
 
 import nats
 from auth_api.models import db
+from auth_api.services import Flags
 from auth_api.services.rest_service import RestService
 from auth_api.utils.roles import ADMIN, COORDINATOR
 from entity_queue_common.service import QueueServiceManager
@@ -55,6 +56,7 @@ APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
 FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
+flag_service = Flags(FLASK_APP)
 
 
 # pylint: disable=too-many-statements, too-many-branches, too-many-locals

--- a/queue_services/activity-log-listener/devops/vaults.json
+++ b/queue_services/activity-log-listener/devops/vaults.json
@@ -17,5 +17,11 @@
         "application": [
              "relationship-api"
         ]
+    },
+    {
+        "vault": "launchdarkly",
+        "application": [
+            "auth"
+        ]
     }
 ]

--- a/queue_services/activity-log-listener/requirements.txt
+++ b/queue_services/activity-log-listener/requirements.txt
@@ -4,26 +4,32 @@ MarkupSafe==2.0.1
 Werkzeug==1.0.1
 asyncio-nats-client==0.11.5
 asyncio-nats-streaming==0.4.0
-attrs==21.4.0
-blinker==1.4
-certifi==2022.6.15
+attrs==22.1.0
+blinker==1.5
+certifi==2022.9.24
 click==8.1.3
-importlib-resources==5.8.0
+expiringdict==1.2.2
+importlib-resources==5.10.0
 itsdangerous==2.0.1
 jaeger-client==4.8.0
-jsonschema==4.7.1
+jsonschema==4.16.0
+launchdarkly-server-sdk==7.5.1
 opentracing==2.4.0
-protobuf==3.19.5
+pkgutil_resolve_name==1.3.10
+protobuf==3.19.6
+pyRFC3339==1.1
 pycountry==22.3.5
 pyrsistent==0.18.1
-python-dotenv==0.20.0
-sentry-sdk==1.7.0
+python-dotenv==0.21.0
+pytz==2022.4
+semver==2.13.0
+sentry-sdk==1.9.10
 six==1.16.0
 threadloop==1.0.2
 thrift==0.16.0
 tornado==6.2
-urllib3==1.26.10
-zipp==3.8.0
+urllib3==1.26.12
+zipp==3.9.0
 -e git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python
 -e git+https://github.com/bcgov/sbc-auth.git#egg=auth-api&subdirectory=auth-api

--- a/queue_services/activity-log-listener/requirements/prod.txt
+++ b/queue_services/activity-log-listener/requirements/prod.txt
@@ -12,3 +12,4 @@ itsdangerous==2.0.1
 Jinja2==3.0.3
 markupsafe==2.0.1
 protobuf~=3.19.5
+launchdarkly-server-sdk

--- a/queue_services/activity-log-listener/src/activity_log_listener/config.py
+++ b/queue_services/activity-log-listener/src/activity_log_listener/config.py
@@ -65,6 +65,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    AUTH_LD_SDK_KEY = os.getenv('AUTH_LD_SDK_KEY', None)
+
     # POSTGRESQL
     DB_USER = os.getenv('DATABASE_USERNAME', '')
     DB_PASSWORD = os.getenv('DATABASE_PASSWORD', '')

--- a/queue_services/activity-log-listener/src/activity_log_listener/worker.py
+++ b/queue_services/activity-log-listener/src/activity_log_listener/worker.py
@@ -31,6 +31,7 @@ import os
 import nats
 from auth_api.models import ActivityLog as ActivityLogModel
 from auth_api.models import db
+from auth_api.services import Flags
 from entity_queue_common.service import QueueServiceManager
 from entity_queue_common.service_utils import QueueException, logger
 from flask import Flask  # pylint: disable=wrong-import-order
@@ -43,6 +44,7 @@ APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
 FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
+flag_service = Flags(FLASK_APP)
 
 
 async def process_event(event_message, flask_app):

--- a/queue_services/business-events-listener/devops/vaults.json
+++ b/queue_services/business-events-listener/devops/vaults.json
@@ -30,5 +30,11 @@
             "jwt-base",
             "sbc-auth-admin"
         ]
+    },
+    {
+        "vault": "launchdarkly",
+        "application": [
+            "auth"
+        ]
     }
 ]

--- a/queue_services/business-events-listener/requirements.txt
+++ b/queue_services/business-events-listener/requirements.txt
@@ -4,27 +4,33 @@ MarkupSafe==2.0.1
 Werkzeug==1.0.1
 asyncio-nats-client==0.11.5
 asyncio-nats-streaming==0.4.0
-attrs==21.4.0
-blinker==1.4
-certifi==2022.5.18.1
+attrs==22.1.0
+blinker==1.5
+certifi==2022.9.24
 click==8.1.3
-importlib-resources==5.7.1
+expiringdict==1.2.2
+importlib-resources==5.10.0
 itsdangerous==2.0.1
 jaeger-client==4.8.0
-jsonschema==4.6.0
+jsonschema==4.16.0
+launchdarkly-server-sdk==7.5.1
 opentracing==2.4.0
-protobuf==3.19.5
+pkgutil_resolve_name==1.3.10
+protobuf==3.19.6
+pyRFC3339==1.1
 pycountry==22.3.5
 pyrsistent==0.18.1
 python-dateutil==2.8.2
-python-dotenv==0.20.0
-sentry-sdk==1.5.12
+python-dotenv==0.21.0
+pytz==2022.4
+semver==2.13.0
+sentry-sdk==1.9.10
 six==1.16.0
 threadloop==1.0.2
 thrift==0.16.0
-tornado==6.1
-urllib3==1.26.9
-zipp==3.8.0
+tornado==6.2
+urllib3==1.26.12
+zipp==3.9.0
 -e git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python
 -e git+https://github.com/bcgov/sbc-auth.git#egg=auth-api&subdirectory=auth-api

--- a/queue_services/business-events-listener/requirements/prod.txt
+++ b/queue_services/business-events-listener/requirements/prod.txt
@@ -13,3 +13,4 @@ itsdangerous==2.0.1
 Jinja2==3.0.3
 markupsafe==2.0.1
 protobuf~=3.19.5
+launchdarkly-server-sdk

--- a/queue_services/business-events-listener/src/business_events_listener/config.py
+++ b/queue_services/business-events-listener/src/business_events_listener/config.py
@@ -65,6 +65,8 @@ class _Config:  # pylint: disable=too-few-public-methods
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    AUTH_LD_SDK_KEY = os.getenv('AUTH_LD_SDK_KEY', None)
+
     # POSTGRESQL
     DB_USER = os.getenv('DATABASE_USERNAME', '')
     DB_PASSWORD = os.getenv('DATABASE_PASSWORD', '')

--- a/queue_services/business-events-listener/src/business_events_listener/worker.py
+++ b/queue_services/business-events-listener/src/business_events_listener/worker.py
@@ -35,6 +35,7 @@ from auth_api.models import Affiliation as AffiliationModel
 from auth_api.models import Entity as EntityModel
 from auth_api.models import Org as OrgModel
 from auth_api.models import db
+from auth_api.services import Flags
 from auth_api.services.rest_service import RestService
 from auth_api.utils.enums import AccessType, ActivityAction, CorpType
 from dateutil import parser
@@ -149,3 +150,4 @@ APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
 FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
+flag_service = Flags(FLASK_APP)

--- a/queue_services/events-listener/devops/vaults.json
+++ b/queue_services/events-listener/devops/vaults.json
@@ -17,5 +17,11 @@
         "application": [
              "relationship-api"
         ]
+    },
+    {
+        "vault": "launchdarkly",
+        "application": [
+            "auth"
+        ]
     }
 ]

--- a/queue_services/events-listener/requirements.txt
+++ b/queue_services/events-listener/requirements.txt
@@ -4,26 +4,32 @@ MarkupSafe==2.0.1
 Werkzeug==1.0.1
 asyncio-nats-client==0.11.5
 asyncio-nats-streaming==0.4.0
-attrs==21.4.0
-blinker==1.4
-certifi==2022.5.18.1
+attrs==22.1.0
+blinker==1.5
+certifi==2022.9.24
 click==8.1.3
-importlib-resources==5.7.1
+expiringdict==1.2.2
+importlib-resources==5.10.0
 itsdangerous==2.0.1
 jaeger-client==4.8.0
-jsonschema==4.6.0
+jsonschema==4.16.0
+launchdarkly-server-sdk==7.5.1
 opentracing==2.4.0
-protobuf==3.19.5
+pkgutil_resolve_name==1.3.10
+protobuf==3.19.6
+pyRFC3339==1.1
 pycountry==22.3.5
 pyrsistent==0.18.1
-python-dotenv==0.20.0
-sentry-sdk==1.5.12
+python-dotenv==0.21.0
+pytz==2022.4
+semver==2.13.0
+sentry-sdk==1.9.10
 six==1.16.0
 threadloop==1.0.2
 thrift==0.16.0
-tornado==6.1
-urllib3==1.26.9
-zipp==3.8.0
+tornado==6.2
+urllib3==1.26.12
+zipp==3.9.0
 -e git+https://github.com/bcgov/lear.git#egg=entity_queue_common&subdirectory=queue_services/common
 -e git+https://github.com/bcgov/sbc-common-components.git#egg=sbc-common-components&subdirectory=python
 -e git+https://github.com/bcgov/sbc-auth.git#egg=auth-api&subdirectory=auth-api

--- a/queue_services/events-listener/requirements/prod.txt
+++ b/queue_services/events-listener/requirements/prod.txt
@@ -12,3 +12,4 @@ itsdangerous==2.0.1
 Jinja2==3.0.3
 markupsafe==2.0.1
 protobuf~=3.19.5
+launchdarkly-server-sdk

--- a/queue_services/events-listener/src/events_listener/config.py
+++ b/queue_services/events-listener/src/events_listener/config.py
@@ -65,6 +65,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    AUTH_LD_SDK_KEY = os.getenv('AUTH_LD_SDK_KEY', None)
+
     # POSTGRESQL
     DB_USER = os.getenv('DATABASE_USERNAME', '')
     DB_PASSWORD = os.getenv('DATABASE_PASSWORD', '')

--- a/queue_services/events-listener/src/events_listener/worker.py
+++ b/queue_services/events-listener/src/events_listener/worker.py
@@ -32,6 +32,7 @@ from datetime import datetime
 import nats
 from auth_api.models import Org as OrgModel
 from auth_api.models import db
+from auth_api.services import Flags
 from auth_api.services.queue_publisher import publish
 from auth_api.utils.enums import OrgStatus
 from entity_queue_common.service import QueueServiceManager
@@ -47,6 +48,7 @@ APP_CONFIG = config.get_named_config(os.getenv('DEPLOYMENT_ENV', 'production'))
 FLASK_APP = Flask(__name__)
 FLASK_APP.config.from_object(APP_CONFIG)
 db.init_app(FLASK_APP)
+flag_service = Flags(FLASK_APP)
 
 UNLOCK_ACCOUNT_MESSAGE_TYPE = 'bc.registry.payment.unlockAccount'
 LOCK_ACCOUNT_MESSAGE_TYPE = 'bc.registry.payment.lockAccount'


### PR DESCRIPTION
*Issue #: 13846*
https://github.com/bcgov/entity/issues/13846

*Description of changes:*
   - imported LD flag service from auth_api.services into account-mailer, activity-log-listener, business-events-listener, and 
     events listener worker files in queue_services
   - updated requirements, configs, and vaults for each respective queue service

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
