### PR TITLE
14427 remove duplicated spaces from party name before comparing

### DIFF
--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -388,6 +388,11 @@ class Affiliation:
                 party_name = officer.get('lastName') + ', ' + officer.get('firstName')
                 if officer.get('middleInitial'):
                     party_name = party_name + ' ' + officer.get('middleInitial')
+
+            # remove duplicate spaces
+            party_name_str = ' '.join(party_name_str.split())
+            party_name = ' '.join(party_name.split())
+
             if party_name_str.upper() == party_name.upper():
                 return True
         return False

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -167,6 +167,20 @@ def test_create_affiliation_firms(session, auth_mock, monkeypatch):  # pylint:di
     assert affiliation.entity.identifier == entity_service.identifier
     assert affiliation.as_dict()['organization']['id'] == org_dictionary['id']
 
+
+def test_create_affiliation_firms_party_with_additional_space(session,
+                                                              auth_mock,
+                                                              monkeypatch):  # pylint:disable=unused-argument
+    """Assert that an Affiliation can be created."""
+    patch_get_firms_parties(monkeypatch)
+    entity_service = factory_entity_service(entity_info=TestEntityInfo.entity_lear_mock3)
+    entity_dictionary = entity_service.as_dict()
+    business_identifier = entity_dictionary['business_identifier']
+
+    org_service = factory_org_service()
+    org_dictionary = org_service.as_dict()
+    org_id = org_dictionary['id']
+
     # When party name has additional space
     pass_code = TestEntityInfo.entity_lear_mock3['passCode'].replace(' ', '  ')
     affiliation = AffiliationService.create_affiliation(org_id, business_identifier,

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -167,6 +167,14 @@ def test_create_affiliation_firms(session, auth_mock, monkeypatch):  # pylint:di
     assert affiliation.entity.identifier == entity_service.identifier
     assert affiliation.as_dict()['organization']['id'] == org_dictionary['id']
 
+    # When party name has additional space
+    pass_code = TestEntityInfo.entity_lear_mock3['passCode'].replace(' ', '  ')
+    affiliation = AffiliationService.create_affiliation(org_id, business_identifier,
+                                                        pass_code)
+    assert affiliation
+    assert affiliation.entity.identifier == entity_service.identifier
+    assert affiliation.as_dict()['organization']['id'] == org_dictionary['id']
+
 
 def test_create_affiliation_firms_party_not_valid(session, auth_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Affiliation can be created."""


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/14427

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
