### PR TITLE
14066 Auth Web: Affiliation certifier should be editable by SBC Staff and Registries Staff

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.1.30",
+  "version": "1.1.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.1.30",
+      "version": "1.1.29",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.9",

--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.1.28",
+  "version": "1.1.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.1.28",
+      "version": "1.1.30",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.9",
@@ -47,7 +47,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/cli-plugin-babel": "^4.5.17",
         "@vue/cli-plugin-e2e-nightwatch": "^4.5.17",
         "@vue/cli-plugin-eslint": "^4.5.17",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.1.28",
+  "version": "1.1.30",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.1.30",
+  "version": "1.1.29",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/src/components/auth/manage-business/AddBusinessDialog.vue
+++ b/auth-web/src/components/auth/manage-business/AddBusinessDialog.vue
@@ -77,7 +77,7 @@
                 persistent-hint
                 :label="certifiedByNameLabel"
                 :rules="certifiedByNameRules"
-                :maxlength="passcodeMaxLength"
+                :maxlength="certifiedByNameMaxLength"
                 :aria-label="certifiedByNameLabel"
                 v-model="certifiedByName"
                 autocomplete="off"
@@ -205,6 +205,8 @@ export default class AddBusinessDialog extends Vue {
     'subject to a maximum fine of $5,000.'
 
   readonly certifiedByNameLabel = 'Legal name of certified person (e.g., Last Name, First Name)'
+
+  readonly certifiedByNameMaxLength = 100
 
   get isBusinessIdentifierValid (): boolean {
     return CommonUtils.validateIncorporationNumber(this.businessIdentifier)

--- a/auth-web/src/components/auth/manage-business/AddBusinessDialog.vue
+++ b/auth-web/src/components/auth/manage-business/AddBusinessDialog.vue
@@ -229,8 +229,7 @@ export default class AddBusinessDialog extends Vue {
 
   get certifiedByNameRules (): any[] {
     return [
-      v => !!v || 'Certification is required',
-      v => v.length <= 150 || 'Maximum 150 characters'
+      v => !!v || 'Certification is required'
     ]
   }
 

--- a/auth-web/src/components/auth/manage-business/AddBusinessDialog.vue
+++ b/auth-web/src/components/auth/manage-business/AddBusinessDialog.vue
@@ -219,7 +219,7 @@ export default class AddBusinessDialog extends Vue {
   }
 
   get isStaffAccount (): boolean {
-    return this.currentUser.roles.includes(Role.StaffManageAccounts)
+    return this.currentUser.roles.some((role) => (role === Role.Staff || role === Role.GOVMAccountUser))
   }
 
   get currentUserName (): string {

--- a/auth-web/src/components/auth/manage-business/Certify.vue
+++ b/auth-web/src/components/auth/manage-business/Certify.vue
@@ -39,12 +39,12 @@ export default class Certify extends Vue {
   @Prop({ default: '' })
   readonly clause: string
 
+  /** Certified by Name */
+  @Prop({ default: '' })
+  readonly currentUserName: string
+
   // local variable
   protected isCertified = false
-
-  get currentUserName (): string {
-    return `${this.currentUser.lastName}, ${this.currentUser.firstName}`
-  }
 
   /** Emits an event to update the Is Certified prop. */
   @Emit('update:isCertified')

--- a/auth-web/src/components/auth/manage-business/EntityManagement.vue
+++ b/auth-web/src/components/auth/manage-business/EntityManagement.vue
@@ -208,6 +208,9 @@
       <!-- Add an Existing Business Dialog -->
       <AddBusinessDialog
         :dialog="addBusinessDialog"
+        :isGovStaffAccount="isStaffAccount || isSbcStaffAccount"
+        :userFirstName="currentUser.firstName"
+        :userLastName="currentUser.lastName"
         @add-success="showAddSuccessModal()"
         @add-failed-invalid-code="showInvalidCodeModal($event)"
         @add-failed-no-entity="showEntityNotFoundModal()"

--- a/auth-web/src/models/affiliation.ts
+++ b/auth-web/src/models/affiliation.ts
@@ -3,6 +3,7 @@ import { Organization } from '@/models/Organization'
 
 export interface CreateRequestBody {
   businessIdentifier: string
+  certifiedByName: string
   passCode: string
 }
 

--- a/auth-web/src/models/business.ts
+++ b/auth-web/src/models/business.ts
@@ -6,6 +6,7 @@ export interface LoginPayload {
     passCode?: string
     phone?: string
     email?: string
+    certifiedByName?: string
 }
 
 export interface FolioNumberload {

--- a/auth-web/src/models/business.ts
+++ b/auth-web/src/models/business.ts
@@ -6,7 +6,7 @@ export interface LoginPayload {
     passCode?: string
     phone?: string
     email?: string
-    certifiedByName?: string
+    certifiedByName: string
 }
 
 export interface FolioNumberload {

--- a/auth-web/src/store/modules/business.ts
+++ b/auth-web/src/store/modules/business.ts
@@ -172,6 +172,7 @@ export default class BusinessModule extends VuexModule {
   public async addBusiness (payload: LoginPayload) {
     const requestBody: CreateAffiliationRequestBody = {
       businessIdentifier: payload.businessIdentifier,
+      certifiedByName: payload.certifiedByName,
       passCode: payload.passCode
     }
 

--- a/auth-web/tests/unit/components/AddBusinessDialog.spec.ts
+++ b/auth-web/tests/unit/components/AddBusinessDialog.spec.ts
@@ -17,81 +17,102 @@ const tests = [
     businessIdentifier: 'CP0000000',
     passcodeLabel: 'Passcode',
     certifyExists: false,
-    forgotButtonText: 'I lost or forgot my passcode'
+    forgotButtonText: 'I lost or forgot my passcode',
+    isGovStaffAccount: false,
+    userFirstName: 'Nadia',
+    userLastName: 'Woodie',
   },
   {
     desc: 'renders the component properly for a BC',
     businessIdentifier: 'BC0000000',
     passcodeLabel: 'Password',
     certifyExists: false,
-    forgotButtonText: 'I lost or forgot my password'
+    forgotButtonText: 'I lost or forgot my password',
+    isGovStaffAccount: false,
+    userFirstName: 'Nadia',
+    userLastName: 'Woodie',
   },
   {
-    desc: 'renders the component properly for a FM',
+    desc: 'renders the component properly for a FM (client User)',
     businessIdentifier: 'FM0000000',
     passcodeLabel: 'Proprietor or Partner Name (e.g., Last Name, First Name Middlename)',
     certifyExists: true,
-    forgotButtonText: null
+    forgotButtonText: null,
+    isGovStaffAccount: false,
+    userFirstName: 'Nadia',
+    userLastName: 'Woodie',
+  },
+  {
+    desc: 'renders the component properly for a FM (staff user)',
+    businessIdentifier: 'FM0000000',
+    passcodeLabel: 'Proprietor or Partner Name (e.g., Last Name, First Name Middlename)',
+    certifyExists: true,
+    forgotButtonText: null,
+    isGovStaffAccount: true,
+    userFirstName: 'Nadia',
+    userLastName: 'Woodie',
+  },
+  {
+    desc: 'renders the component properly for a FM (sbc staff)',
+    businessIdentifier: 'FM0000000',
+    passcodeLabel: 'Proprietor or Partner Name (e.g., Last Name, First Name Middlename)',
+    certifyExists: true,
+    forgotButtonText: null,
+    isGovStaffAccount: false,
+    userFirstName: 'Nadia',
+    userLastName: 'Woodie',
   }
 ]
+tests.forEach(test => {
+  describe('Add Business Form', () => {
+    let wrapper: Wrapper<any>
 
-describe('Add Business Form', () => {
-  let wrapper: Wrapper<any>
-
-  beforeAll(() => {
-    const userModule: any = {
-      namespaced: true,
-      state: {
-        currentUser: {
-          firstName: 'Nadia',
-          lastName: 'Woodie',
-          roles: ['staff']
+    beforeAll(() => {
+      const orgModule = {
+        namespaced: true,
+        state: {
+          currentOrganization: {
+            name: 'new org'
+          }
         }
       }
-    }
 
-    const orgModule = {
-      namespaced: true,
-      state: {
-        currentOrganization: {
-          name: 'new org'
+      const businessModule = {
+        namespaced: true,
+        state: {
+
+        },
+        action: {
+          addBusiness: jest.fn(),
+          updateBusinessName: jest.fn(),
+          updateFolioNumber: jest.fn()
         }
       }
-    }
 
-    const businessModule = {
-      namespaced: true,
-      state: {
+      const store = new Vuex.Store({
+        strict: false,
+        modules: {
+          org: orgModule,
+          business: businessModule
+        }
+      })
 
-      },
-      action: {
-        addBusiness: jest.fn(),
-        updateBusinessName: jest.fn(),
-        updateFolioNumber: jest.fn()
-      }
-    }
-
-    const store = new Vuex.Store({
-      strict: false,
-      modules: {
-        org: orgModule,
-        business: businessModule,
-        user: userModule
-      }
+      wrapper = shallowMount(AddBusinessDialog, {
+        store,
+        vuetify,
+        propsData: { 
+          dialog: true,
+          isGovStaffAccount: test.isGovStaffAccount,
+          userFirstName: test.userFirstName,
+          userLastName: test.userLastName
+        }
+      })
     })
 
-    wrapper = shallowMount(AddBusinessDialog, {
-      store,
-      vuetify,
-      propsData: { dialog: true }
+    afterAll(() => {
+      wrapper.destroy()
     })
-  })
 
-  afterAll(() => {
-    wrapper.destroy()
-  })
-
-  tests.forEach(test => {
     it(test.desc, () => {
       wrapper.setData({ businessIdentifier: test.businessIdentifier })
 
@@ -105,6 +126,10 @@ describe('Add Business Form', () => {
       expect(wrapper.find('.passcode').attributes('label')).toBe(test.passcodeLabel)
       expect(wrapper.find('.certify').exists()).toBe(test.certifyExists)
       expect(wrapper.find('.folio-number').attributes('label')).toBe('Folio or Reference Number (Optional)')
+      expect(wrapper.find('.certifier').exists()).toBe(test.isGovStaffAccount)
+      if (test.isGovStaffAccount) {
+        expect(wrapper.find('.certifier').attributes('label')).toContain('Legal name of certified person')
+      }
 
       // verify buttons
       if (!test.certifyExists) {

--- a/auth-web/tests/unit/components/AddBusinessDialog.spec.ts
+++ b/auth-web/tests/unit/components/AddBusinessDialog.spec.ts
@@ -1,9 +1,10 @@
-import { Wrapper, createLocalVue, shallowMount } from '@vue/test-utils'
+import { Wrapper, createLocalVue, shallowMount, mount } from '@vue/test-utils'
 import AddBusinessDialog from '@/components/auth/manage-business/AddBusinessDialog.vue'
 import HelpDialog from '@/components/auth/common/HelpDialog.vue'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import Vuex from 'vuex'
+import UserModule from '@/store/modules/user'
 
 Vue.use(Vuetify)
 const vuetify = new Vuetify({})
@@ -20,18 +21,18 @@ const tests = [
     forgotButtonText: 'I lost or forgot my passcode'
   },
   {
-    desc: 'renders the component properly for a BC',
-    businessIdentifier: 'BC0000000',
-    passcodeLabel: 'Password',
-    certifyExists: false,
-    forgotButtonText: 'I lost or forgot my password'
-  },
-  {
     desc: 'renders the component properly for a FM',
     businessIdentifier: 'FM0000000',
     passcodeLabel: 'Proprietor or Partner Name (e.g., Last Name, First Name Middlename)',
     certifyExists: true,
     forgotButtonText: null
+  },
+  {
+    desc: 'renders the component properly for a BC',
+    businessIdentifier: 'BC0000000',
+    passcodeLabel: 'Password',
+    certifyExists: false,
+    forgotButtonText: 'I lost or forgot my password'
   }
 ]
 
@@ -39,6 +40,19 @@ describe('Add Business Form', () => {
   let wrapper: Wrapper<any>
 
   beforeAll(() => {
+    const userModule: any = {
+      namespaced: true,
+      state: {
+        currentUser: {
+          firstName: 'Nadia',
+          lastName: 'Woodie'
+        }
+      },
+      // actions: UserModule.actions,
+      // mutations: UserModule.mutations,
+      // getters: UserModule.getters
+    }
+
     const orgModule = {
       namespaced: true,
       state: {
@@ -64,7 +78,8 @@ describe('Add Business Form', () => {
       strict: false,
       modules: {
         org: orgModule,
-        business: businessModule
+        business: businessModule,
+        user: userModule
       }
     })
 

--- a/auth-web/tests/unit/components/AddBusinessDialog.spec.ts
+++ b/auth-web/tests/unit/components/AddBusinessDialog.spec.ts
@@ -20,7 +20,7 @@ const tests = [
     forgotButtonText: 'I lost or forgot my passcode',
     isGovStaffAccount: false,
     userFirstName: 'Nadia',
-    userLastName: 'Woodie',
+    userLastName: 'Woodie'
   },
   {
     desc: 'renders the component properly for a BC',
@@ -30,7 +30,7 @@ const tests = [
     forgotButtonText: 'I lost or forgot my password',
     isGovStaffAccount: false,
     userFirstName: 'Nadia',
-    userLastName: 'Woodie',
+    userLastName: 'Woodie'
   },
   {
     desc: 'renders the component properly for a FM (client User)',
@@ -40,7 +40,7 @@ const tests = [
     forgotButtonText: null,
     isGovStaffAccount: false,
     userFirstName: 'Nadia',
-    userLastName: 'Woodie',
+    userLastName: 'Woodie'
   },
   {
     desc: 'renders the component properly for a FM (staff user)',
@@ -50,7 +50,7 @@ const tests = [
     forgotButtonText: null,
     isGovStaffAccount: true,
     userFirstName: 'Nadia',
-    userLastName: 'Woodie',
+    userLastName: 'Woodie'
   },
   {
     desc: 'renders the component properly for a FM (sbc staff)',
@@ -60,7 +60,7 @@ const tests = [
     forgotButtonText: null,
     isGovStaffAccount: false,
     userFirstName: 'Nadia',
-    userLastName: 'Woodie',
+    userLastName: 'Woodie'
   }
 ]
 tests.forEach(test => {
@@ -100,7 +100,7 @@ tests.forEach(test => {
       wrapper = shallowMount(AddBusinessDialog, {
         store,
         vuetify,
-        propsData: { 
+        propsData: {
           dialog: true,
           isGovStaffAccount: test.isGovStaffAccount,
           userFirstName: test.userFirstName,

--- a/auth-web/tests/unit/components/AddBusinessDialog.spec.ts
+++ b/auth-web/tests/unit/components/AddBusinessDialog.spec.ts
@@ -1,10 +1,9 @@
-import { Wrapper, createLocalVue, shallowMount, mount } from '@vue/test-utils'
+import { Wrapper, createLocalVue, shallowMount } from '@vue/test-utils'
 import AddBusinessDialog from '@/components/auth/manage-business/AddBusinessDialog.vue'
 import HelpDialog from '@/components/auth/common/HelpDialog.vue'
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import Vuex from 'vuex'
-import UserModule from '@/store/modules/user'
 
 Vue.use(Vuetify)
 const vuetify = new Vuetify({})
@@ -21,18 +20,18 @@ const tests = [
     forgotButtonText: 'I lost or forgot my passcode'
   },
   {
-    desc: 'renders the component properly for a FM',
-    businessIdentifier: 'FM0000000',
-    passcodeLabel: 'Proprietor or Partner Name (e.g., Last Name, First Name Middlename)',
-    certifyExists: true,
-    forgotButtonText: null
-  },
-  {
     desc: 'renders the component properly for a BC',
     businessIdentifier: 'BC0000000',
     passcodeLabel: 'Password',
     certifyExists: false,
     forgotButtonText: 'I lost or forgot my password'
+  },
+  {
+    desc: 'renders the component properly for a FM',
+    businessIdentifier: 'FM0000000',
+    passcodeLabel: 'Proprietor or Partner Name (e.g., Last Name, First Name Middlename)',
+    certifyExists: true,
+    forgotButtonText: null
   }
 ]
 
@@ -45,12 +44,10 @@ describe('Add Business Form', () => {
       state: {
         currentUser: {
           firstName: 'Nadia',
-          lastName: 'Woodie'
+          lastName: 'Woodie',
+          roles: ['staff']
         }
-      },
-      // actions: UserModule.actions,
-      // mutations: UserModule.mutations,
-      // getters: UserModule.getters
+      }
     }
 
     const orgModule = {

--- a/auth-web/tests/unit/components/Certify.spec.ts
+++ b/auth-web/tests/unit/components/Certify.spec.ts
@@ -41,7 +41,8 @@ describe('Add Business Form', () => {
       vuetify,
       propsData: {
         entity: 'entity',
-        clause: 'Lorem ipsum dolor sit amet.'
+        clause: 'Lorem ipsum dolor sit amet.',
+        currentUserName: 'Woodie, Nadia'
       }
     })
   })

--- a/auth-web/tests/unit/components/EntityManagement.spec.ts
+++ b/auth-web/tests/unit/components/EntityManagement.spec.ts
@@ -44,7 +44,8 @@ describe('Entity Management Component', () => {
       namespaced: true,
       state: {
         currentOrganization: {
-          name: 'new org'
+          name: 'new org',
+          orgType: 'STAFF'
         }
       }
     }
@@ -61,11 +62,22 @@ describe('Entity Management Component', () => {
       }
     }
 
+    const userModule: any = {
+      namespaced: true,
+      state: {
+        currentUser: {
+          firstName: 'Nadia',
+          lastName: 'Woodie'
+        }
+      }
+    }
+
     const store = new Vuex.Store({
       strict: false,
       modules: {
         org: orgModule,
-        business: businessModule
+        business: businessModule,
+        user: userModule
       }
     })
     wrapper = mount(EntityManagement, {

--- a/auth-web/vue.config.js
+++ b/auth-web/vue.config.js
@@ -16,7 +16,7 @@ module.exports = {
       }
     }
   },
-  chainWebpack(config) {
+  chainWebpack (config) {
     // disable type check for build (composition api library fails)
     if (process.env.NODE_ENV === 'production') config.plugins.delete('fork-ts-checker')
   },


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/14066

*Description of changes:*
- updated UI to allow text entry of certifier (when staff only)
- updated UI to save certifier in call to API
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
