### PR TITLE
14507 add column of BCOL USER ID and 'FIRST' to Admin Email&Phone

### DIFF
--- a/docs/docs/database/bca_users_accounts.sql
+++ b/docs/docs/database/bca_users_accounts.sql
@@ -7,6 +7,7 @@ select
 	o.name as "ACCOUNT NAME",
 	o.branch_name as "BRANCH NAME",
 	m.membership_type_code as "USER TYPE",
+	o.bcol_user_id as "BCOL USER ID",
 	u.first_name || ' ' ||u.last_name as "USER NAME",
 	u.email as "USER EMAIL",
 	(case when u.status = 1 then 'ACTIVE' else 'INACTIVE' end) as "USER STATUS",
@@ -16,8 +17,8 @@ select
 	c.region as "PROVINCE",
 	c.country as "COUNTRY",
 	c.postal_code as "POSTAL CODE",
-	c2.email as "ADMIN EMAIL",
-	c2.phone as "ADMIN PHONE"
+	c2.email as "FIRST ADMIN EMAIL",
+	c2.phone as "FIRST ADMIN PHONE"
 from
 orgs o
 INNER JOIN product_subscriptions ps ON o.id = ps.org_id
@@ -31,6 +32,6 @@ LEFT JOIN contacts c2 on c2.id = cl2.contact_id
 where 
 ps.product_code = 'BCA' 
 and membership_type_code = 'ADMIN'
-and o.id in ('') -- GRAB FROM PAY query.
+-- and o.id in ('') -- GRAB FROM PAY query. "--This line removed, cause it has syntax error if not specify ids--"
 
 order by 3 desc;


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/14507

*Description of changes:*
added column of BCOL USER ID and word 'FIRST' to Admin Email&Phone column

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
