### PR TITLE
12753 - Navigating by URL on staff account causes the wrong org to be loaded 

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.1.34",
+  "version": "1.1.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.1.34",
+      "version": "1.1.35",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.9",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.1.34",
+  "version": "1.1.35",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -397,7 +397,7 @@ export default class AccountInfo extends Mixins(
 
   private async mounted () {
     const accountSettings = this.getAccountFromSession()
-    await this.syncOrganization(accountSettings.id)
+    await this.syncOrganization(parseInt(this.$route.params['orgId']))
     this.setAccountChangedHandler(this.setup)
     await this.setup()
   }

--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -396,7 +396,6 @@ export default class AccountInfo extends Mixins(
   ]
 
   private async mounted () {
-    const accountSettings = this.getAccountFromSession()
     await this.syncOrganization(parseInt(this.$route.params['orgId']))
     this.setAccountChangedHandler(this.setup)
     await this.setup()


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/12753

*Description of changes:*
Read from route instead of session storage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
