### PR TITLE
Required phone for account admin

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.1.36",
+  "version": "1.1.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.1.36",
+      "version": "1.1.35",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.9",

--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "1.1.35",
+  "version": "1.1.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "1.1.35",
+      "version": "1.1.36",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.9",
@@ -47,7 +47,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/cli-plugin-babel": "^4.5.17",
         "@vue/cli-plugin-e2e-nightwatch": "^4.5.17",
         "@vue/cli-plugin-eslint": "^4.5.17",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.1.35",
+  "version": "1.1.36",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "1.1.36",
+  "version": "1.1.35",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/auth-web/src/components/auth/create-account/UserProfileForm.vue
+++ b/auth-web/src/components/auth/create-account/UserProfileForm.vue
@@ -347,7 +347,8 @@ export default class UserProfileForm extends Mixins(NextPageMixin, Steppable) {
     ]
 
     private phoneRules = [
-      v => !v || (v.length === 0 || v.length === 14) || 'Phone number is invalid'
+      v => !!v || 'Phone number is required',
+      v => !v || (v.length === 14) || 'Phone number is invalid'
     ]
 
     private extensionRules = [


### PR DESCRIPTION
*Description of changes:*
Make admin phone number manditory. `Business-create-ui` looks in contacts for a phone number. 

https://github.com/bcgov/business-create-ui/blob/565d9b1bce6bc83f9f326f19e1e93b20253b31ae/src/App.vue#L942

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
