### PR TITLE
isUrl fix.

### DIFF
--- a/auth-web/src/util/common-util.ts
+++ b/auth-web/src/util/common-util.ts
@@ -7,9 +7,8 @@ import moment from 'moment'
  */
 export default class CommonUtils {
   // checking url matches the regex
-  static isUrl (value:string):boolean {
-    const URL_MATCHER = new RegExp('^(?:\\w+:)?\\/([^\\s\\.]+\\.\\S{2}|[\\/]?localhost[\\:?\\d]*)\\S*$')
-    return URL_MATCHER.test(value)
+  static isUrl (value:string): boolean {
+    return value?.startsWith('http')
   }
 
   // formatting incorporation number according to the length of numbers

--- a/auth-web/tests/unit/util/common-util.spec.ts
+++ b/auth-web/tests/unit/util/common-util.spec.ts
@@ -51,6 +51,7 @@ describe('Common Util Test', () => {
   it('is isUrl [negative]', () => {
     expect(CommonUtil.isUrl('abcd')).toBe(false)
     expect(CommonUtil.isUrl('localhost:8080')).toBe(false)
+    expect(CommonUtil.isUrl('/confirmtoken/xxxxx.Y-qrVg.jqfdfdfdfd')).toBe(false)
   })
 
   it('formatIncorporationNumber returns null', () => {


### PR DESCRIPTION
Failing on the string:
EG.

/confirmtoken/eyJpZCI6MTc1MSwidHlwZSI6IlNUQU5EQVJEIn0.Y-qrVg.jqfdfdfdfd


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
