### PR TITLE
15241 minio upgrade fix

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.9",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/util/http-util.ts
+++ b/auth-web/src/util/http-util.ts
@@ -7,6 +7,11 @@ const axios = Axios.create()
 
 axios.interceptors.request.use(
   config => {
+    // Bypass adding auth header for minio, which may otherwise break requests
+    if (config.url?.includes('minio')) {
+      return config
+    }
+
     const token = ConfigHelper.getFromSession(SessionStorageKeys.KeyCloakToken)
     if (token) {
       config.headers.Authorization = `Bearer ${token}`

--- a/auth-web/src/util/http-util.ts
+++ b/auth-web/src/util/http-util.ts
@@ -6,17 +6,17 @@ import { SessionStorageKeys } from '@/util/constants'
 const axios = Axios.create()
 
 axios.interceptors.request.use(
-  config => {
+  request => {
     // Bypass adding auth header for minio
-    if (config.url?.includes('minio')) {
-      return config
+    if (request.url?.includes('minio')) {
+      return request
     }
 
     const token = ConfigHelper.getFromSession(SessionStorageKeys.KeyCloakToken)
     if (token) {
-      config.headers.Authorization = `Bearer ${token}`
+      request.headers.Authorization = `Bearer ${token}`
     }
-    return config
+    return request
   },
   error => Promise.reject(error)
 )

--- a/auth-web/src/util/http-util.ts
+++ b/auth-web/src/util/http-util.ts
@@ -7,7 +7,7 @@ const axios = Axios.create()
 
 axios.interceptors.request.use(
   config => {
-    // Bypass adding auth header for minio, which may otherwise break requests
+    // Bypass adding auth header for minio
     if (config.url?.includes('minio')) {
       return config
     }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/15241

*Description of changes:*
auth-web defaults to sending an `Authorization` header for any request it makes - newer version of Minio does not like this header, and throws 400 errors. This change will not auto-add the header for urls with `minio` in them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
