### PR TITLE
16333 - show historical entities

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.9",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/models/affiliation.ts
+++ b/auth-web/src/models/affiliation.ts
@@ -44,7 +44,7 @@ export interface AffiliationResponse {
   modifiedBy?: string
   nameRequest?: NameRequestResponse
   nrNumber?: string
-  status?: string
+  state?: string
   goodStanding?: boolean
   adminFreeze?: boolean
   dissolved?: boolean

--- a/auth-web/src/store/modules/business.ts
+++ b/auth-web/src/store/modules/business.ts
@@ -126,7 +126,8 @@ export default class BusinessModule extends VuexModule {
         ...(resp.modifiedBy && { modifiedBy: resp.modifiedBy }),
         ...(resp.nrNumber && { nrNumber: resp.nrNumber }),
         ...(resp.adminFreeze !== undefined ? { adminFreeze: resp.adminFreeze } : { adminFreeze: false }),
-        ...(resp.goodStanding !== undefined ? { goodStanding: resp.goodStanding } : { goodStanding: true })
+        ...(resp.goodStanding !== undefined ? { goodStanding: resp.goodStanding } : { goodStanding: true }),
+        ...(resp.state && { status: resp.state })
       }
       if (resp.nameRequest) {
         const nr = resp.nameRequest

--- a/auth-web/tests/unit/components/AffiliatedEntityTable.spec.ts
+++ b/auth-web/tests/unit/components/AffiliatedEntityTable.spec.ts
@@ -80,7 +80,7 @@ describe('AffiliatedEntityTable.vue', () => {
 
   it('Renders affiliated entity table', async () => {
     // verify table header
-    expect(wrapper.find('.table-header').text()).toBe('My List (6)')
+    expect(wrapper.find('.table-header').text()).toBe('My List (7)')
 
     // Wait for the component to render after any state changes
     await wrapper.vm.$nextTick()
@@ -161,5 +161,13 @@ describe('AffiliatedEntityTable.vue', () => {
       expect(entityDetails.props('details')).toEqual(expect.arrayContaining([EntityAlertTypes.FROZEN, EntityAlertTypes.BADSTANDING]))
     }
     expect(wrapper.find('.mdi-alert').exists()).toBeTruthy()
+
+    // seventh item
+    columns = itemRows.at(6).findAll(itemCell)
+    expect(columns.at(0).text()).toBe('0871095 B.C. LTD.')
+    expect(columns.at(1).text()).toBe('BC0871095')
+    expect(columns.at(2).text()).toContain('BC Benefit Company')
+    expect(columns.at(3).text()).toBe('Historical')
+    expect(columns.at(4).text()).toBe('Open')
   })
 })

--- a/auth-web/tests/unit/test-utils/test-data/affiliations.ts
+++ b/auth-web/tests/unit/test-utils/test-data/affiliations.ts
@@ -113,5 +113,13 @@ export const businesses: Business[] = [
     corpSubType: {
       code: CorpTypes.BENEFIT_COMPANY
     }
+  },
+  {
+    adminFreeze: false,
+    goodStanding: true,
+    businessIdentifier: 'BC0871095',
+    name: '0871095 B.C. LTD.',
+    corpType: { code: CorpTypes.BENEFIT_COMPANY },
+    status: 'HISTORICAL'
   }
 ]


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/16333

*Description of changes:*
added "state" to affiliation response, it's status before, so it didn't grab "historical" status

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
