### PR TITLE
16527 - check token cache endpoint before generating new service account token

### DIFF
--- a/auth-api/requirements.txt
+++ b/auth-api/requirements.txt
@@ -57,6 +57,8 @@ pyrsistent==0.19.3
 python-dotenv==1.0.0
 python-jose==3.3.0
 pytz==2022.7.1
+python-memcached==1.59
+redis==4.3.6
 requests==2.31.0
 rsa==4.9
 semver==2.13.0

--- a/auth-api/requirements/dev.txt
+++ b/auth-api/requirements/dev.txt
@@ -23,3 +23,4 @@ FreezeGun
 lovely-pytest-docker
 Faker
 pytest-asyncio==0.21.0
+mock

--- a/auth-api/requirements/prod.txt
+++ b/auth-api/requirements/prod.txt
@@ -31,3 +31,5 @@ launchdarkly-server-sdk
 protobuf~=3.19.5
 aiohttp
 orjson
+python-memcached
+redis

--- a/auth-api/src/auth_api/config.py
+++ b/auth-api/src/auth_api/config.py
@@ -97,6 +97,17 @@ class _Config:  # pylint: disable=too-few-public-methods
     KEYCLOAK_ADMIN_USERNAME = os.getenv('SBC_AUTH_ADMIN_CLIENT_ID')
     KEYCLOAK_ADMIN_SECRET = os.getenv('SBC_AUTH_ADMIN_CLIENT_SECRET')
 
+    # keycloak service account token lifepan
+    try:
+        CACHE_DEFAULT_TIMEOUT = int(os.getenv('ACCESS_TOKEN_LIFESPAN'))
+    except:  # pylint:disable=bare-except # noqa: B901, E722
+        CACHE_DEFAULT_TIMEOUT = 300
+
+    CACHE_MEMCACHED_SERVERS = os.getenv('CACHE_MEMCACHED_SERVERS')
+
+    CACHE_REDIS_HOST = os.getenv('CACHE_REDIS_HOST')
+    CACHE_REDIS_PORT = os.getenv('CACHE_REDIS_PORT')
+
     # Service account details
     KEYCLOAK_SERVICE_ACCOUNT_ID = os.getenv('SBC_AUTH_ADMIN_CLIENT_ID')
     KEYCLOAK_SERVICE_ACCOUNT_SECRET = os.getenv('SBC_AUTH_ADMIN_CLIENT_SECRET')

--- a/auth-api/src/auth_api/services/rest_service.py
+++ b/auth-api/src/auth_api/services/rest_service.py
@@ -164,7 +164,7 @@ class RestService:
         return response
 
     @staticmethod
-    @cache.cached()
+    @cache.cached(query_string=True)
     def get_service_account_token(config_id='KEYCLOAK_SERVICE_ACCOUNT_ID',
                                   config_secret='KEYCLOAK_SERVICE_ACCOUNT_SECRET') -> str:
         """Generate a service account token."""

--- a/auth-api/src/auth_api/services/rest_service.py
+++ b/auth-api/src/auth_api/services/rest_service.py
@@ -30,6 +30,7 @@ from urllib3.util.retry import Retry
 
 from auth_api.exceptions import ServiceUnavailableException
 from auth_api.utils.enums import AuthHeaderType, ContentType
+from auth_api.utils.cache import cache
 
 RETRY_ADAPTER = HTTPAdapter(max_retries=Retry(total=5, backoff_factor=1, status_forcelist=[404]))
 
@@ -163,11 +164,13 @@ class RestService:
         return response
 
     @staticmethod
+    @cache.cached()
     def get_service_account_token(config_id='KEYCLOAK_SERVICE_ACCOUNT_ID',
                                   config_secret='KEYCLOAK_SERVICE_ACCOUNT_SECRET') -> str:
         """Generate a service account token."""
         kc_service_id = current_app.config.get(config_id)
         kc_secret = current_app.config.get(config_secret)
+
         issuer_url = current_app.config.get('JWT_OIDC_ISSUER')
         token_url = issuer_url + '/protocol/openid-connect/token'
         auth_response = requests.post(token_url, auth=(kc_service_id, kc_secret), headers={

--- a/auth-api/src/auth_api/utils/cache.py
+++ b/auth-api/src/auth_api/utils/cache.py
@@ -18,17 +18,17 @@ from flask_caching import Cache
 cache_servers = os.environ.get('CACHE_MEMCACHED_SERVERS')
 
 if cache_servers:
-    cache = Cache(config={  'CACHE_TYPE': 'MemcachedCache',
-                            'CACHE_MEMCACHED_SERVERS': cache_servers.split(',') })
+    cache = Cache(config={'CACHE_TYPE': 'MemcachedCache',
+                          'CACHE_MEMCACHED_SERVERS': cache_servers.split(',')})
 else:
 
     redis_host = os.environ.get('CACHE_REDIS_HOST')
     redis_port = os.environ.get('CACHE_REDIS_PORT')
 
     if redis_host and redis_port:
-        cache = Cache(config={  'CACHE_TYPE': 'RedisCache',
-                                'CACHE_REDIS_HOST': redis_host,
-                                'CACHE_REDIS_PORT': redis_port })
+        cache = Cache(config={'CACHE_TYPE': 'RedisCache',
+                              'CACHE_REDIS_HOST': redis_host,
+                              'CACHE_REDIS_PORT': redis_port})
 
     else:
         cache = Cache(config={'CACHE_TYPE': 'simple'})  # pylint: disable=invalid-name

--- a/auth-api/src/auth_api/utils/cache.py
+++ b/auth-api/src/auth_api/utils/cache.py
@@ -12,8 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Bring in the common cache."""
+import os
 from flask_caching import Cache
 
+cache_servers = os.environ.get('CACHE_MEMCACHED_SERVERS')
 
-# lower case name as used by convention in most Flask apps
-cache = Cache(config={'CACHE_TYPE': 'simple'})  # pylint: disable=invalid-name
+if cache_servers:
+    cache = Cache(config={  'CACHE_TYPE': 'MemcachedCache',
+                            'CACHE_MEMCACHED_SERVERS': cache_servers.split(',') })
+else:
+
+    redis_host = os.environ.get('CACHE_REDIS_HOST')
+    redis_port = os.environ.get('CACHE_REDIS_PORT')
+
+    if redis_host and redis_port:
+        cache = Cache(config={  'CACHE_TYPE': 'RedisCache',
+                                'CACHE_REDIS_HOST': redis_host,
+                                'CACHE_REDIS_PORT': redis_port })
+
+    else:
+        cache = Cache(config={'CACHE_TYPE': 'simple'})  # pylint: disable=invalid-name

--- a/auth-api/tests/conftest.py
+++ b/auth-api/tests/conftest.py
@@ -28,6 +28,10 @@ from auth_api.exceptions import BusinessException, Error
 from auth_api.models import db as _db
 
 
+def mock_token():
+    return "TOKEN...."
+
+
 @pytest.fixture(scope='session')
 def app():
     """Return a session-wide application configured in TEST mode."""

--- a/auth-api/tests/conftest.py
+++ b/auth-api/tests/conftest.py
@@ -29,7 +29,8 @@ from auth_api.models import db as _db
 
 
 def mock_token():
-    return "TOKEN...."
+    """Mock token generator."""
+    return 'TOKEN....'
 
 
 @pytest.fixture(scope='session')

--- a/auth-api/tests/conftest.py
+++ b/auth-api/tests/conftest.py
@@ -28,7 +28,7 @@ from auth_api.exceptions import BusinessException, Error
 from auth_api.models import db as _db
 
 
-def mock_token():
+def mock_token(config_id='', config_secret=''):
     """Mock token generator."""
     return 'TOKEN....'
 

--- a/auth-api/tests/unit/api/test_task.py
+++ b/auth-api/tests/unit/api/test_task.py
@@ -42,6 +42,7 @@ from tests.conftest import mock_token
 current_dt = dt.datetime.now()
 current_date_str = current_dt.strftime('%Y-%m-%d')
 
+
 def test_fetch_tasks(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that the tasks can be fetched."""
     user = factory_user_model()
@@ -246,6 +247,7 @@ def test_put_task_org_on_hold(client, jwt, session, keycloak_mock, monkeypatch):
     dictionary = json.loads(rv.data)
     assert dictionary['id'] == org_id
     assert rv.json.get('orgStatus') == OrgStatus.PENDING_STAFF_REVIEW.value
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_put_task_product(client, jwt, session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/api/test_task.py
+++ b/auth-api/tests/unit/api/test_task.py
@@ -16,6 +16,7 @@
 Test-Suite to ensure that the /tasks endpoint is working as expected.
 """
 import json
+import mock
 
 import datetime as dt
 import pytest
@@ -35,10 +36,11 @@ from tests.utilities.factory_scenarios import (
 from tests.utilities.factory_utils import (
     factory_auth_header, factory_task_model, factory_task_service, factory_user_model, factory_user_model_with_contact,
     patch_token_info)
+from tests.conftest import mock_token
+
 
 current_dt = dt.datetime.now()
 current_date_str = current_dt.strftime('%Y-%m-%d')
-
 
 def test_fetch_tasks(client, jwt, session):  # pylint:disable=unused-argument
     """Assert that the tasks can be fetched."""
@@ -128,6 +130,7 @@ def test_fetch_tasks_end_of_day(client, jwt, session):
     assert rv.status_code == http_status.HTTP_200_OK
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_put_task_org(client, jwt, session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that the task can be updated."""
     # 1. Create User
@@ -185,6 +188,7 @@ def test_put_task_org(client, jwt, session, keycloak_mock, monkeypatch):  # pyli
     assert rv.json.get('orgStatus') == OrgStatus.ACTIVE.value
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_put_task_org_on_hold(client, jwt, session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that the task can be updated."""
     # 1. Create User
@@ -243,7 +247,7 @@ def test_put_task_org_on_hold(client, jwt, session, keycloak_mock, monkeypatch):
     assert dictionary['id'] == org_id
     assert rv.json.get('orgStatus') == OrgStatus.PENDING_STAFF_REVIEW.value
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_put_task_product(client, jwt, session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that the task can be updated."""
     # 1. Create User
@@ -344,6 +348,7 @@ def test_fetch_task(client, jwt, session):  # pylint:disable=unused-argument
     (TestJwtClaims.public_bceid_user, AccessType.GOVN.value, TaskAction.AFFIDAVIT_REVIEW.value),
     (TestJwtClaims.public_user_role, AccessType.GOVN.value, TaskAction.ACCOUNT_REVIEW.value),
 ])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_tasks_on_account_creation(client, jwt, session, keycloak_mock,  # pylint:disable=unused-argument
                                    monkeypatch, user_token, access_type, expected_task_action):
     """Assert that tasks are created."""

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -21,6 +21,7 @@ import json
 import pytest
 import time
 import uuid
+import mock
 
 from sqlalchemy import event
 
@@ -47,6 +48,7 @@ from tests.utilities.factory_utils import (
     factory_invitation_anonymous, factory_membership_model, factory_org_model, factory_product_model,
     factory_user_model, patch_token_info)
 from tests.utilities.sqlalchemy import clear_event_listeners
+from tests.conftest import mock_token
 
 KEYCLOAK_SERVICE = KeycloakService()
 
@@ -58,7 +60,7 @@ def test_add_user(client, jwt, session):  # pylint:disable=unused-argument
     assert rv.status_code == http_status.HTTP_201_CREATED
     assert schema_utils.validate(rv.json, 'user_response')[0]
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_add_user_staff_org(client, jwt, session, keycloak_mock, monkeypatch):
     """Assert that adding and removing membership to a staff org occurs."""
     # Create a user and org
@@ -686,6 +688,7 @@ def test_delete_unknown_user_returns_404(client, jwt, session):  # pylint:disabl
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_user_as_only_admin_returns_400(client, jwt, session, keycloak_mock,
                                                monkeypatch, environment):  # pylint:disable=unused-argument
     """Test if the user is the only owner of a team assert status is 400."""
@@ -717,6 +720,7 @@ def test_delete_user_as_only_admin_returns_400(client, jwt, session, keycloak_mo
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_user_is_member_returns_204(client, jwt, session, keycloak_mock,
                                            monkeypatch, environment):  # pylint:disable=unused-argument
     """Test if the user is the member of a team assert status is 204."""

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -60,6 +60,7 @@ def test_add_user(client, jwt, session):  # pylint:disable=unused-argument
     assert rv.status_code == http_status.HTTP_201_CREATED
     assert schema_utils.validate(rv.json, 'user_response')[0]
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_add_user_staff_org(client, jwt, session, keycloak_mock, monkeypatch):
     """Assert that adding and removing membership to a staff org occurs."""

--- a/auth-api/tests/unit/api/test_user_settings.py
+++ b/auth-api/tests/unit/api/test_user_settings.py
@@ -17,6 +17,7 @@
 Test-Suite to ensure that the /users endpoint is working as expected.
 """
 import copy
+import mock
 
 from auth_api import status as http_status
 from auth_api.models import ContactLink as ContactLinkModel
@@ -25,8 +26,10 @@ from auth_api.services import Org as OrgService
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestUserInfo
 from tests.utilities.factory_utils import (
     factory_auth_header, factory_contact_model, factory_user_model, patch_token_info)
+from tests.conftest import mock_token
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_user_settings(client, jwt, session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that get works and adhere to schema."""
     user_model = factory_user_model(user_info=TestUserInfo.user_test)

--- a/auth-api/tests/unit/services/test_affidavit.py
+++ b/auth-api/tests/unit/services/test_affidavit.py
@@ -15,6 +15,7 @@
 
 Test suite to ensure that the affidavit service routines are working as expected.
 """
+import mock
 from auth_api.services import Affidavit as AffidavitService
 from auth_api.models import Task as TaskModel
 from auth_api.services import Org as OrgService
@@ -23,7 +24,7 @@ from auth_api.utils.enums import (AffidavitStatus, LoginSource, OrgStatus, TaskS
                                   TaskRelationshipStatus)
 from tests.utilities.factory_scenarios import TestAffidavit, TestJwtClaims, TestOrgInfo, TestUserInfo  # noqa: I005
 from tests.utilities.factory_utils import factory_user_model, factory_user_model_with_contact, patch_token_info
-
+from tests.conftest import mock_token
 
 def test_create_affidavit(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Affidavit can be created."""
@@ -56,6 +57,7 @@ def test_create_affidavit_duplicate(session, keycloak_mock, monkeypatch):  # pyl
     assert affidavit3.as_dict().get('status', None) == AffidavitStatus.PENDING.value
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_approve_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Affidavit can be approved."""
     user = factory_user_model_with_contact(user_info=TestUserInfo.user_bceid_tester)
@@ -82,6 +84,7 @@ def test_approve_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unu
     assert affidavit['status'] == AffidavitStatus.APPROVED.value
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_task_creation(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that affidavit reupload creates new task."""
     user = factory_user_model_with_contact()
@@ -102,6 +105,7 @@ def test_task_creation(session, keycloak_mock, monkeypatch):  # pylint:disable=u
     assert TaskModel.find_by_task_for_account(org_id, TaskStatus.OPEN.value) is not None
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_reject_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Affidavit can be rejected."""
     user = factory_user_model_with_contact(user_info=TestUserInfo.user_bceid_tester)

--- a/auth-api/tests/unit/services/test_affidavit.py
+++ b/auth-api/tests/unit/services/test_affidavit.py
@@ -26,6 +26,7 @@ from tests.utilities.factory_scenarios import TestAffidavit, TestJwtClaims, Test
 from tests.utilities.factory_utils import factory_user_model, factory_user_model_with_contact, patch_token_info
 from tests.conftest import mock_token
 
+
 def test_create_affidavit(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Affidavit can be created."""
     user = factory_user_model()

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -17,6 +17,7 @@ Test suite to ensure that the Affiliation service routines are working as expect
 """
 from unittest.mock import ANY, patch
 
+import mock
 import pytest
 
 from auth_api.exceptions import BusinessException
@@ -33,6 +34,7 @@ from tests.utilities.factory_scenarios import TestEntityInfo, TestJwtClaims, Tes
 from tests.utilities.factory_utils import (
     convert_org_to_staff_org, factory_entity_service, factory_membership_model, factory_org_service,
     factory_user_model_with_contact, patch_get_firms_parties, patch_token_info)
+from tests.conftest import mock_token
 
 
 @pytest.mark.parametrize('environment', ['test', None])
@@ -162,7 +164,7 @@ def test_create_affiliation_exists(session, auth_mock, environment):  # pylint:d
 
     assert affiliation
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 @pytest.mark.parametrize('environment', ['test', None])
 def test_create_affiliation_firms(session, auth_mock, monkeypatch, environment):  # pylint:disable=unused-argument
     """Assert that an Affiliation can be created."""
@@ -222,7 +224,7 @@ def test_create_affiliation_staff_sbc_staff(
         with pytest.raises(BusinessException):
             affiliation = AffiliationService.create_affiliation(org_id, business_identifier, environment)
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 @pytest.mark.parametrize('environment', ['test', None])
 def test_create_affiliation_firms_party_with_additional_space(session, auth_mock,
                                                               monkeypatch, environment):
@@ -245,6 +247,7 @@ def test_create_affiliation_firms_party_with_additional_space(session, auth_mock
     assert affiliation.as_dict()['organization']['id'] == org_dictionary['id']
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 @pytest.mark.parametrize('environment', ['test', None])
 def test_create_affiliation_firms_party_not_valid(session, auth_mock, monkeypatch,
                                                   environment):

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -164,6 +164,7 @@ def test_create_affiliation_exists(session, auth_mock, environment):  # pylint:d
 
     assert affiliation
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 @pytest.mark.parametrize('environment', ['test', None])
 def test_create_affiliation_firms(session, auth_mock, monkeypatch, environment):  # pylint:disable=unused-argument
@@ -223,6 +224,7 @@ def test_create_affiliation_staff_sbc_staff(
     else:
         with pytest.raises(BusinessException):
             affiliation = AffiliationService.create_affiliation(org_id, business_identifier, environment)
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 @pytest.mark.parametrize('environment', ['test', None])

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -18,6 +18,7 @@ Test suite to ensure that the Affiliation Invitation service routines are workin
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import mock
 import pytest
 from freezegun import freeze_time
 
@@ -42,7 +43,7 @@ from tests.utilities.factory_scenarios import TestContactInfo, TestEntityInfo, T
 from tests.utilities.factory_utils import (
     factory_affiliation_invitation, factory_entity_model, factory_membership_model, factory_user_model,
     patch_token_info)
-
+from tests.conftest import mock_token
 
 def create_test_entity():
     """Create test entity data."""
@@ -71,6 +72,7 @@ def setup_org_and_entity(user):
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_as_dict(session, auth_mock, keycloak_mock, business_mock, monkeypatch,
                  environment):  # pylint:disable=unused-argument
     """Assert that the Affiliation Invitation is exported correctly as a dictionary."""
@@ -99,6 +101,7 @@ def test_as_dict(session, auth_mock, keycloak_mock, business_mock, monkeypatch,
         ('uuid', 'test'),
     ]
 )
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_affiliation_invitation(session, auth_mock, keycloak_mock, business_mock,
                                        monkeypatch, create_org_with, environment):  # pylint:disable=unused-argument
     """Assert that an Affiliation Invitation can be created."""
@@ -122,6 +125,7 @@ def test_create_affiliation_invitation(session, auth_mock, keycloak_mock, busine
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_find_affiliation_invitation_by_id(session, auth_mock, keycloak_mock, business_mock,
                                            monkeypatch, environment):  # pylint:disable=unused-argument
     """Find an existing affiliation invitation with the provided id."""
@@ -152,6 +156,7 @@ def test_find_invitation_by_id_exception(session, auth_mock):  # pylint:disable=
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_affiliation_invitation(session, auth_mock, keycloak_mock, business_mock,
                                        monkeypatch, environment):  # pylint:disable=unused-argument
     """Delete the specified affiliation invitation."""
@@ -173,6 +178,7 @@ def test_delete_affiliation_invitation(session, auth_mock, keycloak_mock, busine
         assert invitation is None
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_accepted_affiliation_invitation(session, auth_mock, keycloak_mock, business_mock,
                                                 monkeypatch):  # pylint:disable=unused-argument
     """Delete the specified accepted affiliation invitation."""
@@ -210,6 +216,7 @@ def test_delete_affiliation_invitation_exception(session, auth_mock):  # pylint:
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_affiliation_invitation(session, auth_mock, keycloak_mock, business_mock,
                                        monkeypatch, environment):  # pylint:disable=unused-argument
     """Update the specified affiliation invitation with new data."""
@@ -230,6 +237,7 @@ def test_update_affiliation_invitation(session, auth_mock, keycloak_mock, busine
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_invitation_verify_different_tokens(session, auth_mock, keycloak_mock,
                                                    business_mock, monkeypatch,
                                                    environment):  # pylint:disable=unused-argument
@@ -262,6 +270,7 @@ def test_generate_confirmation_token(session):  # pylint:disable=unused-argument
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_validate_token_accepted(session, auth_mock, keycloak_mock, business_mock,
                                  monkeypatch, environment):  # pylint:disable=unused-argument
     """Validate invalid invitation token."""
@@ -303,6 +312,7 @@ def test_validate_token_exception(session):  # pylint:disable=unused-argument
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_affiliation_invitation(session, auth_mock, keycloak_mock, business_mock,
                                        monkeypatch, environment):  # pylint:disable=unused-argument
     """Accept the affiliation invitation and add the affiliation from the invitation."""
@@ -341,6 +351,7 @@ def test_accept_affiliation_invitation(session, auth_mock, keycloak_mock, busine
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_invitation_exceptions(session, auth_mock, keycloak_mock, business_mock,
                                       monkeypatch, environment):  # pylint:disable=unused-argument
     """Accept the affiliation invitation exceptions."""
@@ -391,6 +402,7 @@ def test_accept_invitation_exceptions(session, auth_mock, keycloak_mock, busines
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_invitations_by_from_org_id(session, auth_mock, keycloak_mock, business_mock,
                                         monkeypatch, environment):  # pylint:disable=unused-argument
     """Find an existing invitation with the provided from org id."""
@@ -420,6 +432,7 @@ def test_get_invitations_by_from_org_id(session, auth_mock, keycloak_mock, busin
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_invitations_by_to_org_id(session, auth_mock, keycloak_mock, business_mock,
                                       monkeypatch, environment):  # pylint:disable=unused-argument
     """Find an existing invitation with the provided to org id."""
@@ -621,6 +634,7 @@ def test_send_affiliation_invitation_request_refused(publish_to_mailer_mock,
     ('test user is org coordinator', roles.COORDINATOR, True),
     ('test user is org user', roles.USER, False),
 ])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_all_invitations_with_details_related_to_org(session, auth_mock, keycloak_mock, business_mock, monkeypatch,
                                                          test_name, member_type, expect_request_invites):
     """Verify REQUEST affiliation invitations are returned only when user is org ADMIN/COORDINATOR."""

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -45,6 +45,7 @@ from tests.utilities.factory_utils import (
     patch_token_info)
 from tests.conftest import mock_token
 
+
 def create_test_entity():
     """Create test entity data."""
     entity = EntityService.save_entity({

--- a/auth-api/tests/unit/services/test_invitation.py
+++ b/auth-api/tests/unit/services/test_invitation.py
@@ -38,6 +38,7 @@ from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestUs
 from tests.utilities.factory_utils import factory_invitation, factory_user_model, patch_token_info
 from tests.conftest import mock_token
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_as_dict(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that the Invitation is exported correctly as a dictionary."""
@@ -50,6 +51,7 @@ def test_as_dict(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disa
         invitation = InvitationService.create_invitation(invitation_info, User(user), '')
         invitation_dictionary = invitation.as_dict()
         assert invitation_dictionary['recipient_email'] == invitation_info['recipientEmail']
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -72,6 +74,7 @@ def test_create_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # p
         assert invitation_dictionary['id']
         mock_notify.assert_called()
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_find_invitation_by_id(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Find an existing invitation with the provided id."""
@@ -91,6 +94,7 @@ def test_find_invitation_by_id_exception(session, auth_mock):  # pylint:disable=
     """Find an existing invitation with the provided id with exception."""
     invitation = InvitationService.find_invitation_by_id(None)
     assert invitation is None
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -113,6 +117,7 @@ def test_delete_invitation_exception(session, auth_mock):  # pylint:disable=unus
         InvitationService.delete_invitation(None)
 
     assert exception.value.code == Error.DATA_NOT_FOUND.name
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -168,6 +173,7 @@ def test_validate_token_valid(session, auth_mock, keycloak_mock, monkeypatch):  
         invitation_id = InvitationService.validate_token(confirmation_token).as_dict().get('id')
         assert invitation_id == new_invitation['id']
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_validate_token_accepted(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Validate invalid invitation token."""
@@ -194,6 +200,7 @@ def test_validate_token_exception(session):  # pylint:disable=unused-argument
         InvitationService.validate_token(None)
 
     assert exception.value.code == Error.EXPIRED_INVITATION.name
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -252,6 +259,7 @@ def test_accept_invitation_for_govm(session, auth_mock, keycloak_mock, monkeypat
                 assert members
                 assert len(members) == 1, 'user gets active membership'
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_invitation_exceptions(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Accept the invitation and add membership from the invitation to the org."""
@@ -288,6 +296,7 @@ def test_accept_invitation_exceptions(session, auth_mock, keycloak_mock, monkeyp
                     InvitationService.accept_invitation(expired_invitation.id, User(user_invitee), '')
 
                 assert exception.value.code == Error.EXPIRED_INVITATION.name
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_invitations_by_org_id(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/services/test_invitation.py
+++ b/auth-api/tests/unit/services/test_invitation.py
@@ -18,6 +18,7 @@ Test suite to ensure that the Invitation service routines are working as expecte
 from datetime import datetime, timedelta
 from unittest.mock import ANY, patch
 
+import mock
 import pytest
 from freezegun import freeze_time
 from auth_api.models.dataclass import Activity
@@ -35,8 +36,9 @@ from auth_api.services import User
 from auth_api.utils.enums import ActivityAction
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestUserInfo
 from tests.utilities.factory_utils import factory_invitation, factory_user_model, patch_token_info
+from tests.conftest import mock_token
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_as_dict(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that the Invitation is exported correctly as a dictionary."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -49,7 +51,7 @@ def test_as_dict(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disa
         invitation_dictionary = invitation.as_dict()
         assert invitation_dictionary['recipient_email'] == invitation_info['recipientEmail']
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Invitation can be created."""
     with patch.object(InvitationService, 'send_invitation', return_value=None) as mock_notify:
@@ -70,7 +72,7 @@ def test_create_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # p
         assert invitation_dictionary['id']
         mock_notify.assert_called()
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_find_invitation_by_id(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Find an existing invitation with the provided id."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -90,7 +92,7 @@ def test_find_invitation_by_id_exception(session, auth_mock):  # pylint:disable=
     invitation = InvitationService.find_invitation_by_id(None)
     assert invitation is None
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Delete the specified invitation."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -112,7 +114,7 @@ def test_delete_invitation_exception(session, auth_mock):  # pylint:disable=unus
 
     assert exception.value.code == Error.DATA_NOT_FOUND.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Update the specified invitation with new data."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -126,6 +128,7 @@ def test_update_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # p
         assert updated_invitation['status'] == 'PENDING'
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_invitation_verify_different_tokens(session, auth_mock, keycloak_mock,  # pylint:disable=unused-argument
                                                    monkeypatch):
     """Update the specified invitation with new data."""
@@ -151,6 +154,7 @@ def test_generate_confirmation_token(session):  # pylint:disable=unused-argument
     assert confirmation_token is not None
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_validate_token_valid(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Validate the invitation token."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -164,7 +168,7 @@ def test_validate_token_valid(session, auth_mock, keycloak_mock, monkeypatch):  
         invitation_id = InvitationService.validate_token(confirmation_token).as_dict().get('id')
         assert invitation_id == new_invitation['id']
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_validate_token_accepted(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Validate invalid invitation token."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -191,7 +195,7 @@ def test_validate_token_exception(session):  # pylint:disable=unused-argument
 
     assert exception.value.code == Error.EXPIRED_INVITATION.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Accept the invitation and add membership from the invitation to the org."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -248,7 +252,7 @@ def test_accept_invitation_for_govm(session, auth_mock, keycloak_mock, monkeypat
                 assert members
                 assert len(members) == 1, 'user gets active membership'
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_invitation_exceptions(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Accept the invitation and add membership from the invitation to the org."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -285,7 +289,7 @@ def test_accept_invitation_exceptions(session, auth_mock, keycloak_mock, monkeyp
 
                 assert exception.value.code == Error.EXPIRED_INVITATION.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_invitations_by_org_id(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Find an existing invitation with the provided org id."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):

--- a/auth-api/tests/unit/services/test_invitation.py
+++ b/auth-api/tests/unit/services/test_invitation.py
@@ -230,6 +230,7 @@ def test_accept_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # p
                 assert len(members) == 1
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_invitation_for_govm(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Accept the invitation and add membership from the invitation to the org."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):

--- a/auth-api/tests/unit/services/test_invitation_auth.py
+++ b/auth-api/tests/unit/services/test_invitation_auth.py
@@ -140,6 +140,7 @@ def test_change_authentication_subsequent_invites(session, auth_mock, keycloak_m
             invitation_model = InvitationModel.find_invitation_by_id(invitation_bceid.as_dict()['id'])
             assert invitation_model.login_source == LoginSource.BCEID.value
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_change_authentication_non_govm(session, auth_mock, keycloak_mock, monkeypatch):
     """Assert that non government ministry organization invites can be accepted by different login sources."""
@@ -279,6 +280,7 @@ def test_invitation_govm(session, auth_mock, keycloak_mock, monkeypatch):
                                                             'ACTIVE')
             assert members
             assert len(members) == 1
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_invitation_anonymous(session, auth_mock, keycloak_mock, monkeypatch):

--- a/auth-api/tests/unit/services/test_invitation_auth.py
+++ b/auth-api/tests/unit/services/test_invitation_auth.py
@@ -17,6 +17,7 @@ Test suite to ensure that the Invitation service authentication / login source c
 """
 from unittest.mock import ANY, patch
 
+import mock
 import pytest
 
 from auth_api.exceptions import BusinessException
@@ -32,6 +33,7 @@ from auth_api.utils.enums import AccessType, ActivityAction, InvitationStatus, L
 from auth_api.utils.user_context import UserContext, user_context
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestUserInfo
 from tests.utilities.factory_utils import factory_invitation, factory_user_model, patch_token_info
+from tests.conftest import mock_token
 
 
 @user_context
@@ -84,6 +86,7 @@ def test_token_user_context(session, auth_mock, monkeypatch):
     assert_token_user_context(LoginSource.BCEID.value)
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_change_authentication_subsequent_invites(session, auth_mock, keycloak_mock, monkeypatch):
     """Assert that changing org authentication method changes new invitation required login source."""
     user_with_token = TestUserInfo.user_tester
@@ -137,7 +140,7 @@ def test_change_authentication_subsequent_invites(session, auth_mock, keycloak_m
             invitation_model = InvitationModel.find_invitation_by_id(invitation_bceid.as_dict()['id'])
             assert invitation_model.login_source == LoginSource.BCEID.value
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_change_authentication_non_govm(session, auth_mock, keycloak_mock, monkeypatch):
     """Assert that non government ministry organization invites can be accepted by different login sources."""
     # inviter/invitee user setup
@@ -277,7 +280,7 @@ def test_invitation_govm(session, auth_mock, keycloak_mock, monkeypatch):
             assert members
             assert len(members) == 1
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_invitation_anonymous(session, auth_mock, keycloak_mock, monkeypatch):
     """Assert that non government ministry organization invites can be accepted by different login sources."""
     # inviter/invitee user setup

--- a/auth-api/tests/unit/services/test_invitation_auth.py
+++ b/auth-api/tests/unit/services/test_invitation_auth.py
@@ -222,6 +222,7 @@ def test_change_authentication_non_govm(session, auth_mock, keycloak_mock, monke
             assert len(members) == 2
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_invitation_govm(session, auth_mock, keycloak_mock, monkeypatch):
     """Assert that government ministry organization invites can be accepted by IDIR only."""
     # Users setup

--- a/auth-api/tests/unit/services/test_membership.py
+++ b/auth-api/tests/unit/services/test_membership.py
@@ -30,6 +30,7 @@ from tests.utilities.factory_scenarios import KeycloakScenario, TestOrgInfo, Tes
 from tests.utilities.factory_utils import factory_membership_model, factory_product_model, factory_user_model
 from tests.conftest import mock_token
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_invite_adds_group_to_the_user(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that accepting an invite adds group to the user."""

--- a/auth-api/tests/unit/services/test_membership.py
+++ b/auth-api/tests/unit/services/test_membership.py
@@ -16,6 +16,7 @@
 Test suite to ensure that the Membership service routines are working as expected.
 """
 
+import mock
 from unittest.mock import ANY, patch
 from auth_api.models import MembershipStatusCode as MembershipStatusCodeModel
 from auth_api.models.dataclass import Activity
@@ -27,8 +28,9 @@ from auth_api.utils.constants import GROUP_ACCOUNT_HOLDERS
 from auth_api.utils.enums import ActivityAction, ProductCode, Status
 from tests.utilities.factory_scenarios import KeycloakScenario, TestOrgInfo, TestUserInfo
 from tests.utilities.factory_utils import factory_membership_model, factory_product_model, factory_user_model
+from tests.conftest import mock_token
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_accept_invite_adds_group_to_the_user(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that accepting an invite adds group to the user."""
     # Create a user in keycloak
@@ -79,6 +81,7 @@ def test_accept_invite_adds_group_to_the_user(session, monkeypatch):  # pylint:d
     assert GROUP_ACCOUNT_HOLDERS in groups
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_remove_member_removes_group_to_the_user(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that accepting an invite adds group to the user."""
     # Create a user in keycloak

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -67,6 +67,7 @@ def test_as_dict(session):  # pylint:disable=unused-argument
     assert dictionary
     assert dictionary['name'] == TestOrgInfo.org1['name']
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
@@ -76,6 +77,7 @@ def test_create_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unus
     assert org
     dictionary = org.as_dict()
     assert dictionary['name'] == TestOrgInfo.org1['name']
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_products(session, keycloak_mock, monkeypatch):
@@ -89,6 +91,7 @@ def test_create_org_products(session, keycloak_mock, monkeypatch):
         assert org
     dictionary = org.as_dict()
     assert dictionary['name'] == TestOrgInfo.org_with_products['name']
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_basic_org_assert_pay_request_is_correct(session, keycloak_mock,
@@ -113,6 +116,7 @@ def test_create_basic_org_assert_pay_request_is_correct(session, keycloak_mock,
         }
         assert expected_data == actual_data
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_pay_request_is_correct_with_branch_name(session,
                                                  keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -136,6 +140,7 @@ def test_pay_request_is_correct_with_branch_name(session,
         }
         assert expected_data == actual_data
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_basic_org_assert_pay_request_activity(session, keycloak_mock, monkeypatch):
     """Assert that while org payment update touches activity log."""
@@ -157,6 +162,7 @@ def test_update_basic_org_assert_pay_request_activity(session, keycloak_mock, mo
         mock_alp.assert_called_with(Activity(action=ActivityAction.PAYMENT_INFO_CHANGE.value,
                                              org_id=ANY, name=ANY, id=ANY,
                                              value=PaymentMethod.ONLINE_BANKING.value))
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_basic_org_assert_pay_request_is_correct(session, keycloak_mock,
@@ -202,6 +208,7 @@ def test_update_basic_org_assert_pay_request_is_correct(session, keycloak_mock,
         }
         assert expected_data == actual_data, 'updating bank  to Credit Card works.'
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_basic_org_assert_pay_request_is_correct_online_banking(session,
                                                                        keycloak_mock,
@@ -225,6 +232,7 @@ def test_create_basic_org_assert_pay_request_is_correct_online_banking(session,
 
         }
         assert expected_data == actual_data
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_basic_org_assert_pay_request_is_govm(session,
@@ -251,6 +259,7 @@ def test_create_basic_org_assert_pay_request_is_govm(session,
 
         }
         assert expected_data == actual_data
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_put_basic_org_assert_pay_request_is_govm(session,
@@ -296,6 +305,7 @@ def test_put_basic_org_assert_pay_request_is_govm(session,
         }
         assert expected_data == actual_data
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_premium_org_assert_pay_request_is_correct(session, keycloak_mock,
                                                           monkeypatch):  # pylint:disable=unused-argument
@@ -329,6 +339,7 @@ def test_create_premium_org_assert_pay_request_is_correct(session, keycloak_mock
         }
         assert actual_data == expected_data
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_assert_payment_types(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
@@ -341,6 +352,7 @@ def test_create_org_assert_payment_types(session, keycloak_mock, monkeypatch):  
     assert dictionary.get('bcol_user_id', None) is None
     assert dictionary.get('bcol_user_name', None) is None
     assert dictionary.get('bcol_account_id', None) is None
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_single_subscription(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -359,6 +371,7 @@ def test_create_product_single_subscription(session, keycloak_mock, monkeypatch)
                                                                skip_auth=True)
     assert next(prod for prod in subscriptions
                 if prod.get('code') == TestOrgProductsInfo.org_products1['subscriptions'][0]['productCode'])
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_single_subscription_duplicate_error(session, keycloak_mock,
@@ -385,6 +398,7 @@ def test_create_product_single_subscription_duplicate_error(session, keycloak_mo
                                                    TestOrgProductsInfo.org_products_business,
                                                    skip_auth=True)
     assert exception.value.code == Error.PRODUCT_SUBSCRIPTION_EXISTS.name
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_multiple_subscription(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -430,6 +444,7 @@ def test_create_product_subscription_staff(session, keycloak_mock, org_type, mon
                 if prod.get('code') == TestOrgProductsInfo.org_products2['subscriptions'][0]['productCode'])
     assert next(prod for prod in subscriptions
                 if prod.get('code') == TestOrgProductsInfo.org_products2['subscriptions'][1]['productCode'])
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_subscription_nds(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -493,6 +508,7 @@ def test_create_org_with_duplicate_name(session, monkeypatch):  # pylint:disable
         org.create_org(TestOrgInfo.org2, user_id=user.id)
     assert exception.value.code == Error.DATA_CONFLICT.name
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_with_similar_name(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org with similar name can be created."""
@@ -525,6 +541,7 @@ def test_create_org_with_duplicate_name_bcol(session, keycloak_mock, monkeypatch
             patch_token_info({'sub': user.keycloak_guid, 'idp_userid': user.idp_userid}, monkeypatch)
             org.create_org(TestOrgInfo.bcol_linked(), user_id=user.id)
         assert exception.value.code == Error.DATA_CONFLICT.name
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_org_name(session, monkeypatch):  # pylint:disable=unused-argument
@@ -676,6 +693,7 @@ def test_update_contact_no_contact(session):  # pylint:disable=unused-argument
         OrgService.update_contact(org_dictionary['id'], TestContactInfo.contact2)
     assert exception.value.code == Error.DATA_NOT_FOUND.name
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_members(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that members for an org can be retrieved."""
@@ -693,6 +711,7 @@ def test_get_members(session, keycloak_mock, monkeypatch):  # pylint:disable=unu
     assert response
     assert len(response) == 1
     assert response[0].membership_type_code == 'ADMIN'
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_invitations(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -716,6 +735,7 @@ def test_get_invitations(session, auth_mock, keycloak_mock, monkeypatch):  # pyl
         assert response
         assert len(response) == 1
         assert response[0].recipient_email == invitation.as_dict()['recipient_email']
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_owner_count_one_owner(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -741,6 +761,7 @@ def test_create_staff_org_failure(session, keycloak_mock, staff_org, monkeypatch
         OrgService.create_org(TestOrgInfo.staff_org, user.id)
     assert exception.value.code == Error.INVALID_INPUT.name
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_owner_count_two_owner_with_admins(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert wrong org cannot be created."""
@@ -756,6 +777,7 @@ def test_get_owner_count_two_owner_with_admins(session, keycloak_mock, monkeypat
     user3 = factory_user_model(user_info=TestUserInfo.user3)
     factory_membership_model(user3.id, org._model.id, member_type='ADMIN')
     assert MembershipService.get_owner_count(MembershipService, org._model) == 2
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_org_with_members(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -778,6 +800,7 @@ def test_delete_org_with_members(session, auth_mock, keycloak_mock, monkeypatch)
 
     OrgService.delete_org(org_id)
     assert len(MembershipService.get_members_for_org(org_id)) == 0
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_org_with_affiliation(session, auth_mock, keycloak_mock,
@@ -802,6 +825,7 @@ def test_delete_org_with_affiliation(session, auth_mock, keycloak_mock,
     OrgService.delete_org(org_id)
 
     assert len(AffiliationService.find_visible_affiliations_by_org_id(org_id)) == 0
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_org_with_members_success(session, auth_mock, keycloak_mock,
@@ -864,6 +888,7 @@ def test_delete_contact_org_link(session, auth_mock):  # pylint:disable=unused-a
     exist_contact_link = ContactLinkModel.find_by_org_id(org_id)
     assert not exist_contact_link
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_adds_user_to_account_holders_group(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org creation adds the user to account holders group."""
@@ -882,6 +907,7 @@ def test_create_org_adds_user_to_account_holders_group(session, monkeypatch):  #
     for group in user_groups:
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS in groups
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_org_removes_user_from_account_holders_group(session, auth_mock,
@@ -906,6 +932,7 @@ def test_delete_org_removes_user_from_account_holders_group(session, auth_mock,
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS not in groups
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_does_not_remove_user_from_account_holder_group(session, monkeypatch,
                                                                auth_mock):  # pylint:disable=unused-argument
@@ -929,6 +956,7 @@ def test_delete_does_not_remove_user_from_account_holder_group(session, monkeypa
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS in groups
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_with_linked_bcol_account(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
@@ -951,6 +979,7 @@ def test_bcol_account_exists(session):  # pylint:disable=unused-argument
 
     check_result = OrgService.bcol_account_link_check(TestBCOLInfo.bcol1['bcol_account_id'])
     assert check_result
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_with_different_name_than_bcol_account(session, keycloak_mock,
@@ -977,6 +1006,7 @@ def test_bcol_account_not_exists(session):  # pylint:disable=unused-argument
     check_result = OrgService.bcol_account_link_check(TestBCOLInfo.bcol2['bcol_account_id'])
     assert not check_result
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_with_a_linked_bcol_details(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that org creation with an existing linked BCOL account fails."""
@@ -989,6 +1019,7 @@ def test_create_org_with_a_linked_bcol_details(session, keycloak_mock, monkeypat
     with pytest.raises(BusinessException) as exception:
         OrgService.create_org(TestOrgInfo.bcol_linked(), user_id=user.id)
     assert exception.value.code == Error.BCOL_ACCOUNT_ALREADY_LINKED.name
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_by_bceid_user(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -1006,6 +1037,7 @@ def test_create_org_by_bceid_user(session, keycloak_mock, monkeypatch):  # pylin
         assert dictionary['org_status'] == OrgStatus.PENDING_STAFF_REVIEW.value
         assert dictionary['access_type'] == AccessType.EXTRA_PROVINCIAL.value
         mock_notify.assert_called()
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_by_in_province_bceid_user(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -1034,6 +1066,7 @@ def test_create_org_invalid_access_type_user(session, keycloak_mock, monkeypatch
     with pytest.raises(BusinessException) as exception:
         OrgService.create_org(TestOrgInfo.org_regular, user_id=user.id)
     assert exception.value.code == Error.USER_CANT_CREATE_REGULAR_ORG.name
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_by_verified_bceid_user(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
@@ -1065,6 +1098,7 @@ def test_create_org_by_verified_bceid_user(session, keycloak_mock, monkeypatch):
     TaskService.update_task(TaskService(task_model), task_info)
     org_result: OrgModel = OrgModel.find_by_org_id(org_dict['id'])
     assert org_result.status_code == OrgStatus.ACTIVE.value
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_by_rejected_bceid_user(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -18,6 +18,7 @@ Test suite to ensure that the Org service routines are working as expected.
 from http import HTTPStatus
 from unittest.mock import ANY, Mock, patch
 
+import mock
 import pytest
 from requests import Response
 from werkzeug.exceptions import HTTPException
@@ -53,6 +54,7 @@ from tests.utilities.factory_utils import (
     factory_membership_model, factory_org_model, factory_org_service, factory_user_model,
     factory_user_model_with_contact, patch_pay_account_delete, patch_pay_account_post, patch_pay_account_put,
     patch_token_info)
+from tests.conftest import mock_token
 
 # noqa: I005
 
@@ -65,7 +67,7 @@ def test_as_dict(session):  # pylint:disable=unused-argument
     assert dictionary
     assert dictionary['name'] == TestOrgInfo.org1['name']
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     user = factory_user_model()
@@ -75,7 +77,7 @@ def test_create_org(session, keycloak_mock, monkeypatch):  # pylint:disable=unus
     dictionary = org.as_dict()
     assert dictionary['name'] == TestOrgInfo.org1['name']
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_products(session, keycloak_mock, monkeypatch):
     """Assert that an Org with products can be created."""
     user = factory_user_model()
@@ -88,7 +90,7 @@ def test_create_org_products(session, keycloak_mock, monkeypatch):
     dictionary = org.as_dict()
     assert dictionary['name'] == TestOrgInfo.org_with_products['name']
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_basic_org_assert_pay_request_is_correct(session, keycloak_mock,
                                                         monkeypatch):  # pylint:disable=unused-argument
     """Assert that while org creation , pay-api gets called with proper data for basic accounts."""
@@ -111,7 +113,7 @@ def test_create_basic_org_assert_pay_request_is_correct(session, keycloak_mock,
         }
         assert expected_data == actual_data
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_pay_request_is_correct_with_branch_name(session,
                                                  keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that while org creation , pay-api gets called with proper data for basic accounts."""
@@ -134,7 +136,7 @@ def test_pay_request_is_correct_with_branch_name(session,
         }
         assert expected_data == actual_data
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_basic_org_assert_pay_request_activity(session, keycloak_mock, monkeypatch):
     """Assert that while org payment update touches activity log."""
     user_with_token = TestUserInfo.user_test
@@ -156,7 +158,7 @@ def test_update_basic_org_assert_pay_request_activity(session, keycloak_mock, mo
                                              org_id=ANY, name=ANY, id=ANY,
                                              value=PaymentMethod.ONLINE_BANKING.value))
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_basic_org_assert_pay_request_is_correct(session, keycloak_mock,
                                                         monkeypatch):  # pylint:disable=unused-argument
     """Assert that while org updation , pay-api gets called with proper data for basic accounts."""
@@ -200,7 +202,7 @@ def test_update_basic_org_assert_pay_request_is_correct(session, keycloak_mock,
         }
         assert expected_data == actual_data, 'updating bank  to Credit Card works.'
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_basic_org_assert_pay_request_is_correct_online_banking(session,
                                                                        keycloak_mock,
                                                                        monkeypatch):  # pylint:disable=unused-argument
@@ -224,7 +226,7 @@ def test_create_basic_org_assert_pay_request_is_correct_online_banking(session,
         }
         assert expected_data == actual_data
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_basic_org_assert_pay_request_is_govm(session,
                                                      keycloak_mock, staff_user_mock,
                                                      monkeypatch):  # pylint:disable=unused-argument
@@ -250,7 +252,7 @@ def test_create_basic_org_assert_pay_request_is_govm(session,
         }
         assert expected_data == actual_data
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_put_basic_org_assert_pay_request_is_govm(session,
                                                   keycloak_mock, staff_user_mock,
                                                   monkeypatch):  # pylint:disable=unused-argument
@@ -294,7 +296,7 @@ def test_put_basic_org_assert_pay_request_is_govm(session,
         }
         assert expected_data == actual_data
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_premium_org_assert_pay_request_is_correct(session, keycloak_mock,
                                                           monkeypatch):  # pylint:disable=unused-argument
     """Assert that while org creation , pay-api gets called with proper data for basic accounts."""
@@ -327,7 +329,7 @@ def test_create_premium_org_assert_pay_request_is_correct(session, keycloak_mock
         }
         assert actual_data == expected_data
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_assert_payment_types(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     user = factory_user_model()
@@ -340,7 +342,7 @@ def test_create_org_assert_payment_types(session, keycloak_mock, monkeypatch):  
     assert dictionary.get('bcol_user_name', None) is None
     assert dictionary.get('bcol_account_id', None) is None
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_single_subscription(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -358,7 +360,7 @@ def test_create_product_single_subscription(session, keycloak_mock, monkeypatch)
     assert next(prod for prod in subscriptions
                 if prod.get('code') == TestOrgProductsInfo.org_products1['subscriptions'][0]['productCode'])
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_single_subscription_duplicate_error(session, keycloak_mock,
                                                             monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
@@ -384,7 +386,7 @@ def test_create_product_single_subscription_duplicate_error(session, keycloak_mo
                                                    skip_auth=True)
     assert exception.value.code == Error.PRODUCT_SUBSCRIPTION_EXISTS.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_multiple_subscription(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -410,6 +412,7 @@ def test_create_product_multiple_subscription(session, keycloak_mock, monkeypatc
 @pytest.mark.parametrize(
     'org_type', [(OrgType.STAFF.value), (OrgType.SBC_STAFF.value)]
 )
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_subscription_staff(session, keycloak_mock, org_type, monkeypatch):
     """Assert that updating product subscription works for staff."""
     user = factory_user_model(TestUserInfo.user_test)
@@ -428,7 +431,7 @@ def test_create_product_subscription_staff(session, keycloak_mock, org_type, mon
     assert next(prod for prod in subscriptions
                 if prod.get('code') == TestOrgProductsInfo.org_products2['subscriptions'][1]['productCode'])
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_subscription_nds(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert a product subscription for NDS can be created with a system admin token."""
     # setup an org
@@ -456,6 +459,7 @@ def test_create_product_subscription_nds(session, keycloak_mock, monkeypatch):  
     ('test_staff_manage_accounts', TestJwtClaims.staff_manage_accounts_role),
     ('test_staff_admin', TestJwtClaims.staff_admin_role)
 ])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_subscription_nds_unauthorized(session,  # pylint:disable=unused-argument
                                                       keycloak_mock,
                                                       monkeypatch,
@@ -489,7 +493,7 @@ def test_create_org_with_duplicate_name(session, monkeypatch):  # pylint:disable
         org.create_org(TestOrgInfo.org2, user_id=user.id)
     assert exception.value.code == Error.DATA_CONFLICT.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_with_similar_name(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org with similar name can be created."""
     user = factory_user_model()
@@ -522,7 +526,7 @@ def test_create_org_with_duplicate_name_bcol(session, keycloak_mock, monkeypatch
             org.create_org(TestOrgInfo.bcol_linked(), user_id=user.id)
         assert exception.value.code == Error.DATA_CONFLICT.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_org_name(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org name cannot be updated."""
     org = factory_org_service()
@@ -672,7 +676,7 @@ def test_update_contact_no_contact(session):  # pylint:disable=unused-argument
         OrgService.update_contact(org_dictionary['id'], TestContactInfo.contact2)
     assert exception.value.code == Error.DATA_NOT_FOUND.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_members(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that members for an org can be retrieved."""
     user_with_token = TestUserInfo.user_test
@@ -690,7 +694,7 @@ def test_get_members(session, keycloak_mock, monkeypatch):  # pylint:disable=unu
     assert len(response) == 1
     assert response[0].membership_type_code == 'ADMIN'
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_invitations(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that invitations for an org can be retrieved."""
     with patch.object(InvitationService, 'send_invitation', return_value=None):
@@ -713,7 +717,7 @@ def test_get_invitations(session, auth_mock, keycloak_mock, monkeypatch):  # pyl
         assert len(response) == 1
         assert response[0].recipient_email == invitation.as_dict()['recipient_email']
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_owner_count_one_owner(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that count of owners is correct."""
     user_with_token = TestUserInfo.user_test
@@ -737,7 +741,7 @@ def test_create_staff_org_failure(session, keycloak_mock, staff_org, monkeypatch
         OrgService.create_org(TestOrgInfo.staff_org, user.id)
     assert exception.value.code == Error.INVALID_INPUT.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_owner_count_two_owner_with_admins(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert wrong org cannot be created."""
     user_with_token = TestUserInfo.user_test
@@ -753,7 +757,7 @@ def test_get_owner_count_two_owner_with_admins(session, keycloak_mock, monkeypat
     factory_membership_model(user3.id, org._model.id, member_type='ADMIN')
     assert MembershipService.get_owner_count(MembershipService, org._model) == 2
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_org_with_members(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an org can be deleted."""
     user_with_token = TestUserInfo.user_test
@@ -775,7 +779,7 @@ def test_delete_org_with_members(session, auth_mock, keycloak_mock, monkeypatch)
     OrgService.delete_org(org_id)
     assert len(MembershipService.get_members_for_org(org_id)) == 0
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_org_with_affiliation(session, auth_mock, keycloak_mock,
                                      monkeypatch):  # pylint:disable=unused-argument
     """Assert that an org cannot be deleted."""
@@ -799,7 +803,7 @@ def test_delete_org_with_affiliation(session, auth_mock, keycloak_mock,
 
     assert len(AffiliationService.find_visible_affiliations_by_org_id(org_id)) == 0
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_org_with_members_success(session, auth_mock, keycloak_mock,
                                          monkeypatch):  # pylint:disable=unused-argument
     """Assert that an org can be deleted."""
@@ -860,7 +864,7 @@ def test_delete_contact_org_link(session, auth_mock):  # pylint:disable=unused-a
     exist_contact_link = ContactLinkModel.find_by_org_id(org_id)
     assert not exist_contact_link
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_adds_user_to_account_holders_group(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org creation adds the user to account holders group."""
     # Create a user in keycloak
@@ -879,7 +883,7 @@ def test_create_org_adds_user_to_account_holders_group(session, monkeypatch):  #
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS in groups
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_org_removes_user_from_account_holders_group(session, auth_mock,
                                                             monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org deletion removes the user from account holders group."""
@@ -902,7 +906,7 @@ def test_delete_org_removes_user_from_account_holders_group(session, auth_mock,
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS not in groups
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_does_not_remove_user_from_account_holder_group(session, monkeypatch,
                                                                auth_mock):  # pylint:disable=unused-argument
     """Assert that if the user has multiple Orgs, and deleting one doesn't remove account holders group."""
@@ -925,7 +929,7 @@ def test_delete_does_not_remove_user_from_account_holder_group(session, monkeypa
         groups.append(group.get('name'))
     assert GROUP_ACCOUNT_HOLDERS in groups
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_with_linked_bcol_account(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     user = factory_user_model()
@@ -948,7 +952,7 @@ def test_bcol_account_exists(session):  # pylint:disable=unused-argument
     check_result = OrgService.bcol_account_link_check(TestBCOLInfo.bcol1['bcol_account_id'])
     assert check_result
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_with_different_name_than_bcol_account(session, keycloak_mock,
                                                           monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
@@ -973,7 +977,7 @@ def test_bcol_account_not_exists(session):  # pylint:disable=unused-argument
     check_result = OrgService.bcol_account_link_check(TestBCOLInfo.bcol2['bcol_account_id'])
     assert not check_result
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_with_a_linked_bcol_details(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that org creation with an existing linked BCOL account fails."""
     user = factory_user_model()
@@ -986,7 +990,7 @@ def test_create_org_with_a_linked_bcol_details(session, keycloak_mock, monkeypat
         OrgService.create_org(TestOrgInfo.bcol_linked(), user_id=user.id)
     assert exception.value.code == Error.BCOL_ACCOUNT_ALREADY_LINKED.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_by_bceid_user(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     user = factory_user_model_with_contact()
@@ -1003,7 +1007,7 @@ def test_create_org_by_bceid_user(session, keycloak_mock, monkeypatch):  # pylin
         assert dictionary['access_type'] == AccessType.EXTRA_PROVINCIAL.value
         mock_notify.assert_called()
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_by_in_province_bceid_user(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     user = factory_user_model_with_contact()
@@ -1031,7 +1035,7 @@ def test_create_org_invalid_access_type_user(session, keycloak_mock, monkeypatch
         OrgService.create_org(TestOrgInfo.org_regular, user_id=user.id)
     assert exception.value.code == Error.USER_CANT_CREATE_REGULAR_ORG.name
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_by_verified_bceid_user(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     # Steps
@@ -1062,7 +1066,7 @@ def test_create_org_by_verified_bceid_user(session, keycloak_mock, monkeypatch):
     org_result: OrgModel = OrgModel.find_by_org_id(org_dict['id'])
     assert org_result.status_code == OrgStatus.ACTIVE.value
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_org_by_rejected_bceid_user(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
     # Steps
@@ -1178,6 +1182,7 @@ def test_patch_org_access_type(session, monkeypatch):  # pylint:disable=unused-a
 
 
 @pytest.mark.asyncio
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_product_single_subscription_qs(session, monkeypatch):
     """Assert that qualified supplier sub product subscriptions can be created."""
     # Create a user in keycloak

--- a/auth-api/tests/unit/services/test_product.py
+++ b/auth-api/tests/unit/services/test_product.py
@@ -16,7 +16,9 @@
 Test suite to ensure that the Product service routines are working as expected.
 """
 from unittest.mock import ANY, patch
+from tests.conftest import mock_token
 
+import mock
 import pytest
 
 from auth_api.models.contact_link import ContactLink as ContactLinkModel
@@ -50,6 +52,7 @@ def test_get_products(session):  # pylint:disable=unused-argument
     ('has_contact', True),
     ('no_contact', False),
 ])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_product_subscription(session, keycloak_mock, monkeypatch, test_name, has_contact):
     """Assert that updating product subscription works."""
     user = factory_user_model(TestUserInfo.user_test)
@@ -86,6 +89,7 @@ def test_update_product_subscription(session, keycloak_mock, monkeypatch, test_n
                                              org_id=ANY, value=ANY, id=ANY, name='Personal Property Registry'))
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_users_product_subscriptions_kc_groups(session, keycloak_mock, monkeypatch):
     """Assert that our keycloak groups are returned correctly."""
     # Used these to test without the keycloak_mock.
@@ -242,7 +246,7 @@ def test_get_users_product_subscriptions_kc_groups(session, keycloak_mock, monke
     assert kc_groups[2].group_name == 'vs'
     assert kc_groups[2].group_action == KeycloakGroupActions.REMOVE_FROM_GROUP.value
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_users_sub_product_subscriptions_kc_groups(session, keycloak_mock, monkeypatch):
     """Assert that our keycloak groups are returned correctly for sub products."""
     # Used these to test without the keycloak_mock.

--- a/auth-api/tests/unit/services/test_product.py
+++ b/auth-api/tests/unit/services/test_product.py
@@ -246,6 +246,7 @@ def test_get_users_product_subscriptions_kc_groups(session, keycloak_mock, monke
     assert kc_groups[2].group_name == 'vs'
     assert kc_groups[2].group_action == KeycloakGroupActions.REMOVE_FROM_GROUP.value
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_get_users_sub_product_subscriptions_kc_groups(session, keycloak_mock, monkeypatch):
     """Assert that our keycloak groups are returned correctly for sub products."""

--- a/auth-api/tests/unit/services/test_product_notifications.py
+++ b/auth-api/tests/unit/services/test_product_notifications.py
@@ -41,8 +41,8 @@ from tests.conftest import mock_token
 @pytest.mark.parametrize('org_product_info', [
     TestOrgProductsInfo.org_products_vs
 ])
-@patch.object(auth_api.services.products, 'publish_to_mailer')
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
+@patch.object(auth_api.services.products, 'publish_to_mailer')
 def test_default_approved_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product approved notification default is created."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -110,8 +110,8 @@ def test_default_approved_notification(mock_mailer, session, auth_mock, keycloak
 @pytest.mark.parametrize('org_product_info', [
     TestOrgProductsInfo.org_products_vs
 ])
-@patch.object(auth_api.services.products, 'publish_to_mailer')
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
+@patch.object(auth_api.services.products, 'publish_to_mailer')
 def test_default_rejected_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product rejected notification default is created."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -181,8 +181,8 @@ def test_default_rejected_notification(mock_mailer, session, auth_mock, keycloak
     TestOrgProductsInfo.mhr_qs_home_manufacturers,
     TestOrgProductsInfo.mhr_qs_home_dealers
 ])
-@patch.object(auth_api.services.products, 'publish_to_mailer')
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
+@patch.object(auth_api.services.products, 'publish_to_mailer')
 def test_detailed_approved_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product approved notification with details is created."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -264,8 +264,8 @@ def test_detailed_approved_notification(mock_mailer, session, auth_mock, keycloa
     (TestOrgProductsInfo.mhr_qs_home_manufacturers, 'BCREG'),
     (TestOrgProductsInfo.mhr_qs_home_dealers, 'BCREG')
 ])
-@patch.object(auth_api.services.products, 'publish_to_mailer')
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
+@patch.object(auth_api.services.products, 'publish_to_mailer')
 def test_detailed_rejected_notification(mock_mailer, session, auth_mock, keycloak_mock,
                                         monkeypatch, org_product_info, contact_type):
     """Assert product rejected notification with details is created."""
@@ -352,8 +352,8 @@ def test_detailed_rejected_notification(mock_mailer, session, auth_mock, keycloa
     TestOrgProductsInfo.mhr_qs_home_manufacturers,
     TestOrgProductsInfo.mhr_qs_home_dealers
 ])
-@patch.object(auth_api.services.products, 'publish_to_mailer')
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
+@patch.object(auth_api.services.products, 'publish_to_mailer')
 def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product notification is not created for on hold state."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -424,8 +424,8 @@ def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monke
     (TestOrgProductsInfo.mhr_qs_home_manufacturers, 'BCREG'),
     (TestOrgProductsInfo.mhr_qs_home_dealers, 'BCREG')
 ])
-@patch.object(auth_api.services.products, 'publish_to_mailer')
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
+@patch.object(auth_api.services.products, 'publish_to_mailer')
 def test_confirmation_notification(mock_mailer, session, auth_mock, keycloak_mock,
                                    monkeypatch, org_product_info, contact_type):
     """Assert product confirmation notification is properly created."""
@@ -475,8 +475,8 @@ def test_confirmation_notification(mock_mailer, session, auth_mock, keycloak_moc
 @pytest.mark.parametrize('org_product_info', [
     TestOrgProductsInfo.org_products_vs
 ])
-@patch.object(auth_api.services.products, 'publish_to_mailer')
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
+@patch.object(auth_api.services.products, 'publish_to_mailer')
 def test_no_confirmation_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product confirmation notification not created."""
     user_with_token = TestUserInfo.user_bceid_tester

--- a/auth-api/tests/unit/services/test_product_notifications.py
+++ b/auth-api/tests/unit/services/test_product_notifications.py
@@ -37,6 +37,7 @@ from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestOr
 from tests.utilities.factory_utils import factory_user_model_with_contact, patch_token_info
 from tests.conftest import mock_token
 
+
 @pytest.mark.parametrize('org_product_info', [
     TestOrgProductsInfo.org_products_vs
 ])

--- a/auth-api/tests/unit/services/test_product_notifications.py
+++ b/auth-api/tests/unit/services/test_product_notifications.py
@@ -18,6 +18,7 @@ Test suite to ensure that the correct product notifications are generated.
 
 from unittest.mock import patch
 
+import mock
 import pytest
 
 import auth_api.utils.account_mailer
@@ -34,12 +35,13 @@ from auth_api.utils.notifications import (
     NotificationAttachmentType, ProductAccessDescriptor, ProductCategoryDescriptor, ProductSubjectDescriptor)
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestOrgProductsInfo, TestUserInfo
 from tests.utilities.factory_utils import factory_user_model_with_contact, patch_token_info
-
+from tests.conftest import mock_token
 
 @pytest.mark.parametrize('org_product_info', [
     TestOrgProductsInfo.org_products_vs
 ])
 @patch.object(auth_api.services.products, 'publish_to_mailer')
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_default_approved_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product approved notification default is created."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -108,6 +110,7 @@ def test_default_approved_notification(mock_mailer, session, auth_mock, keycloak
     TestOrgProductsInfo.org_products_vs
 ])
 @patch.object(auth_api.services.products, 'publish_to_mailer')
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_default_rejected_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product rejected notification default is created."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -178,6 +181,7 @@ def test_default_rejected_notification(mock_mailer, session, auth_mock, keycloak
     TestOrgProductsInfo.mhr_qs_home_dealers
 ])
 @patch.object(auth_api.services.products, 'publish_to_mailer')
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_detailed_approved_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product approved notification with details is created."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -260,6 +264,7 @@ def test_detailed_approved_notification(mock_mailer, session, auth_mock, keycloa
     (TestOrgProductsInfo.mhr_qs_home_dealers, 'BCREG')
 ])
 @patch.object(auth_api.services.products, 'publish_to_mailer')
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_detailed_rejected_notification(mock_mailer, session, auth_mock, keycloak_mock,
                                         monkeypatch, org_product_info, contact_type):
     """Assert product rejected notification with details is created."""
@@ -347,6 +352,7 @@ def test_detailed_rejected_notification(mock_mailer, session, auth_mock, keycloa
     TestOrgProductsInfo.mhr_qs_home_dealers
 ])
 @patch.object(auth_api.services.products, 'publish_to_mailer')
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product notification is not created for on hold state."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -418,6 +424,7 @@ def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monke
     (TestOrgProductsInfo.mhr_qs_home_dealers, 'BCREG')
 ])
 @patch.object(auth_api.services.products, 'publish_to_mailer')
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_confirmation_notification(mock_mailer, session, auth_mock, keycloak_mock,
                                    monkeypatch, org_product_info, contact_type):
     """Assert product confirmation notification is properly created."""
@@ -468,6 +475,7 @@ def test_confirmation_notification(mock_mailer, session, auth_mock, keycloak_moc
     TestOrgProductsInfo.org_products_vs
 ])
 @patch.object(auth_api.services.products, 'publish_to_mailer')
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_no_confirmation_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product confirmation notification not created."""
     user_with_token = TestUserInfo.user_bceid_tester

--- a/auth-api/tests/unit/services/test_task.py
+++ b/auth-api/tests/unit/services/test_task.py
@@ -39,6 +39,7 @@ from tests.utilities.factory_utils import (
     patch_token_info)
 from tests.conftest import mock_token
 
+
 def test_fetch_tasks(session, auth_mock):  # pylint:disable=unused-argument
     """Assert that tasks can be fetched."""
     user = factory_user_model()
@@ -200,6 +201,7 @@ def test_hold_task(session, keycloak_mock, monkeypatch):  # pylint:disable=unuse
     assert dictionary['status'] == TaskStatus.HOLD.value
     assert dictionary['relationship_status'] == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
     assert dictionary['remarks'] == ['Test Remark']
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_task_govm(session,

--- a/auth-api/tests/unit/services/test_task.py
+++ b/auth-api/tests/unit/services/test_task.py
@@ -15,6 +15,7 @@
 
 Test suite to ensure that the Task service routines are working as expected.
 """
+import mock
 import pytest
 from datetime import datetime
 from unittest.mock import patch
@@ -36,7 +37,7 @@ from tests.utilities.factory_scenarios import (
 from tests.utilities.factory_utils import (
     factory_org_model, factory_product_model, factory_task_service, factory_user_model, factory_user_model_with_contact,
     patch_token_info)
-
+from tests.conftest import mock_token
 
 def test_fetch_tasks(session, auth_mock):  # pylint:disable=unused-argument
     """Assert that tasks can be fetched."""
@@ -110,6 +111,7 @@ def test_create_task_product(session, keycloak_mock):  # pylint:disable=unused-a
     ('has_contact', False),
     ('no_contact', True),
 ])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_update_task(session, keycloak_mock, monkeypatch, test_name, rmv_contact):  # pylint:disable=unused-argument
     """Assert that a task can be updated."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -157,6 +159,7 @@ def test_update_task(session, keycloak_mock, monkeypatch, test_name, rmv_contact
     assert user.verified
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_hold_task(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a task can be updated."""
     user_with_token = TestUserInfo.user_bceid_tester
@@ -198,7 +201,7 @@ def test_hold_task(session, keycloak_mock, monkeypatch):  # pylint:disable=unuse
     assert dictionary['relationship_status'] == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
     assert dictionary['remarks'] == ['Test Remark']
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_create_task_govm(session,
                           keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a task can be created when updating a GOVM account."""

--- a/auth-api/tests/unit/services/test_user.py
+++ b/auth-api/tests/unit/services/test_user.py
@@ -19,6 +19,7 @@ Test-Suite to ensure that the User Service is working as expected.
 import json
 from unittest.mock import patch
 
+import mock
 import pytest
 from werkzeug.exceptions import HTTPException
 
@@ -40,7 +41,7 @@ from tests.utilities.factory_scenarios import (
 from tests.utilities.factory_utils import (
     factory_contact_model, factory_entity_model, factory_membership_model, factory_org_model, factory_product_model,
     factory_user_model, get_tos_latest_version, patch_token_info)
-
+from tests.conftest import mock_token
 
 def test_as_dict(session):  # pylint: disable=unused-argument
     """Assert that a user is rendered correctly as a dictionary."""
@@ -523,6 +524,7 @@ def test_update_contact_for_user_no_contact(session, monkeypatch):  # pylint: di
     assert exception.value.code == Error.DATA_NOT_FOUND.name
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_contact_for_user(session, monkeypatch):  # pylint: disable=unused-argument
     """Assert that a contact can be deleted for a user."""
     user_with_token = TestUserInfo.user_test
@@ -665,7 +667,7 @@ def test_delete_contact_user_link(session, auth_mock, keycloak_mock, monkeypatch
     exist_contact_link = ContactLinkModel.find_by_org_id(org_id)
     assert exist_contact_link
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_user(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a user can be deleted."""
     user_with_token = TestUserInfo.user_test
@@ -690,7 +692,7 @@ def test_delete_user(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:
     for org in user_orgs:
         assert org.status_code == 'INACTIVE'
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 @pytest.mark.parametrize('environment', ['test', None])
 def test_delete_user_where_org_has_affiliations(session, auth_mock, keycloak_mock,
                                                 monkeypatch, environment):  # pylint:disable=unused-argument
@@ -725,6 +727,7 @@ def test_delete_user_where_org_has_affiliations(session, auth_mock, keycloak_moc
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_user_where_user_is_member_on_org(session, auth_mock, keycloak_mock,
                                                  monkeypatch, environment):  # pylint:disable=unused-argument
     """Assert that a user can be deleted."""
@@ -771,6 +774,7 @@ def test_delete_user_where_user_is_member_on_org(session, auth_mock, keycloak_mo
 
 
 @pytest.mark.parametrize('environment', ['test', None])
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_user_where_org_has_another_owner(session, auth_mock, keycloak_mock,
                                                  monkeypatch, environment):  # pylint:disable=unused-argument
     """Assert that a user can be deleted."""

--- a/auth-api/tests/unit/services/test_user.py
+++ b/auth-api/tests/unit/services/test_user.py
@@ -635,6 +635,7 @@ def test_user_find_by_username_missing_username(session):  # pylint: disable=unu
     assert user is None
 
 
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_contact_user_link(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a contact can not be deleted if contact link exists."""
     user_with_token = TestUserInfo.user_test

--- a/auth-api/tests/unit/services/test_user.py
+++ b/auth-api/tests/unit/services/test_user.py
@@ -43,6 +43,7 @@ from tests.utilities.factory_utils import (
     factory_user_model, get_tos_latest_version, patch_token_info)
 from tests.conftest import mock_token
 
+
 def test_as_dict(session):  # pylint: disable=unused-argument
     """Assert that a user is rendered correctly as a dictionary."""
     user_model = factory_user_model()
@@ -667,6 +668,7 @@ def test_delete_contact_user_link(session, auth_mock, keycloak_mock, monkeypatch
     exist_contact_link = ContactLinkModel.find_by_org_id(org_id)
     assert exist_contact_link
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_delete_user(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a user can be deleted."""
@@ -691,6 +693,7 @@ def test_delete_user(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:
     user_orgs = MembershipModel.find_orgs_for_user(updated_user.id)
     for org in user_orgs:
         assert org.status_code == 'INACTIVE'
+
 
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 @pytest.mark.parametrize('environment', ['test', None])

--- a/auth-api/tests/unit/services/test_user_settings.py
+++ b/auth-api/tests/unit/services/test_user_settings.py
@@ -17,13 +17,15 @@
 Test-Suite to ensure that the User Service is working as expected.
 """
 
+import mock
 from auth_api.services import Org as OrgService
 from auth_api.services import User as UserService
 from auth_api.services import UserSettings as UserSettingsService
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestUserInfo
 from tests.utilities.factory_utils import factory_user_model, patch_token_info
+from tests.conftest import mock_token
 
-
+@mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_user_settings(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a contact can not be deleted if contact link exists."""
     user_with_token = TestUserInfo.user_test

--- a/auth-api/tests/unit/services/test_user_settings.py
+++ b/auth-api/tests/unit/services/test_user_settings.py
@@ -25,6 +25,7 @@ from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestUs
 from tests.utilities.factory_utils import factory_user_model, patch_token_info
 from tests.conftest import mock_token
 
+
 @mock.patch('auth_api.services.affiliation_invitation.RestService.get_service_account_token', mock_token)
 def test_user_settings(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a contact can not be deleted if contact link exists."""


### PR DESCRIPTION
*Issue #: https://github.com/bcgov/entity/issues/16527

*Description of changes: added a service account token caching service in gcp as a POC: https://github.com/bolyachevets/token_cache

Looking for some feedback.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
