### PR TITLE
15899 - create affiliation invitation security check update to includ…

### DIFF
--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -79,7 +79,9 @@ class AffiliationInvitation:
         to_org_id = affiliation_invitation_info['toOrgId']
         business_identifier = affiliation_invitation_info['businessIdentifier']
 
-        check_auth(org_id=from_org_id, one_of_roles=(ADMIN, COORDINATOR, STAFF))
+        check_auth(org_id=from_org_id,
+                   business_identifier=business_identifier,
+                   one_of_roles=(ADMIN, COORDINATOR, STAFF))
 
         # Validate from/to organizations exists
         if not (from_org := OrgModel.find_by_org_id(from_org_id)):
@@ -159,7 +161,9 @@ class AffiliationInvitation:
 
     def update_affiliation_invitation(self, user, invitation_origin, affiliation_invitation_info: Dict):
         """Update the specified affiliation invitation with new data."""
-        check_auth(org_id=self._model.from_org_id, one_of_roles=(ADMIN, COORDINATOR, STAFF))
+        check_auth(org_id=self._model.from_org_id,
+                   business_identifier=self._model.entity.business_identifier,
+                   one_of_roles=(ADMIN, COORDINATOR, STAFF))
 
         context_path = CONFIG.AUTH_WEB_TOKEN_CONFIRM_PATH
         invitation: AffiliationInvitationModel = self._model

--- a/auth-api/tests/unit/api/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/api/test_affiliation_invitation.py
@@ -377,4 +377,9 @@ def setup_affiliation_invitation_data(client, jwt, session, keycloak_mock,
     to_org_id = dictionary_to_org['id']
     business_identifier = dictionary_entity['businessIdentifier']
 
+    client.post('/api/v1/orgs/{}/affiliations'.format(from_org_id), headers=headers,
+                data=json.dumps(
+                    {'businessIdentifier': business_identifier,
+                     'passCode': entity_info['passCode']}), content_type='application/json')
+
     return headers, from_org_id, to_org_id, business_identifier


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/15899

*Description of changes:*
- update creation of an affiliation invitation to also check against business identifier for auth
- fix tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
