### PR TITLE
17097, 17098 - qualified supplier sub project subscriptions

### DIFF
--- a/auth-api/migrations/versions/2023_07_24_b20a33cb84f2_mhr_qualified_supplier.py
+++ b/auth-api/migrations/versions/2023_07_24_b20a33cb84f2_mhr_qualified_supplier.py
@@ -1,0 +1,57 @@
+"""mhr_qualified_supplier
+
+Revision ID: b20a33cb84f2
+Revises: 13121bcf368a
+Create Date: 2023-07-24 13:12:24.781629
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b20a33cb84f2'
+down_revision = '13121bcf368a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    # add parent_code column to allow for sub product hierarchy
+    op.add_column('product_codes', sa.Column('parent_code', sa.String(length=15), nullable=True))
+
+    # add external_source_id to tasks to capture an identifier for an external resource to retrieve
+    # task related details managed by an external system - MHR Qualified Supplier for this particular change
+    op.add_column('tasks',
+                  sa.Column('external_source_id', sa.String(length=75), nullable=True))
+
+    # Add MHR sub product codes
+    op.execute("INSERT INTO public.product_codes "
+               "(code, description,\"default\", type_code, hidden, need_review, premium_only, url, keycloak_group, "
+               "parent_code) "
+               "VALUES "
+               "('MHR_QSLN', 'Qualified Supplier - Lawyers and Notaries', false, 'INTERNAL', false, true, true, "
+               "'https://www.bcregistry.ca/ppr', 'mhr_qualified_user', 'MHR')")
+    op.execute("INSERT INTO public.product_codes "
+               "(code, description,\"default\", type_code, hidden, need_review, premium_only, url, keycloak_group, "
+               "parent_code) "
+               "VALUES "
+               "('MHR_QSHM', 'Qualified Supplier - Home Manufacturers', false, 'INTERNAL', false, true, true, "
+               "'https://www.bcregistry.ca/ppr', 'mhr_manufacturer', 'MHR')")
+    op.execute("INSERT INTO public.product_codes "
+               "(code, description,\"default\", type_code, hidden, need_review, premium_only, url, keycloak_group, "
+               "parent_code) "
+               "VALUES "
+               "('MHR_QSHD', 'Qualified Supplier - Home Dealers', false, 'INTERNAL', false, true, true, "
+               "'https://www.bcregistry.ca/ppr', 'mhr_general_user', 'MHR')")
+
+    op.execute("commit")
+
+
+def downgrade():
+    op.execute("DELETE FROM product_codes WHERE code in ('MHR_QSLN')")
+    op.execute("DELETE FROM product_codes WHERE code in ('MHR_QSHM')")
+    op.execute("DELETE FROM product_codes WHERE code in ('MHR_QSHD')")
+    op.drop_column('product_codes', 'parent_code')
+    op.drop_column('tasks', 'external_source_id')

--- a/auth-api/src/auth_api/models/dataclass.py
+++ b/auth-api/src/auth_api/models/dataclass.py
@@ -81,3 +81,16 @@ class KeycloakGroupSubscription:
     product_code: str
     group_name: str
     group_action: KeycloakGroupActions
+
+
+@dataclass
+class ProductReviewTask:
+    """Used for creating product subscription review task."""
+
+    org_id: str
+    org_name: str
+    product_code: str
+    product_description: str
+    product_subscription_id: int
+    user_id: str
+    external_source_id: str = None

--- a/auth-api/src/auth_api/models/dataclass.py
+++ b/auth-api/src/auth_api/models/dataclass.py
@@ -93,4 +93,4 @@ class ProductReviewTask:
     product_description: str
     product_subscription_id: int
     user_id: str
-    external_source_id: str = None
+    external_source_id: Optional[str] = None

--- a/auth-api/src/auth_api/models/product_code.py
+++ b/auth-api/src/auth_api/models/product_code.py
@@ -47,6 +47,7 @@ class ProductCode(BaseCodeModel):  # pylint: disable=too-few-public-methods
             'keycloak_group',
             'linked_product_code',
             'need_review',
+            'parent_code',
             'premium_only',
             'type_code',
             'url'
@@ -54,6 +55,7 @@ class ProductCode(BaseCodeModel):  # pylint: disable=too-few-public-methods
     }
 
     type_code = Column(ForeignKey('product_type_codes.code'), default='INTERNAL', nullable=False)
+    parent_code = Column(String(75), nullable=True)  # Used for sub products to define a parent product code
     premium_only = Column(Boolean(), default=False, nullable=True)  # Available only for premium accounts
     need_review = Column(Boolean(), default=False, nullable=True)  # Need a review from staff for activating product
     hidden = Column(Boolean(), default=False, nullable=True)  # Flag to hide from the UI

--- a/auth-api/src/auth_api/models/task.py
+++ b/auth-api/src/auth_api/models/task.py
@@ -33,6 +33,7 @@ class Task(BaseModel):
     id = Column(Integer, index=True, primary_key=True)
     name = Column(String(250), nullable=False)  # Stores name of the relationship item. For eg, an org name
     date_submitted = Column(DateTime)  # Instance when task is created
+    external_source_id = Column(String(75), nullable=True)  # Optional external system source identifier
     relationship_type = Column(String(50), nullable=False)  # That is to be acted up on. For eg, an org
     relationship_id = Column(Integer, index=True, nullable=False)
     relationship_status = Column(String(100), nullable=True)  # Status of the related object. e.g, PENDING_STAFF_REVIEW

--- a/auth-api/src/auth_api/resources/task.py
+++ b/auth-api/src/auth_api/resources/task.py
@@ -93,7 +93,7 @@ class TaskUpdate(Resource):
                 task_dict = task.update_task(task_info=request_json,
                                              origin_url=origin).as_dict()
                 # ProductService uses TaskService already. So, we need to avoid circular import.
-                if request_json.get('relationshipStatus') == TaskRelationshipType.PRODUCT.value:
+                if task_dict['relationship_type'] == TaskRelationshipType.PRODUCT.value:
                     ProductService.update_org_product_keycloak_groups(task_dict['account_id'])
                 response = task_dict
                 status = http_status.HTTP_200_OK

--- a/auth-api/src/auth_api/schemas/product_code.py
+++ b/auth-api/src/auth_api/schemas/product_code.py
@@ -29,5 +29,6 @@ class ProductCodeSchema(ma.ModelSchema):  # pylint: disable=too-many-ancestors, 
         exclude = ['default', 'linked_product_code']
 
     type_code = fields.String(data_key='type')
+    parent_code = fields.String(data_key='parentCode')
     premium_only = fields.Boolean(data_key='premiumOnly')
     need_review = fields.Boolean(data_key='needReview')

--- a/auth-api/src/auth_api/schemas/schemas/org_product_subscription.json
+++ b/auth-api/src/auth_api/schemas/schemas/org_product_subscription.json
@@ -16,6 +16,14 @@
             "PPR"
           ],
           "pattern": "^(.*)$"
+        },
+        "externalSourceId": {
+          "type": "string",
+          "title": "External source identifier",
+          "default": "",
+          "examples": [
+            "10"
+          ]
         }
       },
       "required": [

--- a/auth-api/src/auth_api/schemas/schemas/product.json
+++ b/auth-api/src/auth_api/schemas/schemas/product.json
@@ -10,6 +10,12 @@
             "description": "Personal Property Registry",
             "url": "https://dev.bcregistry.ca/business/ppr",
             "type": "INTERNAL"
+        },
+        {
+            "description": "Qualified Supplier - Lawyers and Notaries",
+            "url": "https://www.bcregistry.ca/ppr",
+            "type": "INTERNAL",
+            "parentCode": "MHR"
         }
     ],
     "required": [
@@ -79,6 +85,15 @@
             "default": "",
             "examples": [
                 "INTERNAL"
+            ]
+        },
+        "parentCode": {
+            "$id": "#/properties/parentCode",
+            "type": ["string", "null"],
+            "title": "Parent Product Code",
+            "default": "",
+            "examples": [
+                "MHR"
             ]
         }
     },

--- a/auth-api/src/auth_api/schemas/schemas/task_request.json
+++ b/auth-api/src/auth_api/schemas/schemas/task_request.json
@@ -105,6 +105,14 @@
           "Affidavit is Missing Seal"
         ]
       ]
+    },
+    "externalSourceId": {
+      "type": "string",
+      "title": "External source identifier",
+      "default": "",
+      "examples": [
+        "10"
+      ]
     }
   }
 }

--- a/auth-api/src/auth_api/schemas/schemas/task_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/task_response.json
@@ -13,7 +13,8 @@
             "relationship_id": 12,
             "date_submitted": "2020-11-23T15:14:20.712096+00:00",
             "due_date": "2020-11-03T20:50:39.366030+00:00",
-            "type": "PENDING_STAFF_REVIEW"
+            "type": "PENDING_STAFF_REVIEW",
+            "externalSourceId": "5"
         },
         {
             "id": 125,
@@ -22,7 +23,8 @@
             "relationship_id": 12,
             "date_submitted": "2020-11-23T15:14:20.712096+00:00",
             "due_date": "2020-11-03T20:50:39.366030+00:00",
-            "type": "PENDING_STAFF_REVIEW"
+            "type": "PENDING_STAFF_REVIEW",
+            "externalSourceId": "10"
         }
     ],
     "properties": {
@@ -98,6 +100,14 @@
             "default": "",
             "examples": [
                 "OPEN"
+            ]
+        },
+        "externalSourceId": {
+            "type": "string",
+            "title": "External source identifier",
+            "default": "",
+            "examples": [
+                "10"
             ]
         }
     },

--- a/auth-api/src/auth_api/services/products.py
+++ b/auth-api/src/auth_api/services/products.py
@@ -33,8 +33,8 @@ from auth_api.schemas import ProductCodeSchema
 from auth_api.services.user import User as UserService
 from auth_api.utils.constants import BCOL_PROFILE_PRODUCT_MAP
 from auth_api.utils.enums import (
-    AccessType, ActivityAction, KeycloakGroupActions, OrgType, ProductSubscriptionStatus, Status, TaskAction,
-    TaskRelationshipStatus, TaskRelationshipType, TaskStatus)
+    AccessType, ActivityAction, KeycloakGroupActions, OrgType, ProductCode, ProductSubscriptionStatus, Status,
+    TaskAction, TaskRelationshipStatus, TaskRelationshipType, TaskStatus)
 from auth_api.utils.user_context import UserContext, user_context
 
 from ..utils.account_mailer import publish_to_mailer
@@ -43,6 +43,9 @@ from ..utils.roles import CLIENT_ADMIN_ROLES, CLIENT_AUTH_ROLES, PREMIUM_ORG_TYP
 from .activity_log_publisher import ActivityLogPublisher
 from .authorization import check_auth
 from .task import Task as TaskService
+
+QUALIFIED_SUPPLIER_PRODUCT_CODES = [ProductCode.MHR_QSLN.value, ProductCode.MHR_QSHD.value,
+                                    ProductCode.MHR_QSHM.value]
 
 
 class Product:
@@ -98,30 +101,32 @@ class Product:
                     continue
 
                 subscription_status = Product.find_subscription_status(org, product_model)
-                product_subscription = ProductSubscriptionModel(org_id=org_id,
-                                                                product_code=product_code,
-                                                                status_code=subscription_status
-                                                                ).flush()
-                if subscription_status == ProductSubscriptionStatus.ACTIVE.value:
-                    ActivityLogPublisher.publish_activity(Activity(org_id, ActivityAction.ADD_PRODUCT_AND_SERVICE.value,
-                                                                   name=product_model.description))
+                product_subscription = Product._subscribe_and_publish_activity(org_id,
+                                                                               product_code,
+                                                                               subscription_status,
+                                                                               product_model.description)
 
                 # If there is a linked product, add subscription to that too.
                 # This is to handle cases where Names and Business Registry is combined together.
                 if product_model.linked_product_code:
-                    ProductSubscriptionModel(org_id=org_id,
-                                             product_code=product_model.linked_product_code,
-                                             status_code=subscription_status
-                                             ).flush()
-                    if subscription_status == ProductSubscriptionStatus.ACTIVE.value:
-                        ActivityLogPublisher.publish_activity(Activity(org_id,
-                                                                       ActivityAction.ADD_PRODUCT_AND_SERVICE.value,
-                                                                       name=product_model.description))
+                    Product._subscribe_and_publish_activity(org_id,
+                                                            product_model.linked_product_code,
+                                                            subscription_status,
+                                                            product_model.description)
+
+                # If there is a parent product, add subscription to that to
+                # This is to satisfy any preceding subscriptions required
+                if product_model.parent_code:
+                    Product._subscribe_and_publish_activity(org_id,
+                                                            product_model.parent_code,
+                                                            subscription_status,
+                                                            product_model.description)
 
                 # create a staff review task for this product subscription if pending status
                 if subscription_status == ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value:
                     user = UserModel.find_by_jwt_token()
-                    Product._create_review_task(org, product_model, product_subscription, user)
+                    external_source_id = subscription.get('externalSourceId')
+                    Product._create_review_task(org, product_model, product_subscription, user, external_source_id)
 
             else:
                 raise BusinessException(Error.DATA_NOT_FOUND, None)
@@ -132,18 +137,33 @@ class Product:
         return Product.get_all_product_subscription(org_id=org_id, skip_auth=True)
 
     @staticmethod
-    def _create_review_task(org, product_model, product_subscription, user):
+    def _subscribe_and_publish_activity(org_id, product_code, status_code, product_model_description):
+        subscription = ProductSubscriptionModel(org_id=org_id, product_code=product_code, status_code=status_code)\
+            .flush()
+        if status_code == ProductSubscriptionStatus.ACTIVE.value:
+            ActivityLogPublisher.publish_activity(Activity(org_id,
+                                                           ActivityAction.ADD_PRODUCT_AND_SERVICE.value,
+                                                           name=product_model_description))
+        return subscription
+
+    @staticmethod
+    def _create_review_task(org, product_model, product_subscription, user, external_source_id=None):
         task_type = product_model.description
+        action_type = TaskAction.QUALIFIED_SUPPLIER_REVIEW.value \
+            if product_subscription.product_code in QUALIFIED_SUPPLIER_PRODUCT_CODES \
+            else TaskAction.PRODUCT_REVIEW.value
+
         task_info = {'name': org.name,
                      'relationshipId': product_subscription.id,
                      'relatedTo': user.id,
                      'dateSubmitted': datetime.today(),
                      'relationshipType': TaskRelationshipType.PRODUCT.value,
                      'type': task_type,
-                     'action': TaskAction.PRODUCT_REVIEW.value,
+                     'action': action_type,
                      'status': TaskStatus.OPEN.value,
                      'accountId': org.id,
-                     'relationship_status': TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
+                     'relationship_status': TaskRelationshipStatus.PENDING_STAFF_REVIEW.value,
+                     'externalSourceId': external_source_id
                      }
         TaskService.create_task(task_info, False)
 
@@ -221,6 +241,7 @@ class Product:
         current_app.logger.debug('<update_task_product ')
         # Approve/Reject Product subscription
         product_subscription: ProductSubscriptionModel = ProductSubscriptionModel.find_by_id(product_subscription_id)
+
         if is_approved:
             product_subscription.status_code = ProductSubscriptionStatus.ACTIVE.value
         else:
@@ -241,7 +262,55 @@ class Product:
         if is_approved:
             ActivityLogPublisher.publish_activity(Activity(org_id, ActivityAction.ADD_PRODUCT_AND_SERVICE.value,
                                                            name=product_model.description))
+
+        if product_model.parent_code:
+            Product.update_parent_subscription(product_model.parent_code, is_approved, org_id, is_new_transaction)
+
         current_app.logger.debug('>update_task_product ')
+
+    @staticmethod
+    def update_parent_subscription(parent_product_code: int, is_approved: bool, org_id: int,
+                                   is_new_transaction: bool = True):
+        """Update Parent Product Subscription."""
+        current_app.logger.debug('<update_task_parent_product ')
+
+        product_subscription: ProductSubscriptionModel = ProductSubscriptionModel.find_by_org_id_product_code(
+            org_id=org_id,
+            product_code=parent_product_code
+        )
+
+        # There is no parent product subscription
+        if len(product_subscription) == 0:
+            return
+
+        status = product_subscription[0].status_code
+
+        # Subscription is already Active
+        if status == ProductSubscriptionStatus.ACTIVE.value:
+            return
+
+        if is_approved:
+            product_subscription[0].status_code = ProductSubscriptionStatus.ACTIVE.value
+        else:
+            product_subscription[0].status_code = ProductSubscriptionStatus.REJECTED.value
+
+        product_subscription[0].flush()
+        if is_new_transaction:  # Commit the transaction if it's a new transaction
+            db.session.commit()
+
+        product_model: ProductCodeModel = ProductCodeModel.find_by_code(parent_product_code)
+        # Find admin email addresses
+        admin_emails = UserService.get_admin_emails_for_org(org_id)
+        if admin_emails != '':
+            Product.send_approved_product_subscription_notification(admin_emails, product_model.description,
+                                                                    status)
+        else:
+            # continue but log error
+            current_app.logger.error('No admin email record for org id %s', org_id)
+        if is_approved:
+            ActivityLogPublisher.publish_activity(Activity(org_id, ActivityAction.ADD_PRODUCT_AND_SERVICE.value,
+                                                           name=product_model.description))
+        current_app.logger.debug('>update_task_parent_product ')
 
     @staticmethod
     def send_approved_product_subscription_notification(receipt_admin_emails, product_name,

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -245,6 +245,9 @@ class ProductCode(Enum):
     DIR_SEARCH = 'DIR_SEARCH'
     NAMES_REQUEST = 'NRO'
     MHR = 'MHR'
+    MHR_QSLN = 'MHR_QSLN'  # Qualified Supplier - Lawyers and Notaries
+    MHR_QSHM = 'MHR_QSHM'  # Qualified Supplier - Home Manufacturers
+    MHR_QSHD = 'MHR_QSHD'  # Qualified Supplier - Home Dealers
 
 
 class TaskRelationshipType(Enum):
@@ -293,6 +296,7 @@ class TaskAction(Enum):
     AFFIDAVIT_REVIEW = 'AFFIDAVIT_REVIEW'
     ACCOUNT_REVIEW = 'ACCOUNT_REVIEW'
     PRODUCT_REVIEW = 'PRODUCT_REVIEW'
+    QUALIFIED_SUPPLIER_REVIEW = 'QUALIFIED_SUPPLIER_REVIEW'
 
 
 class ActivityAction(Enum):

--- a/auth-api/tests/docker/setup/demo-realm.json
+++ b/auth-api/tests/docker/setup/demo-realm.json
@@ -398,6 +398,46 @@
       ],
       "clientRoles": {},
       "subGroups": []
+    },
+    {
+      "name": "mhr_search_user",
+      "path": "/mhr_search_user",
+      "attributes": {},
+      "realmRoles": [
+        "edit"
+      ],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "name": "mhr_qualified_user",
+      "path": "/mhr_qualified_user",
+      "attributes": {},
+      "realmRoles": [
+        "edit"
+      ],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "name": "mhr_manufacturer",
+      "path": "/mhr_manufacturer",
+      "attributes": {},
+      "realmRoles": [
+        "edit"
+      ],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "name": "mhr_general_user",
+      "path": "/mhr_general_user",
+      "attributes": {},
+      "realmRoles": [
+        "edit"
+      ],
+      "clientRoles": {},
+      "subGroups": []
     }
   ],
   "defaultRoles": [

--- a/auth-api/tests/unit/api/test_product.py
+++ b/auth-api/tests/unit/api/test_product.py
@@ -28,5 +28,11 @@ def test_get_all_products(client, session):  # pylint:disable=unused-argument
 
     assert schema_utils.validate(item_list, 'products')[0]
     # assert the structure is correct by checking for name, description properties in each element
+    mhr_sub_prods = ['MHR_QSLN', 'MHR_QSHM', 'MHR_QSHD']
     for item in item_list:
         assert item['code'] and item['description']
+        if item['code'] in mhr_sub_prods:
+            assert item['parentCode'] == 'MHR'
+            assert item['keycloak_group']
+        else:
+            assert not item.get('parentCode')

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -21,13 +21,14 @@ import pytest
 from requests import Response
 from sqlalchemy import event
 
-from auth_api.models.dataclass import Activity
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
 from auth_api.models import ContactLink as ContactLinkModel
 from auth_api.models import Org as OrgModel
-from auth_api.models.org import receive_before_insert, receive_before_update
+from auth_api.models import ProductSubscription as ProductSubscriptionModel
 from auth_api.models import Task as TaskModel
+from auth_api.models.dataclass import Activity
+from auth_api.models.org import receive_before_insert, receive_before_update
 from auth_api.services import ActivityLogPublisher
 from auth_api.services import Affidavit as AffidavitService
 from auth_api.services import Affiliation as AffiliationService
@@ -42,8 +43,8 @@ from auth_api.services.keycloak import KeycloakService
 from auth_api.services.rest_service import RestService
 from auth_api.utils.constants import GROUP_ACCOUNT_HOLDERS
 from auth_api.utils.enums import (
-    AccessType, ActivityAction, LoginSource, OrgStatus, OrgType, PatchActions, PaymentMethod, SuspensionReasonCode,
-    TaskAction, TaskRelationshipStatus, TaskStatus)
+    AccessType, ActivityAction, LoginSource, OrgStatus, OrgType, PatchActions, PaymentMethod, ProductSubscriptionStatus,
+    SuspensionReasonCode, TaskAction, TaskRelationshipStatus, TaskRelationshipType, TaskStatus)
 from tests.utilities.factory_scenarios import (
     KeycloakScenario, TestAffidavit, TestBCOLInfo, TestContactInfo, TestEntityInfo, TestJwtClaims, TestOrgInfo,
     TestOrgProductsInfo, TestOrgTypeInfo, TestPaymentMethodInfo, TestUserInfo)
@@ -1131,3 +1132,84 @@ def test_patch_org_access_type(session, monkeypatch):  # pylint:disable=unused-a
     patch_info['accessType'] = AccessType.GOVN.value
     updated_org = org.patch_org(PatchActions.UPDATE_ACCESS_TYPE.value, patch_info)
     assert updated_org['access_type'] == AccessType.GOVN.value
+
+
+@pytest.mark.asyncio
+def test_create_product_single_subscription_qs(session, monkeypatch):
+    """Assert that qualified supplier sub product subscriptions can be created."""
+    # Create a user in keycloak
+    keycloak_service = KeycloakService()
+    request = KeycloakScenario.create_user_by_user_info(TestJwtClaims.public_bceid_user)
+    keycloak_service.add_user(request, return_if_exists=True)
+    kc_user = keycloak_service.get_user_by_username(request.user_name)
+    user = factory_user_model(TestUserInfo.get_bceid_user_with_kc_guid(kc_guid=kc_user.id))
+    patch_token_info({'sub': user.keycloak_guid, 'idp_userid': user.idp_userid}, monkeypatch)
+
+    org = OrgService.create_org(TestOrgInfo.org_premium, user_id=user.id)
+    assert org
+    dictionary = org.as_dict()
+    assert dictionary['name'] == TestOrgInfo.org_premium['name']
+
+    product_code = TestOrgProductsInfo.mhr_qs_lawyer_and_notaries['subscriptions'][0]['productCode']
+    external_source_id = TestOrgProductsInfo.mhr_qs_lawyer_and_notaries['subscriptions'][0]['externalSourceId']
+
+    ProductService.create_product_subscription(org_id=dictionary['id'],
+                                               subscription_data=TestOrgProductsInfo.mhr_qs_lawyer_and_notaries,
+                                               skip_auth=True)
+
+    org_subscriptions = ProductSubscriptionModel.find_by_org_ids(org_ids=[dictionary['id']])
+    org_prod_sub = next(prod for prod in org_subscriptions
+                        if prod.product_code == product_code)
+
+    token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.STAFF.value)
+    patch_token_info(token_info, monkeypatch)
+    all_subs = ProductService.get_all_product_subscription(org_id=dictionary['id'])
+
+    prod_sub = next(sub for sub in all_subs if sub.get('code') == product_code)
+    parent_prod_sub = next(sub for sub in all_subs if sub.get('code') == 'MHR')
+
+    # MHR Qualified Supplier product and parent product should be in pending staff review
+    assert prod_sub
+    assert prod_sub['code'] == product_code
+    assert prod_sub['needReview']
+    assert prod_sub['parentCode'] == 'MHR'
+    assert prod_sub['subscriptionStatus'] == ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value
+    assert prod_sub['keycloak_group'] == 'mhr_qualified_user'
+
+    # Parent Product MHR should also be pending staff review
+    assert parent_prod_sub
+    assert parent_prod_sub['code'] == 'MHR'
+    assert not parent_prod_sub['needReview']
+    assert not parent_prod_sub.get('parentCode')
+    assert parent_prod_sub['subscriptionStatus'] == ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value
+    assert parent_prod_sub['keycloak_group'] == 'mhr_search_user'
+
+    # Staff review task should have been created
+    task = TaskModel.find_by_task_relationship_id(
+        task_relationship_type=TaskRelationshipType.PRODUCT.value, relationship_id=org_prod_sub.id)
+
+    assert task
+    assert task.account_id == dictionary['id']
+    assert task.external_source_id == external_source_id
+    assert task.relationship_type == TaskRelationshipType.PRODUCT.value
+    assert task.relationship_status == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
+    assert task.relationship_id == org_prod_sub.id
+    assert task.action == TaskAction.QUALIFIED_SUPPLIER_REVIEW.value
+
+    task_info = {
+        'relationshipStatus': TaskRelationshipStatus.ACTIVE.value
+    }
+
+    # Approve task and update org keycloak groups
+    TaskService.update_task(TaskService(task), task_info=task_info)
+    ProductService.update_org_product_keycloak_groups(dictionary['id'])
+
+    patch_token_info({'sub': user.keycloak_guid, 'idp_userid': user.idp_userid}, monkeypatch)
+    user_groups = keycloak_service.get_user_groups(user_id=kc_user.id)
+    groups = []
+    for group in user_groups:
+        groups.append(group.get('name'))
+
+    # Confirm account has the expected groups
+    assert 'mhr_search_user' in groups
+    assert 'mhr_qualified_user' in groups

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -680,6 +680,9 @@ class TestOrgProductsInfo(dict, Enum):
                                        {'productCode': 'PPR'}]}
     org_products_vs = {'subscriptions': [{'productCode': 'VS'}]}
     org_products_business = {'subscriptions': [{'productCode': 'BUSINESS'}]}
+    mhr_qs_lawyer_and_notaries = {'subscriptions': [{'productCode': 'MHR_QSLN', 'externalSourceId': 'ABC123'}]}
+    mhr_qs_home_manufacturers = {'subscriptions': [{'productCode': 'MHR_QSHM', 'externalSourceId': 'ABC123'}]}
+    mhr_qs_home_dealers = {'subscriptions': [{'productCode': 'MHR_QSHD', 'externalSourceId': 'ABC123'}]}
 
 
 class TestEntityInfo(dict, Enum):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17097
https://github.com/bcgov/entity/issues/17098

*Description of changes:*
- Add MHR qualified supplier sub product codes for (Lawyers and Notaries, Home Manufacturers, Home Dealers)
- Extend Product Subscriptions POST to allow an external_source_id to be persisted to a created staff review task
- Update task to include the external source identifier
- Add parent product code to product codes to track hierarchy
- When activating a sub product subscription, the parent product is also evaluated and activated as needed
- update keycloak demo realm to include new groups for unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
