### PR TITLE
hide new sub products (has parentCode)

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.2.7",
+      "version": "2.2.8",
       "dependencies": {
         "@bcrs-shared-components/bread-crumb": "^1.0.2",
         "@bcrs-shared-components/corp-type-module": "1.0.12",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/account-settings/product/ProductPackage.vue
+++ b/auth-web/src/components/auth/account-settings/product/ProductPackage.vue
@@ -20,7 +20,7 @@
     <template v-else>
       <template v-if="productList && productList.length > 0">
         <div v-for="product in productList" :key="product.code">
-          <Product
+          <Product v-if="!product.parentCode"
             :productDetails="product"
             @set-selected-product="setSelectedProduct"
             :userName="currentUser.fullName"

--- a/auth-web/src/models/Organization.ts
+++ b/auth-web/src/models/Organization.ts
@@ -246,6 +246,7 @@ export interface OrgProduct {
   hidden?:boolean
   premiumOnly?:boolean
   needReview?:boolean
+  parentCode?: string;
 }
 
 export interface OrgProductsRequestBody {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17098

*Description of changes:*
- As part of implementing #17098 sub products now appear in the account products and services list. 
- Update to not display any products with a parentCode (MHR - Qualified supplier will have this on their own forms in the near future)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
