### PR TITLE
15769 - Affiliation Invitations - updates and fixes

### DIFF
--- a/auth-api/migrations/versions/2023_08_08_628b52a95bad_affiliation_invitations_to_org_nullable.py
+++ b/auth-api/migrations/versions/2023_08_08_628b52a95bad_affiliation_invitations_to_org_nullable.py
@@ -1,0 +1,30 @@
+"""affiliation_invitations_to_org_nullable
+
+Revision ID: 628b52a95bad
+Revises: 27d53abf3f48
+Create Date: 2023-08-08 11:12:40.149008
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '628b52a95bad'
+down_revision = '18823fc88aac'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('affiliation_invitations', 'to_org_id',
+                    nullable=True)
+    op.alter_column('affiliation_invitations', 'recipient_email',
+                    nullable=True)
+
+
+def downgrade():
+    op.alter_column('affiliation_invitations', 'to_org_id',
+                    nullable=False)
+    op.alter_column('affiliation_invitations', 'recipient_email',
+                    nullable=False)

--- a/auth-api/src/auth_api/exceptions/errors.py
+++ b/auth-api/src/auth_api/exceptions/errors.py
@@ -34,6 +34,7 @@ class Error(Enum):
     ACTIONED_INVITATION = 'The invitation has already been accepted.', http_status.HTTP_400_BAD_REQUEST
     ACTIONED_AFFILIATION_INVITATION = 'The affiliation invitation has already been accepted.', \
                                       http_status.HTTP_400_BAD_REQUEST
+    INVALID_BUSINESS_EMAIL = 'Business contact email not valid.', http_status.HTTP_400_BAD_REQUEST
     EXPIRED_INVITATION = 'The invitation has expired.', http_status.HTTP_400_BAD_REQUEST
     EXPIRED_AFFILIATION_INVITATION = 'The affiliation invitation has expired.', http_status.HTTP_400_BAD_REQUEST
     INVALID_AFFILIATION_INVITATION_STATE = 'The affiliation invitation is in an invalid state for this action.', \

--- a/auth-api/src/auth_api/models/affiliation_invitation.py
+++ b/auth-api/src/auth_api/models/affiliation_invitation.py
@@ -37,12 +37,12 @@ class AffiliationInvitation(BaseModel):  # pylint: disable=too-many-instance-att
 
     id = Column(Integer, primary_key=True)
     from_org_id = Column(ForeignKey('orgs.id'), nullable=False, index=True)
-    to_org_id = Column(ForeignKey('orgs.id'), nullable=False, index=True)
+    to_org_id = Column(ForeignKey('orgs.id'), nullable=True, index=True)
     entity_id = Column(ForeignKey('entities.id'), nullable=False, index=True)
     affiliation_id = Column(ForeignKey('affiliations.id'), nullable=True, index=True)
     sender_id = Column(ForeignKey('users.id'), nullable=False)
     approver_id = Column(ForeignKey('users.id'), nullable=True)
-    recipient_email = Column(String(100), nullable=False)
+    recipient_email = Column(String(100), nullable=True)
     sent_date = Column(DateTime, nullable=False)
     accepted_date = Column(DateTime, nullable=True)
     token = Column(String(100), nullable=True)  # stores the one time affiliation invitation token
@@ -92,7 +92,7 @@ class AffiliationInvitation(BaseModel):  # pylint: disable=too-many-instance-att
         affiliation_invitation.from_org_id = invitation_info['fromOrgId']
         affiliation_invitation.to_org_id = invitation_info['toOrgId']
         affiliation_invitation.entity_id = invitation_info['entityId']
-        affiliation_invitation.recipient_email = invitation_info['recipientEmail']
+        affiliation_invitation.recipient_email = invitation_info.get('recipientEmail')
         affiliation_invitation.sent_date = datetime.now()
         affiliation_invitation.type = invitation_info.get('type')
         affiliation_invitation.invitation_status = InvitationStatus.get_default_status()

--- a/auth-api/src/auth_api/resources/affiliation_invitation.py
+++ b/auth-api/src/auth_api/resources/affiliation_invitation.py
@@ -94,7 +94,8 @@ class AffiliationInvitations(Resource):
         try:
             user = UserService.find_by_jwt_token()
             response, status = AffiliationInvitationService.create_affiliation_invitation(request_json,
-                                                                                          user, origin).as_dict(), \
+                                                                                          user, origin)\
+                .as_dict(mask_email=True), \
                 http_status.HTTP_201_CREATED
         except BusinessException as exception:
             response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
@@ -117,7 +118,8 @@ class AffiliationInvitation(Resource):
             response, status = {'message': 'The requested affiliation invitation could not be found.'}, \
                 http_status.HTTP_404_NOT_FOUND
         else:
-            response, status = affiliation_invitation.as_dict(), http_status.HTTP_200_OK
+            dictionary = affiliation_invitation.as_dict(mask_email=True)
+            response, status = dictionary, http_status.HTTP_200_OK
         return response, status
 
     @staticmethod
@@ -137,7 +139,7 @@ class AffiliationInvitation(Resource):
             else:
                 user = UserService.find_by_jwt_token()
                 response, status = affiliation_invitation\
-                    .update_affiliation_invitation(user, origin, request_json).as_dict(),\
+                    .update_affiliation_invitation(user, origin, request_json).as_dict(mask_email=True),\
                     http_status.HTTP_200_OK
         except BusinessException as exception:
             response, status = {'code': exception.code, 'message': exception.message}, exception.status_code
@@ -181,7 +183,7 @@ class InvitationAction(Resource):
                     .validate_token(affiliation_invitation_token, int(affiliation_invitation_id)).as_dict().get('id')
 
                 response, status = AffiliationInvitationService\
-                    .accept_affiliation_invitation(affiliation_invitation_id, user, origin).as_dict(), \
+                    .accept_affiliation_invitation(affiliation_invitation_id, user, origin).as_dict(mask_email=True), \
                     http_status.HTTP_200_OK
 
         except BusinessException as exception:
@@ -225,11 +227,12 @@ class InvitationActionAuthorize(Resource):
                 response, status = AffiliationInvitationService \
                     .accept_affiliation_invitation(affiliation_invitation_id=affiliation_invitation_id,
                                                    user=user,
-                                                   origin=origin).as_dict(), \
+                                                   origin=origin).as_dict(mask_email=True), \
                     http_status.HTTP_200_OK
             elif authorize_action == 'refuse':
                 response, status = AffiliationInvitationService \
-                    .refuse_affiliation_invitation(invitation_id=affiliation_invitation_id, user=user).as_dict(), \
+                    .refuse_affiliation_invitation(invitation_id=affiliation_invitation_id, user=user)\
+                    .as_dict(mask_email=True), \
                     http_status.HTTP_200_OK
             else:
                 err = {'code': 400, 'message': f'{authorize_action} is not supported on this endpoint'}

--- a/auth-api/src/auth_api/schemas/affiliation_invitation.py
+++ b/auth-api/src/auth_api/schemas/affiliation_invitation.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 """Manager for affiliation invitation schema and export."""
 
-from marshmallow import fields
+from marshmallow import fields, post_dump
 
 from auth_api.models import AffiliationInvitation as AffiliationInvitationModel
 
 from .base_schema import BaseSchema
+from ..utils.util import mask_email
 
 
 class AffiliationInvitationSchema(BaseSchema):  # pylint: disable=too-many-ancestors, too-few-public-methods
@@ -32,5 +33,16 @@ class AffiliationInvitationSchema(BaseSchema):  # pylint: disable=too-many-ances
             'accepted_date', 'status', 'token', 'type', 'affiliation_id')
 
     from_org = fields.Nested('OrgSchema', only=('id', 'name', 'org_type'))
-    to_org = fields.Nested('OrgSchema', only=('id', 'name', 'org_type'))
+    to_org = fields.Nested('OrgSchema', only=('id', 'name', 'org_type'), allow_none=True, required=False)
     business_identifier = fields.String(attribute='entity.business_identifier', data_key='business_identifier')
+
+
+# pylint: disable=too-many-ancestors, too-few-public-methods
+class AffiliationInvitationSchemaPublic(AffiliationInvitationSchema):
+    """This is the public schema for the Affiliation Invitation model that masks the email."""
+
+    @post_dump(pass_many=False)
+    def _mask_recipient_email_field(self, data, many):  # pylint: disable=unused-argument
+        """Mask recipient email field."""
+        data['recipient_email'] = mask_email(data.get('recipient_email'))
+        return data

--- a/auth-api/src/auth_api/schemas/contact.py
+++ b/auth-api/src/auth_api/schemas/contact.py
@@ -18,6 +18,7 @@ from marshmallow import fields, post_dump
 from auth_api.models import Contact as ContactModel
 
 from .base_schema import BaseSchema
+from ..utils.util import mask_email
 
 
 class ContactSchema(BaseSchema):  # pylint: disable=too-many-ancestors, too-few-public-methods
@@ -48,11 +49,5 @@ class ContactSchemaPublic(BaseSchema):
     @post_dump(pass_many=False)
     def _mask_email_field(self, data, many):  # pylint: disable=unused-argument
         """Mask email field."""
-        email = data.get('email')
-        parts = email.split('@')
-        if len(parts) == 2:
-            username, domain = parts
-            masked_username = username[:2] + '*' * (len(username) - 2)
-            masked_domain = domain[:2] + '*' * (len(domain) - 2)
-            data['email'] = masked_username + '@' + masked_domain
+        data['email'] = mask_email(data.get('email'))
         return data

--- a/auth-api/src/auth_api/schemas/schemas/affiliation_invitation.json
+++ b/auth-api/src/auth_api/schemas/schemas/affiliation_invitation.json
@@ -9,7 +9,7 @@
       "type": "number"
     },
     "toOrgId": {
-      "type": "number"
+      "type": ["number", "null"]
     },
     "businessIdentifier": {
       "$id": "#/properties/businessIdentifier",
@@ -20,10 +20,6 @@
         "CP1234567"
       ],
       "pattern": "^(.*)$"
-    },
-    "recipientEmail": {
-      "type": "string",
-      "title": "The recipient email."
     },
     "type": {
       "type": "string",
@@ -48,9 +44,7 @@
     }
   },
   "required": [
-    "recipientEmail",
     "fromOrgId",
-    "toOrgId",
     "businessIdentifier"
   ]
 }

--- a/auth-api/src/auth_api/schemas/schemas/affiliation_invitation_response.json
+++ b/auth-api/src/auth_api/schemas/schemas/affiliation_invitation_response.json
@@ -31,9 +31,7 @@
     "required": [
         "id",
         "fromOrg",
-        "toOrg",
         "businessIdentifier",
-        "recipientEmail",
         "sentDate",
         "status"
     ],
@@ -79,12 +77,7 @@
         "toOrg": {
             "$id": "#/properties/toOrg",
             "type": "object",
-            "title": "To Org ",
-            "required":[
-                "id",
-                "name",
-                "orgType"
-            ]
+            "title": "To Org "
         },
         "businessIdentifier": {
             "$id": "#/properties/businessIdentifier",

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -398,7 +398,6 @@ class AffiliationInvitation:
             if is_authorized is not None:
                 notification_type = 'affiliationInvitationRequestAuthorization'
                 data['isAuthorized'] = is_authorized
-                data['isAuthorized'] = is_authorized
             else:
                 notification_type = 'affiliationInvitationRequest'
                 data['additionalMessage'] = affiliation_invitation.additional_message

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -40,6 +40,7 @@ from auth_api.services.user import User as UserService
 from auth_api.utils.enums import AccessType, AffiliationInvitationType, InvitationStatus, LoginSource, Status
 from auth_api.utils.roles import ADMIN, COORDINATOR, STAFF
 from auth_api.utils.user_context import UserContext, user_context
+from ..schemas.affiliation_invitation import AffiliationInvitationSchemaPublic
 
 from ..utils.account_mailer import publish_to_mailer
 from ..utils.passcode import validate_passcode
@@ -64,21 +65,23 @@ class AffiliationInvitation:
         self._model = model
 
     @ServiceTracing.disable_tracing
-    def as_dict(self):
+    def as_dict(self, mask_email=False):
         """Return the Affiliation Invitation model as a dictionary."""
-        affiliation_invitation_schema = AffiliationInvitationSchema()
+        affiliation_invitation_schema = self.get_affiliation_invitation_schema(mask_email)
         obj = affiliation_invitation_schema.dump(self._model, many=False)
         return obj
 
     @classmethod
-    def affiliation_invitation_to_dict(cls, model: AffiliationInvitationModel) -> Dict:
-        """Return the Affiliation Invitation model as a dictionary."""
-        return AffiliationInvitationSchema().dump(model, many=False)
+    def get_affiliation_invitation_schema(cls, mask_email: bool):
+        """Return the appropriate affiliation invitation schema."""
+        return AffiliationInvitationSchemaPublic() if mask_email else AffiliationInvitationSchema()
 
     @classmethod
-    def affiliation_invitations_to_dict_list(cls, models: List[AffiliationInvitationModel]) -> List[Dict]:
+    def affiliation_invitations_to_dict_list(cls, models: List[AffiliationInvitationModel], mask_email=True) \
+            -> List[Dict]:
         """Return list of AffiliationInvitationModels converted to list dicts."""
-        return [AffiliationInvitationSchema().dump(model) for model in models]
+        schema = cls.get_affiliation_invitation_schema(mask_email)
+        return [schema.dump(model) for model in models]
 
     @classmethod
     def enrich_affiliation_invitations_dict_list_with_business_data(cls, affiliation_invitation_dicts: List[Dict]) -> \
@@ -128,16 +131,25 @@ class AffiliationInvitation:
 
     @staticmethod
     def _validate_prerequisites(business_identifier, from_org_id, to_org_id):
-        # Validate from/to organizations exists
+        # Validate from organizations exists
         if not (from_org := OrgModel.find_by_org_id(from_org_id)):
             raise BusinessException(Error.DATA_NOT_FOUND, None)
 
-        if not OrgModel.find_by_org_id(to_org_id):
+        # Validate to organization exists if it is provided
+        if to_org_id and not OrgModel.find_by_org_id(to_org_id):
             raise BusinessException(Error.DATA_NOT_FOUND, None)
 
         # Validate that entity exists
         if not (entity := EntityService.find_by_business_identifier(business_identifier, skip_auth=True)):
             raise BusinessException(Error.DATA_NOT_FOUND, None)
+
+        # Validate that entity contact exists
+        if not (contact := entity.get_contact()):
+            raise BusinessException(Error.INVALID_BUSINESS_EMAIL, None)
+
+        # Validate that entity contact email exists
+        if not contact.email:
+            raise BusinessException(Error.INVALID_BUSINESS_EMAIL, None)
 
         # Check if affiliation already exists
         if AffiliationModel.find_affiliation_by_org_and_entity_ids(to_org_id, entity.identifier):
@@ -165,13 +177,13 @@ class AffiliationInvitation:
             raise BusinessException(Error.DATA_ALREADY_EXISTS, None)
 
         check_auth(org_id=from_org_id,
-                   business_identifier=business_identifier,
                    one_of_roles=(ADMIN, COORDINATOR, STAFF))
 
         entity, from_org = AffiliationInvitation. \
             _validate_prerequisites(business_identifier, from_org_id, to_org_id)
 
         affiliation_invitation_info['entityId'] = entity.identifier
+        affiliation_invitation_info['recipientEmail'] = entity.get_contact().email
 
         if from_org.access_type == AccessType.ANONYMOUS.value:  # anonymous account never get bceid or bcsc choices
             mandatory_login_source = LoginSource.BCROS.value
@@ -189,6 +201,7 @@ class AffiliationInvitation:
             if not validate_passcode(pass_code, entity.pass_code):
                 raise BusinessException(Error.INVALID_USER_CREDENTIALS, None)
 
+            affiliation_invitation_info['recipientEmail'] = None
             affiliation_invitation_info['type'] = AffiliationInvitationType.PASSCODE.value
 
         affiliation_invitation = AffiliationInvitationModel.create_from_dict(affiliation_invitation_info,
@@ -245,7 +258,6 @@ class AffiliationInvitation:
     def update_affiliation_invitation(self, user, invitation_origin, affiliation_invitation_info: Dict):
         """Update the specified affiliation invitation with new data."""
         check_auth(org_id=self._model.from_org_id,
-                   business_identifier=self._model.entity.business_identifier,
                    one_of_roles=(ADMIN, COORDINATOR, STAFF))
 
         context_path = CONFIG.AUTH_WEB_TOKEN_CONFIRM_PATH
@@ -294,10 +306,10 @@ class AffiliationInvitation:
         invitation.delete()
 
     @staticmethod
-    def search_invitations(search_filter: AffiliationInvitationSearch):
+    def search_invitations(search_filter: AffiliationInvitationSearch, mask_email=True):
         """Search affiliation invitations."""
         invitation_models = AffiliationInvitationModel().filter_by(search_filter=search_filter)
-        return [AffiliationInvitation(invitation).as_dict() for invitation in invitation_models]
+        return [AffiliationInvitation(invitation).as_dict(mask_email=mask_email) for invitation in invitation_models]
 
     @staticmethod
     @user_context
@@ -359,14 +371,15 @@ class AffiliationInvitation:
         """Send the email notification."""
         current_app.logger.debug('<send_affiliation_invitation')
         affiliation_invitation_type = affiliation_invitation.type
-        to_org_name = affiliation_invitation.to_org.name
-        to_org_id = affiliation_invitation.to_org_id
+        from_org_name = affiliation_invitation.from_org.name
+        from_org_id = affiliation_invitation.from_org_id
+        to_org_name = affiliation_invitation.to_org.name if affiliation_invitation.to_org else None
 
         data = {
-            'accountId': to_org_id,
+            'accountId': from_org_id,
             'businessName': business_name,
             'emailAddresses': affiliation_invitation.recipient_email,
-            'orgName': to_org_name
+            'orgName': from_org_name
         }
         notification_type = 'affiliationInvitation'
 
@@ -374,7 +387,7 @@ class AffiliationInvitation:
             # if MAGIC LINK type, add data for magic link
             data['contextUrl'] = AffiliationInvitation._get_token_confirm_path(
                 app_url=app_url,
-                org_name=to_org_name,
+                org_name=from_org_name,
                 token=affiliation_invitation.token,
                 query_params=query_params)
 
@@ -385,12 +398,13 @@ class AffiliationInvitation:
             if is_authorized is not None:
                 notification_type = 'affiliationInvitationRequestAuthorization'
                 data['isAuthorized'] = is_authorized
+                data['isAuthorized'] = is_authorized
             else:
                 notification_type = 'affiliationInvitationRequest'
                 data['additionalMessage'] = affiliation_invitation.additional_message
 
         try:
-            publish_to_mailer(notification_type=notification_type, org_id=to_org_id, data=data)
+            publish_to_mailer(notification_type=notification_type, org_id=from_org_id, data=data)
         except BusinessException as exception:
             affiliation_invitation.invitation_status_code = InvitationStatus.FAILED.value
             affiliation_invitation.save()
@@ -462,7 +476,7 @@ class AffiliationInvitation:
     def accept_affiliation_invitation(affiliation_invitation_id,
                                       # pylint:disable=unused-argument
                                       user: UserService, origin, **kwargs):
-        """Add an affiliation from the affilation invitation."""
+        """Add an affiliation from the affiliation invitation."""
         current_app.logger.debug('>accept_affiliation_invitation')
         affiliation_invitation: AffiliationInvitationModel = AffiliationInvitationModel.\
             find_invitation_by_id(affiliation_invitation_id)
@@ -476,7 +490,7 @@ class AffiliationInvitation:
         if affiliation_invitation.invitation_status_code == InvitationStatus.FAILED.value:
             raise BusinessException(Error.INVALID_AFFILIATION_INVITATION_STATE, None)
 
-        org_id = affiliation_invitation.to_org_id
+        org_id = affiliation_invitation.from_org_id
         entity_id = affiliation_invitation.entity_id
 
         if not (affiliation_model := AffiliationModel.find_affiliation_by_org_and_entity_ids(org_id, entity_id)):

--- a/auth-api/src/auth_api/utils/util.py
+++ b/auth-api/src/auth_api/utils/util.py
@@ -74,3 +74,15 @@ def escape_wam_friendly_url(param):
     base64_org_name = base64.b64encode(bytes(param, encoding='utf-8')).decode('utf-8')
     encode_org_name = urllib.parse.quote(base64_org_name, safe='')
     return encode_org_name
+
+
+def mask_email(email: str):
+    """Return masked email."""
+    if email:
+        parts = email.split('@')
+        if len(parts) == 2:
+            username, domain = parts
+            masked_username = username[:2] + '*' * (len(username) - 2)
+            masked_domain = domain[:2] + '*' * (len(domain) - 2)
+            email = masked_username + '@' + masked_domain
+    return email

--- a/auth-api/src/auth_api/utils/util.py
+++ b/auth-api/src/auth_api/utils/util.py
@@ -76,7 +76,7 @@ def escape_wam_friendly_url(param):
     return encode_org_name
 
 
-def mask_email(email: str):
+def mask_email(email: str) -> str:
     """Return masked email."""
     if email:
         parts = email.split('@')

--- a/auth-api/tests/utilities/factory_utils.py
+++ b/auth-api/tests/utilities/factory_utils.py
@@ -196,16 +196,12 @@ def factory_affiliation_service(entity_id, org_id):
 def factory_affiliation_invitation(from_org_id,
                                    to_org_id,
                                    business_identifier,
-                                   email='abc123@email.com',
-                                   sent_date=datetime.datetime.now().strftime('Y-%m-%d %H:%M:%S'),
                                    affiliation_invitation_type='EMAIL'):
     """Produce an affiliation invitation for the given from/to org, business and email."""
     return {
         'fromOrgId': from_org_id,
         'toOrgId': to_org_id,
         'businessIdentifier': business_identifier,
-        'recipientEmail': email,
-        'sentDate': sent_date,
         'type': affiliation_invitation_type
     }
 


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/15769

*Description of changes:*

- update affiliation_invitations table: to_org_id and recipient_email is nullable (email is not required for passcode flow)
- update affiliation to be created for the from_org
- update to_org to be an optional parameter
- update auth check to not include business_identifier as there is no affiliation to the from_org when creating an invite
- update auth check to not include business_identifier when working with an affiliation invitation
- removed sent date parameter for creation (was already being set as part of create date, sent date updates when an email it resent)
- removed recipient email parameter for creation (this is fetched via the entity contacts), if there is no email a validation error is thrown
- recipient_email is masked when returned as part of an affiliation invitation
- moved email masking logic to utils
- introduced public schema for affiliation invitation (for use with masked email)
- update tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
