### PR TITLE
affiliation invitations - update not found exception message for busi…

### DIFF
--- a/auth-api/src/auth_api/exceptions/errors.py
+++ b/auth-api/src/auth_api/exceptions/errors.py
@@ -43,6 +43,9 @@ class Error(Enum):
                                            http_status.HTTP_400_BAD_REQUEST
     FAILED_AFFILIATION_INVITATION = 'Failed to dispatch the affiliation invitation', \
                                     http_status.HTTP_500_INTERNAL_SERVER_ERROR
+    AFFILIATION_INVITATION_BUSINESS_NOT_FOUND = 'The business specified for the affiliation ' \
+                                                'invitation could not be found.', \
+                                                http_status.HTTP_400_BAD_REQUEST
     FAILED_INVITATION = 'Failed to dispatch the invitation', http_status.HTTP_500_INTERNAL_SERVER_ERROR
     FAILED_NOTIFICATION = 'Failed to dispatch the notification', http_status.HTTP_500_INTERNAL_SERVER_ERROR
     DELETE_FAILED_ONLY_OWNER = 'Cannot delete as user is the only Account Administrator of some teams', \

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -148,6 +148,12 @@ class AffiliationInvitation:
         if to_org_id and not OrgModel.find_by_org_id(to_org_id):
             raise BusinessException(Error.DATA_NOT_FOUND, None)
 
+        # Validate business exists in LEAR
+        # Fetch the up-to-date business details from legal API - Business exception raised if failure
+        token = RestService.get_service_account_token(config_id='ENTITY_SVC_CLIENT_ID',
+                                                      config_secret='ENTITY_SVC_CLIENT_SECRET')
+        business = AffiliationInvitation._get_business_details(business_identifier, token)
+
         # Validate that entity exists
         if not (entity := EntityService.find_by_business_identifier(business_identifier, skip_auth=True)):
             raise BusinessException(Error.DATA_NOT_FOUND, None)
@@ -170,7 +176,7 @@ class AffiliationInvitation:
                                                                          to_org_id=to_org_id,
                                                                          entity_id=entity.identifier):
             raise BusinessException(Error.DATA_ALREADY_EXISTS, None)
-        return entity, from_org
+        return entity, from_org, business
 
     @staticmethod
     def get_invitation_email(affiliation_invitation_type: AffiliationInvitationType,
@@ -219,7 +225,7 @@ class AffiliationInvitation:
         check_auth(org_id=from_org_id,
                    one_of_roles=(ADMIN, COORDINATOR, STAFF))
 
-        entity, from_org = AffiliationInvitation. \
+        entity, from_org, business = AffiliationInvitation. \
             _validate_prerequisites(business_identifier=business_identifier, from_org_id=from_org_id,
                                     to_org_id=to_org_id, affiliation_invitation_type=affiliation_invitation_type)
 
@@ -259,10 +265,6 @@ class AffiliationInvitation:
         affiliation_invitation.save()
 
         if affiliation_invitation.type != AffiliationInvitationType.PASSCODE.value:
-            # Fetch the up-to-date business details from legal API
-            token = RestService.get_service_account_token(config_id='ENTITY_SVC_CLIENT_ID',
-                                                          config_secret='ENTITY_SVC_CLIENT_SECRET')
-            business = AffiliationInvitation._get_business_details(business_identifier, token)
             AffiliationInvitation.send_affiliation_invitation(affiliation_invitation=affiliation_invitation,
                                                               business_name=business['business']['legalName'],
                                                               app_url=f'{invitation_origin}/{context_path}',
@@ -282,7 +284,7 @@ class AffiliationInvitation:
             get_business_response = RestService.get(get_businesses_url, token=token, skip_404_logging=True)
         except (HTTPError, ServiceUnavailableException) as e:
             current_app.logger.info(e)
-            raise BusinessException(Error.DATA_NOT_FOUND, None) from e
+            raise BusinessException(Error.AFFILIATION_INVITATION_BUSINESS_NOT_FOUND, None) from e
 
         return get_business_response.json()
 
@@ -297,7 +299,7 @@ class AffiliationInvitation:
             get_business_response = RestService.post(get_businesses_url, token=token, data=data)
         except (HTTPError, ServiceUnavailableException) as e:
             current_app.logger.info(e)
-            raise BusinessException(Error.DATA_NOT_FOUND, None) from e
+            raise BusinessException(Error.AFFILIATION_INVITATION_BUSINESS_NOT_FOUND, None) from e
 
         return get_business_response.json()['businessEntities']
 

--- a/auth-api/tests/conftest.py
+++ b/auth-api/tests/conftest.py
@@ -24,6 +24,7 @@ from stan.aio.client import Client as Stan
 
 from auth_api import create_app, setup_jwt_manager
 from auth_api.auth import jwt as _jwt
+from auth_api.exceptions import BusinessException, Error
 from auth_api.models import db as _db
 
 
@@ -251,6 +252,17 @@ def keycloak_mock(monkeypatch):
                         lambda *args, **kwargs: None)
     monkeypatch.setattr('auth_api.services.keycloak.KeycloakService.add_or_remove_product_keycloak_groups',
                         lambda *args, **kwargs: None)
+
+
+@pytest.fixture()
+def business_exception_mock(monkeypatch):
+    """Mock get business call exceotion."""
+
+    def get_business(business_identifier, token):
+        raise BusinessException(Error.AFFILIATION_INVITATION_BUSINESS_NOT_FOUND, None)
+
+    monkeypatch.setattr('auth_api.services.affiliation_invitation.AffiliationInvitation._get_business_details',
+                        get_business)
 
 
 @pytest.fixture()


### PR DESCRIPTION
…ness identifier not found via legal-api. Move business look up to validation prereq

*Description of changes:*
- update affiliation invitation generic data not found for business look up to its own specific error code
- moved legal-api business look up to validate prerequisites
- add test case when a business look up fails

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
