### PR TITLE
fix sub product handling of parent product subscriptions

### DIFF
--- a/auth-api/src/auth_api/models/product_subscription.py
+++ b/auth-api/src/auth_api/models/product_subscription.py
@@ -47,4 +47,4 @@ class ProductSubscription(VersionedModel):  # pylint: disable=too-few-public-met
         """Find an product subscription instance that matches the provided id."""
         return cls.query.filter(
             and_(ProductSubscription.org_id == org_id, ProductSubscription.product_code == product_code,
-                 ProductSubscription.status_code.in_(valid_statuses))).all()
+                 ProductSubscription.status_code.in_(valid_statuses))).first()

--- a/auth-api/src/auth_api/services/products.py
+++ b/auth-api/src/auth_api/services/products.py
@@ -159,9 +159,9 @@ class Product:
             return
 
         # Parent sub exists and is not active - update the status
-        if existing_parent_sub[0].status_code != ProductSubscriptionStatus.ACTIVE.value:
-            existing_parent_sub[0].status_code = subscription_status
-            existing_parent_sub[0].flush()
+        if existing_parent_sub.status_code != ProductSubscriptionStatus.ACTIVE.value:
+            existing_parent_sub.status_code = subscription_status
+            existing_parent_sub.flush()
 
     @staticmethod
     def _subscribe_and_publish_activity(org_id: int, product_code: str, status_code: str,
@@ -222,7 +222,7 @@ class Product:
                     ProductSubscriptionModel(org_id=org_id, product_code=product_code,
                                              status_code=ProductSubscriptionStatus.ACTIVE.value).flush()
                 elif subscription and \
-                        (existing_sub := subscription[0]).status_code != ProductSubscriptionStatus.ACTIVE.value:
+                        (existing_sub := subscription).status_code != ProductSubscriptionStatus.ACTIVE.value:
                     existing_sub.status_code = ProductSubscriptionStatus.ACTIVE.value
                     existing_sub.flush()
 
@@ -311,21 +311,21 @@ class Product:
         )
 
         # There is no parent product subscription
-        if len(product_subscription) == 0:
+        if not product_subscription:
             return
 
-        status = product_subscription[0].status_code
+        status = product_subscription.status_code
 
         # Subscription is already Active
         if status == ProductSubscriptionStatus.ACTIVE.value:
             return
 
         if is_approved:
-            product_subscription[0].status_code = ProductSubscriptionStatus.ACTIVE.value
+            product_subscription.status_code = ProductSubscriptionStatus.ACTIVE.value
         else:
-            product_subscription[0].status_code = ProductSubscriptionStatus.REJECTED.value
+            product_subscription.status_code = ProductSubscriptionStatus.REJECTED.value
 
-        product_subscription[0].flush()
+        product_subscription.flush()
         if is_new_transaction:  # Commit the transaction if it's a new transaction
             db.session.commit()
 

--- a/auth-api/tests/utilities/factory_scenarios.py
+++ b/auth-api/tests/utilities/factory_scenarios.py
@@ -705,9 +705,10 @@ class TestOrgProductsInfo(dict, Enum):
     org_products_vs = {'subscriptions': [{'productCode': 'VS'}]}
     org_products_business = {'subscriptions': [{'productCode': 'BUSINESS'}]}
     org_products_nds = {'subscriptions': [{'productCode': 'NDS'}]}
-    mhr_qs_lawyer_and_notaries = {'subscriptions': [{'productCode': 'MHR_QSLN', 'externalSourceId': 'ABC123'}]}
-    mhr_qs_home_manufacturers = {'subscriptions': [{'productCode': 'MHR_QSHM', 'externalSourceId': 'ABC123'}]}
-    mhr_qs_home_dealers = {'subscriptions': [{'productCode': 'MHR_QSHD', 'externalSourceId': 'ABC123'}]}
+    mhr = {'subscriptions': [{'productCode': 'MHR'}]}
+    mhr_qs_lawyer_and_notaries = {'subscriptions': [{'productCode': 'MHR_QSLN', 'externalSourceId': 'ABC101'}]}
+    mhr_qs_home_manufacturers = {'subscriptions': [{'productCode': 'MHR_QSHM', 'externalSourceId': 'ABC102'}]}
+    mhr_qs_home_dealers = {'subscriptions': [{'productCode': 'MHR_QSHD', 'externalSourceId': 'ABC103'}]}
 
 
 class TestEntityInfo(dict, Enum):


### PR DESCRIPTION
*Description of changes:*
- update parent product handling for sub products - checks additional checks for parent product and the current status
- additional test cases to test different approval and rejection situations


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
