### PR TITLE
auth-api version increment to 2.8.0

### DIFF
--- a/auth-api/src/auth_api/version.py
+++ b/auth-api/src/auth_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.7.0'  # pylint: disable=invalid-name
+__version__ = '2.8.0'  # pylint: disable=invalid-name


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
