### PR TITLE
affiliation invitation patch endpoint - business look up service clie…

### DIFF
--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -330,8 +330,9 @@ class AffiliationInvitation:
             invitation = self._model.update_invitation_as_retried(user.identifier)
             entity: EntityModel = invitation.entity
 
-            business = AffiliationInvitation._get_business_details(entity.business_identifier,
-                                                                   RestService.get_service_account_token())
+            token = RestService.get_service_account_token(config_id='ENTITY_SVC_CLIENT_ID',
+                                                          config_secret='ENTITY_SVC_CLIENT_SECRET')
+            business = AffiliationInvitation._get_business_details(entity.business_identifier, token)
 
             AffiliationInvitation\
                 .send_affiliation_invitation(affiliation_invitation=invitation,


### PR DESCRIPTION
*Description of changes:*
- fix affiliation invitation patch endpoint to use the correct service client when doing a business look up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
