### PR TITLE
Fix missing to_org_id when creating affiliation invitation with toOrgUuid.

### DIFF
--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -229,9 +229,9 @@ class AffiliationInvitation:
         """Create a new affiliation invitation."""
         context_path = CONFIG.AUTH_WEB_TOKEN_CONFIRM_PATH
         from_org_id = affiliation_invitation_info['fromOrgId']
-        to_org_id = affiliation_invitation_info.get('toOrgId')
         if to_org_uuid := affiliation_invitation_info.get('toOrgUuid'):
             affiliation_invitation_info['toOrgId'] = AffiliationInvitation._get_org_id_from_org_uuid(to_org_uuid)
+        to_org_id = affiliation_invitation_info.get('toOrgId')
 
         business_identifier = affiliation_invitation_info['businessIdentifier']
         affiliation_invitation_type = AffiliationInvitationType.from_value(affiliation_invitation_info.get('type'))


### PR DESCRIPTION
*Description of changes:*
Fix missing to_org_id when creating affiliation invitation with toOrgUuid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
