### PR TITLE
17385 - Fix amalgamation NR display in MBR

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/composables/affiliations-factory.ts
+++ b/auth-web/src/composables/affiliations-factory.ts
@@ -161,7 +161,7 @@ export const useAffiliations = () => {
   const nameRequestType = (business: Business): string => {
     if (isNameRequest(business)) {
       // Try action code first, and if not found in the enum then use type code
-      let nrType = CommonUtils.mapRequestActionCdToNrType(business.nameRequest?.requestActionCd)
+      let nrType: string = CommonUtils.mapRequestActionCdToNrType(business.nameRequest?.requestActionCd)
       nrType = nrType || CommonUtils.mapRequestTypeCdToNrType(business.nameRequest?.requestTypeCd)
       if (nrType) {
         const emDash = '—' // ALT + 0151

--- a/auth-web/src/composables/affiliations-factory.ts
+++ b/auth-web/src/composables/affiliations-factory.ts
@@ -162,7 +162,7 @@ export const useAffiliations = () => {
     if (isNameRequest(business)) {
       // Try action code first, and if not found in the enum then use type code
       let nrType = CommonUtils.mapRequestActionCdToNrType(business.nameRequest?.requestActionCd)
-      nrType = nrType ? nrType : CommonUtils.mapRequestTypeCdToNrType(business.nameRequest?.requestTypeCd)
+      nrType = nrType || CommonUtils.mapRequestTypeCdToNrType(business.nameRequest?.requestTypeCd)
       if (nrType) {
         const emDash = '—' // ALT + 0151
         return `${emDash} ${nrType}`

--- a/auth-web/src/composables/affiliations-factory.ts
+++ b/auth-web/src/composables/affiliations-factory.ts
@@ -157,10 +157,12 @@ export const useAffiliations = () => {
     )
   }
 
-  /** Returns the Name Request type using the NR type code */
+  /** Returns the Name Request type using the NR action code or the NR type code */
   const nameRequestType = (business: Business): string => {
     if (isNameRequest(business)) {
-      const nrType = CommonUtils.mapRequestTypeCdToNrType(business.nameRequest?.requestTypeCd)
+      // Try action code first, and if not found in the enum then use type code
+      let nrType = CommonUtils.mapRequestActionCdToNrType(business.nameRequest?.requestActionCd)
+      nrType = nrType ? nrType : CommonUtils.mapRequestTypeCdToNrType(business.nameRequest?.requestTypeCd)
       if (nrType) {
         const emDash = '—' // ALT + 0151
         return `${emDash} ${nrType}`

--- a/auth-web/src/models/affiliation.ts
+++ b/auth-web/src/models/affiliation.ts
@@ -1,8 +1,8 @@
 import { Action, Applicant, Business, CorpType, Names } from '@/models/business'
 import { CorpTypes, NrTargetTypes } from '@/util/constants'
+import { NrRequestActionCodes, NrRequestTypeCodes } from '@bcrs-shared-components/enums'
 import { OrgNameAndId, Organization } from '@/models/Organization'
 import { Contact } from './contact'
-import { NrRequestTypeCodes } from '@bcrs-shared-components/enums'
 
 export interface CreateRequestBody {
   businessIdentifier: string
@@ -98,6 +98,7 @@ export interface NameRequestResponse {
   target?: NrTargetTypes
   entityTypeCd?: string
   requestTypeCd?: NrRequestTypeCodes
+  requestActionCd?: NrRequestActionCodes
   natureOfBusiness?: string
   expirationDate?: Date
   nrNum?: string

--- a/auth-web/src/models/business.ts
+++ b/auth-web/src/models/business.ts
@@ -1,7 +1,7 @@
 import { CorpTypes, FilingTypes, LearFilingTypes, NrTargetTypes } from '@/util/constants'
+import { NrRequestActionCodes, NrRequestTypeCodes } from '@bcrs-shared-components/enums'
 import { AffiliationInviteInfo } from '@/models/affiliation'
 import { Contact } from './contact'
-import { NrRequestTypeCodes } from '@bcrs-shared-components/enums'
 
 export interface LoginPayload {
     businessIdentifier: string
@@ -78,6 +78,7 @@ export interface NameRequest {
     target?: NrTargetTypes
     entityTypeCd?: string
     requestTypeCd?: NrRequestTypeCodes
+    requestActionCd?: NrRequestActionCodes
     natureOfBusiness?: string
     expirationDate?: Date
     nrNum?: string

--- a/auth-web/src/stores/business.ts
+++ b/auth-web/src/stores/business.ts
@@ -116,6 +116,7 @@ export const useBusinessStore = defineStore('business', () => {
       target: getTarget(nr),
       entityTypeCd: nr.entityTypeCd,
       requestTypeCd: nr.requestTypeCd,
+      requestActionCd: nr.requestActionCd,
       natureOfBusiness: nr.natureBusinessInfo,
       expirationDate: nr.expirationDate,
       applicants: nr.applicants

--- a/auth-web/src/util/common-util.ts
+++ b/auth-web/src/util/common-util.ts
@@ -1,6 +1,6 @@
 import { Address, BaseAddressModel } from '@/models/address'
-import { NrRequestTypeStrings, Permission } from '@/util/constants'
-import { NrRequestTypeCodes } from '@bcrs-shared-components/enums'
+import { NrRequestActionCodes, NrRequestTypeCodes } from '@bcrs-shared-components/enums'
+import { NrRequestActionStrings, NrRequestTypeStrings, Permission } from '@/util/constants'
 import moment from 'moment'
 
 /**
@@ -271,6 +271,11 @@ export default class CommonUtils {
   // trim last slas from URL
   static trimTrailingSlashURL (url) {
     return (url) ? url.trim().replace(/\/+$/, '') : ''
+  }
+
+  /** use NR request action code to get NR type from enum */
+  static mapRequestActionCdToNrType (requestActionCd: NrRequestActionCodes): string {
+    return NrRequestActionStrings[requestActionCd] as string
   }
 
   /** use NR request type code to get NR type from enum */

--- a/auth-web/src/util/common-util.ts
+++ b/auth-web/src/util/common-util.ts
@@ -1,6 +1,6 @@
 import { Address, BaseAddressModel } from '@/models/address'
 import { NrRequestActionCodes, NrRequestTypeCodes } from '@bcrs-shared-components/enums'
-import { NrRequestActionStrings, NrRequestTypeStrings, Permission } from '@/util/constants'
+import { NrRequestTypeStrings, Permission } from '@/util/constants'
 import moment from 'moment'
 
 /**
@@ -275,7 +275,11 @@ export default class CommonUtils {
 
   /** use NR request action code to get NR type from enum */
   static mapRequestActionCdToNrType (requestActionCd: NrRequestActionCodes): string {
-    return NrRequestActionStrings[requestActionCd] as string
+    // Can add other NrRequestActionCodes here to use the action code instead of the NrRequestTypeCd.
+    // Must ensure that the action code does not have several potential types
+    // Example: the NEW action code can be for Incorporation or Registration, so we cannot use it for the NR type
+    if (requestActionCd === NrRequestActionCodes.AMALGAMATE) { return 'Amalgamation' }
+    return ''
   }
 
   /** use NR request type code to get NR type from enum */

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -248,6 +248,13 @@ export enum NrEntityType {
     INFO = 'INFO', // special value for sub-menu
 }
 
+export enum NrRequestActionStrings {
+  // Can add other NrRequestActionCodes here to use the action code instead of the NrRequestTypeCd. 
+  // Must ensure that the action code does not have several potential types 
+  // Example: the NEW action code can be for Incorporate or Register, so we cannot use it for the NR type
+  AML = 'Amalgamation',
+}
+
 export enum NrRequestTypeStrings {
   // Alteration
   BECV = 'Alteration', // BC Benefit Company Incorporation

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -248,13 +248,6 @@ export enum NrEntityType {
     INFO = 'INFO', // special value for sub-menu
 }
 
-export enum NrRequestActionStrings {
-  // Can add other NrRequestActionCodes here to use the action code instead of the NrRequestTypeCd.
-  // Must ensure that the action code does not have several potential types
-  // Example: the NEW action code can be for Incorporation or Registration, so we cannot use it for the NR type
-  AML = 'Amalgamation',
-}
-
 export enum NrRequestTypeStrings {
   // Alteration
   BECV = 'Alteration', // BC Benefit Company Incorporation

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -249,9 +249,9 @@ export enum NrEntityType {
 }
 
 export enum NrRequestActionStrings {
-  // Can add other NrRequestActionCodes here to use the action code instead of the NrRequestTypeCd. 
-  // Must ensure that the action code does not have several potential types 
-  // Example: the NEW action code can be for Incorporate or Register, so we cannot use it for the NR type
+  // Can add other NrRequestActionCodes here to use the action code instead of the NrRequestTypeCd.
+  // Must ensure that the action code does not have several potential types
+  // Example: the NEW action code can be for Incorporation or Registration, so we cannot use it for the NR type
   AML = 'Amalgamation',
 }
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17385

*Description of changes:*

- Use the action code for amalgamation to display Name Request type.

*Notes:*
While the `requestTypeCd` returned from LEAR can be used for the NR type in most cases, in this situation we have to use the `requestActionCd`. This is because for _Incorporation_ and _Amalgamation_ NR types for a BC Limited Company, the `requestTypeCode` will be "CR" in both cases (so we can't differentiate using this), however the `requestActionCd`s will be "NEW" and "AML" respectively. I couldn't find a general solution using just `requestActionCd`s as many of the codes have dual uses.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
