### PR TITLE
fix 500 error fetching on documents endpoint for tos pad

### DIFF
--- a/auth-api/src/auth_api/resources/v1/documents.py
+++ b/auth-api/src/auth_api/resources/v1/documents.py
@@ -62,7 +62,6 @@ def get_document_by_type(document_type):
     return response, status
 
 
-@staticmethod
 def _replace_current_date(doc):
     """Replace any dynamic contents."""
     today = datetime.today()

--- a/auth-api/tests/unit/api/test_documents.py
+++ b/auth-api/tests/unit/api/test_documents.py
@@ -20,7 +20,8 @@ Test-Suite to ensure that the /documents endpoint is working as expected.
 from auth_api import status as http_status
 from auth_api.schemas import utils as schema_utils
 from tests.utilities.factory_scenarios import TestJwtClaims
-from tests.utilities.factory_utils import factory_auth_header, factory_document_model, get_tos_latest_version
+from tests.utilities.factory_utils import (
+    factory_auth_header, factory_document_model, get_tos_latest_version, get_tos_pad_latest_version)
 
 
 def test_documents_returns_200(client, jwt, session):  # pylint:disable=unused-argument
@@ -31,12 +32,22 @@ def test_documents_returns_200(client, jwt, session):  # pylint:disable=unused-a
     assert rv.status_code == http_status.HTTP_200_OK
     assert rv.json.get('versionId') == get_tos_latest_version()
 
+    rv = client.get('/api/v1/documents/termsofuse_pad', headers=headers, content_type='application/json')
+
+    assert rv.status_code == http_status.HTTP_200_OK
+    assert rv.json.get('versionId') == get_tos_pad_latest_version()
+
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.anonymous_bcros_role)
     rv = client.get('/api/v1/documents/termsofuse', headers=headers, content_type='application/json')
 
     assert rv.status_code == http_status.HTTP_200_OK
     assert schema_utils.validate(rv.json, 'document')[0]
     assert rv.json.get('versionId') == 'd1'
+
+    rv = client.get('/api/v1/documents/termsofuse_pad', headers=headers, content_type='application/json')
+
+    assert rv.status_code == http_status.HTTP_200_OK
+    assert rv.json.get('versionId') == get_tos_pad_latest_version()
 
 
 def test_invalid_documents_returns_404(client, jwt, session):  # pylint:disable=unused-argument

--- a/auth-api/tests/utilities/factory_utils.py
+++ b/auth-api/tests/utilities/factory_utils.py
@@ -346,6 +346,11 @@ def get_tos_latest_version():
     return '5'
 
 
+def get_tos_pad_latest_version():
+    """Return latest tos pad version."""
+    return 'p1'
+
+
 def patch_pay_account_post(monkeypatch):
     """Patch pay account post success (200 or 201)."""
     class MockPayResponse:


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/15686

*Description of changes:*
- fix 500 error returning specifically for TOS PAD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
