### PR TITLE
17525, 17526, 17527 - Qualified Supplier Emails

### DIFF
--- a/auth-api/src/auth_api/services/products.py
+++ b/auth-api/src/auth_api/services/products.py
@@ -280,7 +280,7 @@ class Product:
         # Approve/Reject Product subscription
         product_subscription: ProductSubscriptionModel = ProductSubscriptionModel.find_by_id(product_subscription_id)
 
-        is_reapproved = product_subscription.status_code == ProductSubscriptionStatus.REJECTED.value and is_approved
+        is_reapproved = Product.is_reapproved(product_subscription.status_code, is_approved)
 
         if is_approved:
             product_subscription.status_code = ProductSubscriptionStatus.ACTIVE.value
@@ -337,7 +337,7 @@ class Product:
         if status == ProductSubscriptionStatus.ACTIVE.value:
             return
 
-        is_reapproved = status == ProductSubscriptionStatus.REJECTED.value and is_approved
+        is_reapproved = Product.is_reapproved(status, is_approved)
 
         if is_approved:
             product_subscription.status_code = ProductSubscriptionStatus.ACTIVE.value
@@ -366,6 +366,11 @@ class Product:
             ActivityLogPublisher.publish_activity(Activity(org_id, ActivityAction.ADD_PRODUCT_AND_SERVICE.value,
                                                            name=product_model.description))
         current_app.logger.debug('>approve_reject_parent_subscription ')
+
+    @staticmethod
+    def is_reapproved(product_sub_status: str, is_approved: str) -> bool:
+        """Determine if the product subscriptions is re-approved."""
+        return product_sub_status == ProductSubscriptionStatus.REJECTED.value and is_approved
 
     @staticmethod
     def send_product_subscription_notification(product_notification_info: ProductNotificationInfo):

--- a/auth-api/src/auth_api/services/products.py
+++ b/auth-api/src/auth_api/services/products.py
@@ -19,17 +19,17 @@ from flask import current_app
 from sqlalchemy import and_, case, func, literal, or_
 from sqlalchemy.exc import SQLAlchemyError
 
-from auth_api.models.dataclass import Activity, KeycloakGroupSubscription, ProductReviewTask
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
-from auth_api.services.keycloak import KeycloakService
 from auth_api.models import Membership as MembershipModel
 from auth_api.models import Org as OrgModel
 from auth_api.models import ProductCode as ProductCodeModel
 from auth_api.models import ProductSubscription as ProductSubscriptionModel
 from auth_api.models import User as UserModel
 from auth_api.models import db
+from auth_api.models.dataclass import Activity, KeycloakGroupSubscription, ProductReviewTask
 from auth_api.schemas import ProductCodeSchema
+from auth_api.services.keycloak import KeycloakService
 from auth_api.services.user import User as UserService
 from auth_api.utils.constants import BCOL_PROFILE_PRODUCT_MAP
 from auth_api.utils.enums import (
@@ -39,10 +39,13 @@ from auth_api.utils.user_context import UserContext, user_context
 
 from ..utils.account_mailer import publish_to_mailer
 from ..utils.cache import cache
+from ..utils.notifications import (
+    ProductNotificationInfo, ProductSubscriptionInfo, get_product_notification_data, get_product_notification_type)
 from ..utils.roles import CLIENT_ADMIN_ROLES, CLIENT_AUTH_ROLES, PREMIUM_ORG_TYPES, STAFF
 from .activity_log_publisher import ActivityLogPublisher
 from .authorization import check_auth
 from .task import Task as TaskService
+
 
 QUALIFIED_SUPPLIER_PRODUCT_CODES = [ProductCode.MHR_QSLN.value, ProductCode.MHR_QSHD.value,
                                     ProductCode.MHR_QSHM.value]
@@ -265,15 +268,24 @@ class Product:
         return products
 
     @staticmethod
-    def update_product_subscription(product_subscription_id: int, is_approved: bool, org_id: int,
-                                    is_new_transaction: bool = True):
+    def update_product_subscription(product_sub_info: ProductSubscriptionInfo, is_new_transaction: bool = True):
         """Update Product Subscription."""
-        current_app.logger.debug('<update_task_product ')
+        current_app.logger.debug('<update_product_subscription ')
+
+        product_subscription_id = product_sub_info.product_subscription_id
+        is_approved = product_sub_info.is_approved
+        is_hold = product_sub_info.is_hold
+        org_id = product_sub_info.org_id
+
         # Approve/Reject Product subscription
         product_subscription: ProductSubscriptionModel = ProductSubscriptionModel.find_by_id(product_subscription_id)
 
+        is_reapproved = product_subscription.status_code == ProductSubscriptionStatus.REJECTED.value and is_approved
+
         if is_approved:
             product_subscription.status_code = ProductSubscriptionStatus.ACTIVE.value
+        elif is_hold:
+            product_subscription.status_code = ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value
         else:
             product_subscription.status_code = ProductSubscriptionStatus.REJECTED.value
         product_subscription.flush()
@@ -283,9 +295,14 @@ class Product:
         product_model: ProductCodeModel = ProductCodeModel.find_by_code(product_subscription.product_code)
         # Find admin email addresses
         admin_emails = UserService.get_admin_emails_for_org(org_id)
-        if admin_emails != '':
-            Product.send_approved_product_subscription_notification(admin_emails, product_model.description,
-                                                                    product_subscription.status_code)
+        if admin_emails != '' and not is_hold:
+            Product.send_product_subscription_notification(
+                ProductNotificationInfo(recipient_emails=admin_emails,
+                                        product_model=product_model,
+                                        product_sub_model=product_subscription,
+                                        is_reapproved=is_reapproved,
+                                        remarks=product_sub_info.task_remarks))
+
         else:
             # continue but log error
             current_app.logger.error('No admin email record for org id %s', org_id)
@@ -294,14 +311,14 @@ class Product:
                                                            name=product_model.description))
 
         if product_model.parent_code:
-            Product.approve_reject_parent_subscription(product_model.parent_code, is_approved, org_id,
-                                                       is_new_transaction)
+            Product.approve_reject_parent_subscription(product_model.parent_code, is_approved, is_hold,
+                                                       org_id, is_new_transaction)
 
-        current_app.logger.debug('>update_task_product ')
+        current_app.logger.debug('>update_product_subscription ')
 
     @staticmethod
-    def approve_reject_parent_subscription(parent_product_code: int, is_approved: bool, org_id: int,
-                                           is_new_transaction: bool = True):
+    def approve_reject_parent_subscription(parent_product_code: int, is_approved: bool, is_hold: bool,
+                                           org_id: int, is_new_transaction: bool = True):
         """Approve or reject Parent Product Subscription."""
         current_app.logger.debug('<approve_reject_parent_subscription ')
 
@@ -320,8 +337,12 @@ class Product:
         if status == ProductSubscriptionStatus.ACTIVE.value:
             return
 
+        is_reapproved = status == ProductSubscriptionStatus.REJECTED.value and is_approved
+
         if is_approved:
             product_subscription.status_code = ProductSubscriptionStatus.ACTIVE.value
+        elif is_hold:
+            product_subscription.status_code = ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value
         else:
             product_subscription.status_code = ProductSubscriptionStatus.REJECTED.value
 
@@ -332,9 +353,12 @@ class Product:
         product_model: ProductCodeModel = ProductCodeModel.find_by_code(parent_product_code)
         # Find admin email addresses
         admin_emails = UserService.get_admin_emails_for_org(org_id)
-        if admin_emails != '':
-            Product.send_approved_product_subscription_notification(admin_emails, product_model.description,
-                                                                    status)
+        if admin_emails != '' and not is_hold:
+            Product.send_product_subscription_notification(
+                ProductNotificationInfo(recipient_emails=admin_emails,
+                                        product_model=product_model,
+                                        product_sub_model=product_subscription,
+                                        is_reapproved=is_reapproved))
         else:
             # continue but log error
             current_app.logger.error('No admin email record for org id %s', org_id)
@@ -344,24 +368,23 @@ class Product:
         current_app.logger.debug('>approve_reject_parent_subscription ')
 
     @staticmethod
-    def send_approved_product_subscription_notification(receipt_admin_emails, product_name,
-                                                        product_subscription_status: ProductSubscriptionStatus):
+    def send_product_subscription_notification(product_notification_info: ProductNotificationInfo):
         """Send Approved product subscription notification to the user."""
-        current_app.logger.debug('<send_approved_prod_subscription_notification')
+        current_app.logger.debug('<send_prod_subscription_notification')
 
-        if product_subscription_status == ProductSubscriptionStatus.ACTIVE.value:
-            notification_type = 'prodPackageApprovedNotification'
-        else:
-            notification_type = 'prodPackageRejectedNotification'
-        data = {
-            'productName': product_name,
-            'emailAddresses': receipt_admin_emails
-        }
+        notification_type = get_product_notification_type(product_notification_info)
+
+        # There is no defined notification type to handle the current state
+        if notification_type is None:
+            return
+
+        data = get_product_notification_data(product_notification_info)
+
         try:
             publish_to_mailer(notification_type, data=data)
-            current_app.logger.debug('<send_approved_prod_subscription_notification>')
+            current_app.logger.debug('<send_prod_subscription_notification>')
         except Exception as e:  # noqa=B901
-            current_app.logger.error('<send_approved_prod_subscription_notification failed')
+            current_app.logger.error('<send_prod_subscription_notification failed')
             raise BusinessException(Error.FAILED_NOTIFICATION, None) from e
 
     @staticmethod

--- a/auth-api/src/auth_api/services/task.py
+++ b/auth-api/src/auth_api/services/task.py
@@ -29,12 +29,14 @@ from auth_api.models import Org as OrgModel
 from auth_api.models import Task as TaskModel
 from auth_api.models import User as UserModel
 from auth_api.models import db
+from auth_api.models.dataclass import TaskSearch
 from auth_api.schemas import TaskSchema
 from auth_api.services.user import User as UserService
 from auth_api.utils.account_mailer import publish_to_mailer
-from auth_api.utils.enums import Status, TaskRelationshipStatus, TaskRelationshipType, TaskStatus, TaskAction
+from auth_api.utils.enums import Status, TaskAction, TaskRelationshipStatus, TaskRelationshipType, TaskStatus
+from auth_api.utils.notifications import ProductSubscriptionInfo
 from auth_api.utils.util import camelback2snake  # noqa: I005
-from auth_api.models.dataclass import TaskSearch
+
 
 ENV = Environment(loader=FileSystemLoader('.'), autoescape=True)
 
@@ -137,8 +139,16 @@ class Task:  # pylint: disable=too-many-instance-attributes
             # Update Product relationship
             product_subscription_id = task_model.relationship_id
             account_id = task_model.account_id
-            self._update_product_subscription(is_approved=is_approved, product_subscription_id=product_subscription_id,
-                                              org_id=account_id)
+
+            task_remarks = None
+            if task_model.remarks and len(task_model.remarks) > 0:
+                task_remarks = task_model.remarks[0]
+
+            self._update_product_subscription(ProductSubscriptionInfo(is_approved=is_approved,
+                                                                      is_hold=is_hold,
+                                                                      product_subscription_id=product_subscription_id,
+                                                                      org_id=account_id,
+                                                                      task_remarks=task_remarks))
 
         elif task_model.relationship_type == TaskRelationshipType.USER.value:
             user_id = task_model.relationship_id
@@ -230,14 +240,13 @@ class Task:  # pylint: disable=too-many-instance-attributes
         current_app.logger.debug('>update_bceid_admin_to_org ')
 
     @staticmethod
-    def _update_product_subscription(is_approved: bool, product_subscription_id: int, org_id: int):
+    def _update_product_subscription(product_sub_info: ProductSubscriptionInfo):
         """Review Product Subscription."""
         current_app.logger.debug('<_update_product_subscription ')
         from auth_api.services import Product as ProductService  # pylint:disable=cyclic-import, import-outside-toplevel
 
         # Approve/Reject Product subscription
-        ProductService.update_product_subscription(product_subscription_id=product_subscription_id,
-                                                   is_approved=is_approved, org_id=org_id, is_new_transaction=False)
+        ProductService.update_product_subscription(product_sub_info=product_sub_info, is_new_transaction=False)
         current_app.logger.debug('>_update_product_subscription ')
 
     @staticmethod

--- a/auth-api/src/auth_api/services/task.py
+++ b/auth-api/src/auth_api/services/task.py
@@ -140,15 +140,11 @@ class Task:  # pylint: disable=too-many-instance-attributes
             product_subscription_id = task_model.relationship_id
             account_id = task_model.account_id
 
-            task_remarks = None
-            if task_model.remarks and len(task_model.remarks) > 0:
-                task_remarks = task_model.remarks[0]
-
             self._update_product_subscription(ProductSubscriptionInfo(is_approved=is_approved,
                                                                       is_hold=is_hold,
                                                                       product_subscription_id=product_subscription_id,
                                                                       org_id=account_id,
-                                                                      task_remarks=task_remarks))
+                                                                      task_remarks=Task.get_task_remark(task_model)))
 
         elif task_model.relationship_type == TaskRelationshipType.USER.value:
             user_id = task_model.relationship_id
@@ -167,6 +163,13 @@ class Task:  # pylint: disable=too-many-instance-attributes
             task_model.user.save()
 
         current_app.logger.debug('>update_task_relationship ')
+
+    @staticmethod
+    def get_task_remark(task_model: TaskModel):
+        """Check and return the task remarks."""
+        if task_model.remarks and len(task_model.remarks) > 0:
+            return task_model.remarks[0]
+        return None
 
     @staticmethod
     def _notify_admin_about_hold(task_model, org: OrgModel = None, is_new_bceid_admin_request: bool = False,

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -342,3 +342,13 @@ class KeycloakGroupActions(Enum):
 
     ADD_TO_GROUP = 'ADD_TO_GROUP'
     REMOVE_FROM_GROUP = 'REMOVE_FROM_GROUP'
+
+
+class NotificationTypes(Enum):
+    """Account mailer notification types."""
+
+    DEFAULT_APPROVED_PRODUCT = 'prodPackageApprovedNotification'
+    DEFAULT_REJECTED_PRODUCT = 'prodPackageRejectedNotification'
+    DETAILED_CONFIRMATION_PRODUCT = 'productConfirmationNotificationDetailed'
+    DETAILED_APPROVED_PRODUCT = 'productApprovedNotificationDetailed'
+    DETAILED_REJECTED_PRODUCT = 'productRejectedNotificationDetailed'

--- a/auth-api/src/auth_api/utils/notifications.py
+++ b/auth-api/src/auth_api/utils/notifications.py
@@ -1,0 +1,152 @@
+# Copyright © 2023 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility helping with notifications to the mailer."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from auth_api.models import ProductCode as ProductCodeModel
+from auth_api.models import ProductSubscription as ProductSubscriptionModel
+from auth_api.utils.enums import NotificationTypes, ProductCode, ProductSubscriptionStatus
+
+DETAILED_MHR_NOTIFICATIONS = (ProductCode.MHR_QSLN.value,
+                              ProductCode.MHR_QSHD.value,
+                              ProductCode.MHR_QSHM.value
+                              )
+
+
+@dataclass
+class ProductSubscriptionInfo:
+    """Used for managing product subscription."""
+
+    is_approved: bool
+    product_subscription_id: int
+    org_id: int
+    task_remarks: Optional[str] = None
+    is_hold: Optional[bool] = False
+
+
+@dataclass
+class ProductNotificationInfo:
+    """Used for retrieving product notification configuration."""
+
+    product_model: ProductCodeModel
+    product_sub_model: ProductSubscriptionModel
+    recipient_emails: str
+    remarks: Optional[str] = None
+    is_reapproved: Optional[bool] = False
+
+
+# e.g [BC Registries and Online Services] Your {{MHR_QUALIFIED_SUPPLIER}} Access Has Been Approved
+class ProductSubjectDescriptor(Enum):
+    """Notification product subject descriptor."""
+
+    MHR_QUALIFIED_SUPPLIER = 'Manufactured Home Registry Qualified Supplier'
+
+
+# e.g. You've been approved for {{MHR_QUALIFIED_SUPPLIER}} access to...
+class ProductAccessDescriptor(Enum):
+    """Notification product access descriptor."""
+
+    MHR_QUALIFIED_SUPPLIER = 'Qualified Supplier'
+
+
+# e.g. You've been approved for Qualified Supplier access to {{MHR}}.
+class ProductCategoryDescriptor(Enum):
+    """Notification product category descriptor."""
+
+    MHR = 'the Manufactured Home Registry'
+
+
+def get_product_notification_type(product_notification_info: ProductNotificationInfo):
+    """Get the appropriate product notification type."""
+    product_model = product_notification_info.product_model
+    is_reapproved = product_notification_info.is_reapproved
+    subscription_status_code = product_notification_info.product_sub_model.status_code
+
+    # Use detailed version of product subscription notification templates
+    if product_model.code in DETAILED_MHR_NOTIFICATIONS:
+        if is_reapproved or subscription_status_code == ProductSubscriptionStatus.ACTIVE.value:
+            return NotificationTypes.DETAILED_APPROVED_PRODUCT.value
+
+        if subscription_status_code == ProductSubscriptionStatus.REJECTED.value:
+            return NotificationTypes.DETAILED_REJECTED_PRODUCT.value
+
+    # Use default product subscription notification templates
+    if subscription_status_code == ProductSubscriptionStatus.ACTIVE.value:
+        return NotificationTypes.DEFAULT_APPROVED_PRODUCT.value
+
+    if subscription_status_code == ProductSubscriptionStatus.REJECTED.value:
+        return NotificationTypes.DEFAULT_REJECTED_PRODUCT.value
+
+    return None
+
+
+def get_product_notification_data(product_notification_info: ProductNotificationInfo):
+    """Get the appropriate product notification data."""
+    product_model = product_notification_info.product_model
+    recipient_emails = product_notification_info.recipient_emails
+    is_reapproved = product_notification_info.is_reapproved
+    subscription_status_code = product_notification_info.product_sub_model.status_code
+    remarks = product_notification_info.remarks
+
+    if product_model.code not in DETAILED_MHR_NOTIFICATIONS:
+        return get_default_product_notification_data(product_model, recipient_emails)
+
+    if is_reapproved or subscription_status_code == ProductSubscriptionStatus.ACTIVE.value:
+        return get_mhr_qs_approval_data(product_model, recipient_emails, is_reapproved)
+
+    if subscription_status_code == ProductSubscriptionStatus.REJECTED.value:
+        return get_mhr_qs_rejected_data(product_model, recipient_emails, remarks)
+
+    return None
+
+
+def get_default_product_notification_data(product_model: ProductCodeModel, recipient_emails: str):
+    """Get the default product notification data."""
+    data = {
+        'productName': product_model.description,
+        'emailAddresses': recipient_emails
+    }
+    return data
+
+
+def get_mhr_qs_approval_data(product_model: ProductCodeModel, recipient_emails: str, is_reapproved: bool = False):
+    """Get the mhr qualified supplier product approval notification data."""
+    data = {
+        'subjectDescriptor': ProductSubjectDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+        'productAccessDescriptor': ProductAccessDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+        'categoryDescriptor': ProductCategoryDescriptor.MHR.value,
+        'isReapproved': is_reapproved,
+        'productName': product_model.description,
+        'emailAddresses': recipient_emails
+    }
+    return data
+
+
+def get_mhr_qs_rejected_data(product_model: ProductCodeModel, recipient_emails: str, reject_reason: str = None):
+    """Get the mhr qualified supplier product rejected notification data."""
+    contact_type = 'BCOL' if product_model.code == ProductCode.MHR_QSLN.value else 'BCREG'
+    data = {
+        'subjectDescriptor': ProductSubjectDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+        'productAccessDescriptor': ProductAccessDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+        'accessDisclaimer': True,
+        'categoryDescriptor': ProductCategoryDescriptor.MHR.value,
+        'productName': product_model.description,
+        'emailAddresses': recipient_emails,
+        'remarks': reject_reason,
+        'contactType': contact_type
+    }
+    return data

--- a/auth-api/tests/unit/services/test_product.py
+++ b/auth-api/tests/unit/services/test_product.py
@@ -31,6 +31,7 @@ from auth_api.services import User as UserService
 from auth_api.services.activity_log_publisher import ActivityLogPublisher
 
 from auth_api.utils.enums import ActivityAction, KeycloakGroupActions, ProductCode, ProductSubscriptionStatus, Status
+from auth_api.utils.notifications import ProductSubscriptionInfo
 from tests.utilities.factory_scenarios import KeycloakScenario, TestOrgInfo, TestUserInfo
 from tests.utilities.factory_utils import (
     factory_membership_model, factory_product_model, factory_user_model, patch_token_info)
@@ -69,10 +70,17 @@ def test_update_product_subscription(session, keycloak_mock, monkeypatch, test_n
     with patch.object(ActivityLogPublisher, 'publish_activity', return_value=None) as mock_alp:
         if has_contact:
             with patch.object(ContactLinkModel, 'find_by_user_id', return_value=MockPerson(contact=MockContact())):
-                ProductService.update_product_subscription(product_subscription.id, True, org._model.id)
+                ProductService.update_product_subscription(
+                    ProductSubscriptionInfo(product_subscription_id=product_subscription.id,
+                                            is_approved=True,
+                                            org_id=org._model.id))
+
         else:
             assert UserService.get_admin_emails_for_org(org.as_dict()['id']) == ''
-            ProductService.update_product_subscription(product_subscription.id, True, org._model.id)
+            ProductService.update_product_subscription(
+                ProductSubscriptionInfo(product_subscription_id=product_subscription.id,
+                                        is_approved=True,
+                                        org_id=org._model.id))
 
         mock_alp.assert_called_with(Activity(action=ActivityAction.ADD_PRODUCT_AND_SERVICE.value,
                                              org_id=ANY, value=ANY, id=ANY, name='Personal Property Registry'))

--- a/auth-api/tests/unit/services/test_product_notifications.py
+++ b/auth-api/tests/unit/services/test_product_notifications.py
@@ -32,7 +32,7 @@ from auth_api.utils.enums import (
     LoginSource, NotificationTypes, TaskAction, TaskRelationshipStatus, TaskRelationshipType, TaskStatus)
 from auth_api.utils.notifications import ProductAccessDescriptor, ProductCategoryDescriptor, ProductSubjectDescriptor
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestOrgProductsInfo, TestUserInfo
-from tests.utilities.factory_utils import factory_user_model, patch_token_info, factory_user_model_with_contact
+from tests.utilities.factory_utils import factory_user_model_with_contact, patch_token_info
 
 
 @pytest.mark.parametrize('org_product_info', [

--- a/auth-api/tests/unit/services/test_product_notifications.py
+++ b/auth-api/tests/unit/services/test_product_notifications.py
@@ -1,0 +1,411 @@
+# Copyright © 2023 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the notifications through the Product service.
+
+Test suite to ensure that the correct product notifications are generated.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import auth_api.utils.account_mailer
+from auth_api.models import ProductSubscription as ProductSubscriptionModel
+from auth_api.models import Task as TaskModel
+from auth_api.models.product_code import ProductCode as ProductCodeModel
+from auth_api.services import Org as OrgService
+from auth_api.services import Product as ProductService
+from auth_api.services import Task as TaskService
+from auth_api.services.user import User as UserService
+from auth_api.utils.enums import (
+    LoginSource, NotificationTypes, TaskAction, TaskRelationshipStatus, TaskRelationshipType, TaskStatus)
+from auth_api.utils.notifications import ProductAccessDescriptor, ProductCategoryDescriptor, ProductSubjectDescriptor
+from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestOrgProductsInfo, TestUserInfo
+from tests.utilities.factory_utils import factory_user_model, patch_token_info, factory_user_model_with_contact
+
+
+@pytest.mark.parametrize('org_product_info', [
+    TestOrgProductsInfo.org_products_vs
+])
+@patch.object(auth_api.services.products, 'publish_to_mailer')
+def test_default_approved_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
+    """Assert product approved notification default is created."""
+    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_bceid_user['sub']
+    user_with_token['idp_userid'] = TestJwtClaims.public_bceid_user['idp_userid']
+    user = factory_user_model_with_contact(user_with_token)
+
+    patch_token_info(TestJwtClaims.public_bceid_user, monkeypatch)
+
+    org = OrgService.create_org(TestOrgInfo.org_premium, user_id=user.id)
+    assert org
+    dictionary = org.as_dict()
+    assert dictionary['name'] == TestOrgInfo.org_premium['name']
+
+    product_code = org_product_info['subscriptions'][0]['productCode']
+
+    # Subscribe to product
+    ProductService.create_product_subscription(org_id=dictionary['id'],
+                                               subscription_data=org_product_info,
+                                               skip_auth=True)
+
+    org_subscriptions = ProductSubscriptionModel.find_by_org_ids(org_ids=[dictionary['id']])
+    org_prod_sub = next(prod for prod in org_subscriptions
+                        if prod.product_code == product_code)
+
+    # Fetch products and confirm product subscription is present
+    token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.STAFF.value)
+    patch_token_info(token_info, monkeypatch)
+    all_subs = ProductService.get_all_product_subscription(org_id=dictionary['id'])
+
+    prod_sub = next(sub for sub in all_subs if sub.get('code') == product_code)
+
+    assert prod_sub
+    assert prod_sub['code'] == product_code
+
+    # Staff review task should have been created
+    task = TaskModel.find_by_task_relationship_id(
+        task_relationship_type=TaskRelationshipType.PRODUCT.value, relationship_id=org_prod_sub.id)
+
+    assert task
+    assert task.account_id == dictionary['id']
+    assert task.relationship_type == TaskRelationshipType.PRODUCT.value
+    assert task.relationship_status == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
+    assert task.relationship_id == org_prod_sub.id
+    assert task.action == TaskAction.PRODUCT_REVIEW.value
+
+    # Approve task and check for publish to mailer
+    task_info = {
+        'relationshipStatus': TaskRelationshipStatus.ACTIVE.value
+    }
+
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    with patch.object(UserService, 'get_admin_emails_for_org', return_value='test@test.com'):
+        TaskService.update_task(TaskService(task), task_info=task_info)
+
+        expected_data = {
+            'productName': product_code_model.description,
+            'emailAddresses': 'test@test.com'
+        }
+        mock_mailer.assert_called_with(NotificationTypes.DEFAULT_APPROVED_PRODUCT.value,
+                                       data=expected_data)
+
+
+@pytest.mark.parametrize('org_product_info', [
+    TestOrgProductsInfo.org_products_vs
+])
+@patch.object(auth_api.services.products, 'publish_to_mailer')
+def test_default_rejected_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
+    """Assert product rejected notification default is created."""
+    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_bceid_user['sub']
+    user_with_token['idp_userid'] = TestJwtClaims.public_bceid_user['idp_userid']
+    user = factory_user_model_with_contact(user_with_token)
+
+    patch_token_info(TestJwtClaims.public_bceid_user, monkeypatch)
+
+    org = OrgService.create_org(TestOrgInfo.org_premium, user_id=user.id)
+    assert org
+    dictionary = org.as_dict()
+    assert dictionary['name'] == TestOrgInfo.org_premium['name']
+
+    product_code = org_product_info['subscriptions'][0]['productCode']
+
+    # Subscribe to product
+    ProductService.create_product_subscription(org_id=dictionary['id'],
+                                               subscription_data=org_product_info,
+                                               skip_auth=True)
+
+    org_subscriptions = ProductSubscriptionModel.find_by_org_ids(org_ids=[dictionary['id']])
+    org_prod_sub = next(prod for prod in org_subscriptions
+                        if prod.product_code == product_code)
+
+    # Fetch products and confirm product subscription is present
+    token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.STAFF.value)
+    patch_token_info(token_info, monkeypatch)
+    all_subs = ProductService.get_all_product_subscription(org_id=dictionary['id'])
+
+    prod_sub = next(sub for sub in all_subs if sub.get('code') == product_code)
+
+    assert prod_sub
+    assert prod_sub['code'] == product_code
+
+    # Staff review task should have been created
+    task = TaskModel.find_by_task_relationship_id(
+        task_relationship_type=TaskRelationshipType.PRODUCT.value, relationship_id=org_prod_sub.id)
+
+    assert task
+    assert task.account_id == dictionary['id']
+    assert task.relationship_type == TaskRelationshipType.PRODUCT.value
+    assert task.relationship_status == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
+    assert task.relationship_id == org_prod_sub.id
+    assert task.action == TaskAction.PRODUCT_REVIEW.value
+
+    # Approve task and check for publish to mailer
+    task_info = {
+        'relationshipStatus': TaskRelationshipStatus.REJECTED.value
+    }
+
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    with patch.object(UserService, 'get_admin_emails_for_org', return_value='test@test.com'):
+        TaskService.update_task(TaskService(task), task_info=task_info)
+
+        expected_data = {
+            'productName': product_code_model.description,
+            'emailAddresses': 'test@test.com'
+        }
+        mock_mailer.assert_called_with(NotificationTypes.DEFAULT_REJECTED_PRODUCT.value,
+                                       data=expected_data)
+
+
+@pytest.mark.parametrize('org_product_info', [
+    TestOrgProductsInfo.mhr_qs_lawyer_and_notaries,
+    TestOrgProductsInfo.mhr_qs_home_manufacturers,
+    TestOrgProductsInfo.mhr_qs_home_dealers
+])
+@patch.object(auth_api.services.products, 'publish_to_mailer')
+def test_detailed_approved_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
+    """Assert product approved notification with details is created."""
+    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_bceid_user['sub']
+    user_with_token['idp_userid'] = TestJwtClaims.public_bceid_user['idp_userid']
+    user = factory_user_model_with_contact(user_with_token)
+
+    patch_token_info(TestJwtClaims.public_bceid_user, monkeypatch)
+
+    org = OrgService.create_org(TestOrgInfo.org_premium, user_id=user.id)
+    assert org
+    dictionary = org.as_dict()
+    assert dictionary['name'] == TestOrgInfo.org_premium['name']
+
+    product_code = org_product_info['subscriptions'][0]['productCode']
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    if product_code_model.parent_code:
+        # Create parent product subscription
+        ProductService.create_product_subscription(org_id=dictionary['id'],
+                                                   subscription_data={'subscriptions': [
+                                                       {'productCode': product_code_model.parent_code}]},
+                                                   skip_auth=True)
+
+    # Subscribe to product
+    ProductService.create_product_subscription(org_id=dictionary['id'],
+                                               subscription_data=org_product_info,
+                                               skip_auth=True)
+
+    org_subscriptions = ProductSubscriptionModel.find_by_org_ids(org_ids=[dictionary['id']])
+    org_prod_sub = next(prod for prod in org_subscriptions
+                        if prod.product_code == product_code)
+
+    # Fetch products and confirm product subscription is present
+    token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.STAFF.value)
+    patch_token_info(token_info, monkeypatch)
+    all_subs = ProductService.get_all_product_subscription(org_id=dictionary['id'])
+
+    prod_sub = next(sub for sub in all_subs if sub.get('code') == product_code)
+
+    assert prod_sub
+    assert prod_sub['code'] == product_code
+
+    # Staff review task should have been created
+    task = TaskModel.find_by_task_relationship_id(
+        task_relationship_type=TaskRelationshipType.PRODUCT.value, relationship_id=org_prod_sub.id)
+
+    assert task
+    assert task.account_id == dictionary['id']
+    assert task.relationship_type == TaskRelationshipType.PRODUCT.value
+    assert task.relationship_status == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
+    assert task.relationship_id == org_prod_sub.id
+    assert task.action == TaskAction.QUALIFIED_SUPPLIER_REVIEW.value
+
+    # Approve task and check for publish to mailer
+    task_info = {
+        'relationshipStatus': TaskRelationshipStatus.ACTIVE.value
+    }
+
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    with patch.object(UserService, 'get_admin_emails_for_org', return_value='test@test.com'):
+        TaskService.update_task(TaskService(task), task_info=task_info)
+
+        expected_data = {
+            'subjectDescriptor': ProductSubjectDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+            'productAccessDescriptor': ProductAccessDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+            'categoryDescriptor': ProductCategoryDescriptor.MHR.value,
+            'isReapproved': False,
+            'productName': product_code_model.description,
+            'emailAddresses': 'test@test.com'
+        }
+        mock_mailer.assert_called_with(NotificationTypes.DETAILED_APPROVED_PRODUCT.value,
+                                       data=expected_data)
+
+
+@pytest.mark.parametrize('org_product_info, contact_type', [
+    (TestOrgProductsInfo.mhr_qs_lawyer_and_notaries, 'BCOL'),
+    (TestOrgProductsInfo.mhr_qs_home_manufacturers, 'BCREG'),
+    (TestOrgProductsInfo.mhr_qs_home_dealers, 'BCREG')
+])
+@patch.object(auth_api.services.products, 'publish_to_mailer')
+def test_detailed_rejected_notification(mock_mailer, session, auth_mock, keycloak_mock,
+                                        monkeypatch, org_product_info, contact_type):
+    """Assert product rejected notification with details is created."""
+    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_bceid_user['sub']
+    user_with_token['idp_userid'] = TestJwtClaims.public_bceid_user['idp_userid']
+    user = factory_user_model_with_contact(user_with_token)
+
+    patch_token_info(TestJwtClaims.public_bceid_user, monkeypatch)
+
+    org = OrgService.create_org(TestOrgInfo.org_premium, user_id=user.id)
+    assert org
+    dictionary = org.as_dict()
+    assert dictionary['name'] == TestOrgInfo.org_premium['name']
+
+    product_code = org_product_info['subscriptions'][0]['productCode']
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    if product_code_model.parent_code:
+        # Create parent product subscription
+        ProductService.create_product_subscription(org_id=dictionary['id'],
+                                                   subscription_data={'subscriptions': [
+                                                       {'productCode': product_code_model.parent_code}]},
+                                                   skip_auth=True)
+
+    # Subscribe to product
+    ProductService.create_product_subscription(org_id=dictionary['id'],
+                                               subscription_data=org_product_info,
+                                               skip_auth=True)
+
+    org_subscriptions = ProductSubscriptionModel.find_by_org_ids(org_ids=[dictionary['id']])
+    org_prod_sub = next(prod for prod in org_subscriptions
+                        if prod.product_code == product_code)
+
+    # Fetch products and confirm product subscription is present
+    token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.STAFF.value)
+    patch_token_info(token_info, monkeypatch)
+    all_subs = ProductService.get_all_product_subscription(org_id=dictionary['id'])
+
+    prod_sub = next(sub for sub in all_subs if sub.get('code') == product_code)
+
+    assert prod_sub
+    assert prod_sub['code'] == product_code
+
+    # Staff review task should have been created
+    task = TaskModel.find_by_task_relationship_id(
+        task_relationship_type=TaskRelationshipType.PRODUCT.value, relationship_id=org_prod_sub.id)
+
+    assert task
+    assert task.account_id == dictionary['id']
+    assert task.relationship_type == TaskRelationshipType.PRODUCT.value
+    assert task.relationship_status == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
+    assert task.relationship_id == org_prod_sub.id
+    assert task.action == TaskAction.QUALIFIED_SUPPLIER_REVIEW.value
+
+    # Approve task and check for publish to mailer
+    task_info = {
+        'relationshipStatus': TaskRelationshipStatus.REJECTED.value,
+        'remarks': ['Test remark']
+    }
+
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    with patch.object(UserService, 'get_admin_emails_for_org', return_value='test@test.com'):
+        task = TaskService.update_task(TaskService(task), task_info=task_info)
+        task_dict = task.as_dict()
+
+        expected_data = {
+            'subjectDescriptor': ProductSubjectDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+            'productAccessDescriptor': ProductAccessDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+            'categoryDescriptor': ProductCategoryDescriptor.MHR.value,
+            'accessDisclaimer': True,
+            'productName': product_code_model.description,
+            'emailAddresses': 'test@test.com',
+            'contactType': contact_type,
+            'remarks': task_dict['remarks'][0]
+        }
+        mock_mailer.assert_called_with(NotificationTypes.DETAILED_REJECTED_PRODUCT.value,
+                                       data=expected_data)
+
+
+@pytest.mark.parametrize('org_product_info', [
+    TestOrgProductsInfo.mhr_qs_lawyer_and_notaries,
+    TestOrgProductsInfo.mhr_qs_home_manufacturers,
+    TestOrgProductsInfo.mhr_qs_home_dealers
+])
+@patch.object(auth_api.services.products, 'publish_to_mailer')
+def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
+    """Assert product approved notification with details is created."""
+    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_bceid_user['sub']
+    user_with_token['idp_userid'] = TestJwtClaims.public_bceid_user['idp_userid']
+    user = factory_user_model_with_contact(user_with_token)
+
+    patch_token_info(TestJwtClaims.public_bceid_user, monkeypatch)
+
+    org = OrgService.create_org(TestOrgInfo.org_premium, user_id=user.id)
+    assert org
+    dictionary = org.as_dict()
+    assert dictionary['name'] == TestOrgInfo.org_premium['name']
+
+    product_code = org_product_info['subscriptions'][0]['productCode']
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    if product_code_model.parent_code:
+        # Create parent product subscription
+        ProductService.create_product_subscription(org_id=dictionary['id'],
+                                                   subscription_data={'subscriptions': [
+                                                       {'productCode': product_code_model.parent_code}]},
+                                                   skip_auth=True)
+
+    # Subscribe to product
+    ProductService.create_product_subscription(org_id=dictionary['id'],
+                                               subscription_data=org_product_info,
+                                               skip_auth=True)
+
+    org_subscriptions = ProductSubscriptionModel.find_by_org_ids(org_ids=[dictionary['id']])
+    org_prod_sub = next(prod for prod in org_subscriptions
+                        if prod.product_code == product_code)
+
+    # Fetch products and confirm product subscription is present
+    token_info = TestJwtClaims.get_test_user(sub=user.keycloak_guid, source=LoginSource.STAFF.value)
+    patch_token_info(token_info, monkeypatch)
+    all_subs = ProductService.get_all_product_subscription(org_id=dictionary['id'])
+
+    prod_sub = next(sub for sub in all_subs if sub.get('code') == product_code)
+
+    assert prod_sub
+    assert prod_sub['code'] == product_code
+
+    # Staff review task should have been created
+    task = TaskModel.find_by_task_relationship_id(
+        task_relationship_type=TaskRelationshipType.PRODUCT.value, relationship_id=org_prod_sub.id)
+
+    assert task
+    assert task.account_id == dictionary['id']
+    assert task.relationship_type == TaskRelationshipType.PRODUCT.value
+    assert task.relationship_status == TaskRelationshipStatus.PENDING_STAFF_REVIEW.value
+    assert task.relationship_id == org_prod_sub.id
+    assert task.action == TaskAction.QUALIFIED_SUPPLIER_REVIEW.value
+
+    # Approve task and check for publish to mailer
+    task_info = {
+        'relationshipStatus': TaskRelationshipStatus.PENDING_STAFF_REVIEW.value,
+        'status': TaskStatus.HOLD.value
+    }
+
+    with patch.object(UserService, 'get_admin_emails_for_org', return_value='test@test.com'):
+        TaskService.update_task(TaskService(task), task_info=task_info)
+        mock_mailer.assert_not_called

--- a/queue_services/account-mailer/src/account_mailer/email_templates/product_approved_notification_detailed.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/product_approved_notification_detailed.html
@@ -1,0 +1,11 @@
+# You've been approved for {{ product_access_descriptor }} access to {{ category_descriptor }}.
+
+{% if is_reapproved %}
+BC Registries staff have reviewed your previously-rejected application to have {{ product_name }} access to {{ category_descriptor}}, and you have been approved.
+
+{% else %}
+BC Registries staff have reviewed your application to have {{ product_name }} access to {{ category_descriptor}}, and you have been approved.
+
+{% endif %}
+
+[Log in to access {{ category_descriptor }}]({{ url }})

--- a/queue_services/account-mailer/src/account_mailer/email_templates/product_rejected_notification_detailed.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/product_rejected_notification_detailed.html
@@ -1,0 +1,21 @@
+# Your application for {{ product_access_descriptor }} access to {{ category_descriptor }} has been rejected.
+
+{% if access_disclaimer %}
+
+You will continue to have search access only to {{ category_descriptor }}.
+
+{% endif %}
+
+BC Registries staff have reviewed your application to have {{ product_name }} access to {{ category_descriptor }}, and you have been rejected for the following reason(s):
+
+{{ remarks }}
+
+{% if contact_type == 'BCOL' %}
+Please contact BC OnLine at 1-800-663-6102 or email bcolhelp@gov.bc.ca to discuss further actions.
+{% else %}
+Please contact BC Registries at 1-877-526-1526 or email bcregistries@gov.bc.ca to discuss further actions.
+{% endif %}
+
+You can now submit a new {{ product_access_descriptor }} access request from {{ category_descriptor }} dashboard once you have all the required information.
+
+[Log in to access {{ category_descriptor }}]({{ url }})

--- a/queue_services/account-mailer/src/account_mailer/enums.py
+++ b/queue_services/account-mailer/src/account_mailer/enums.py
@@ -103,9 +103,9 @@ class SubjectType(Enum):
     PROD_PACKAGE_REJECTED_NOTIFICATION = '[BC Registries and Online Services] YOUR ACTION REQUIRED: ' \
                                          'Your Product Request {product_name} Has Been Rejected'
     PRODUCT_APPROVED_NOTIFICATION_DETAILED = '[BC Registries and Online Services] Your {subject_descriptor} ' \
-                                                  'Access Has Been Approved'
+                                             'Access Has Been Approved'
     PRODUCT_REJECTED_NOTIFICATION_DETAILED = '[BC Registries and Online Services] Your {subject_descriptor} ' \
-                                                  'Access Has Been Rejected'
+                                             'Access Has Been Rejected'
     RESUBMIT_BCEID_ORG_NOTIFICATION = '[BC Registries and Online Services] YOUR ACTION REQUIRED: ' \
                                       'Update your information.'
     RESUBMIT_BCEID_ADMIN_NOTIFICATION = '[BC Registries and Online Services] YOUR ACTION REQUIRED: ' \

--- a/queue_services/account-mailer/src/account_mailer/enums.py
+++ b/queue_services/account-mailer/src/account_mailer/enums.py
@@ -53,6 +53,8 @@ class MessageType(Enum):
     GOVM_REJECTED_NOTIFICATION = 'bc.registry.auth.govmRejectedNotification'
     PROD_PACKAGE_APPROVED_NOTIFICATION = 'bc.registry.auth.prodPackageApprovedNotification'
     PROD_PACKAGE_REJECTED_NOTIFICATION = 'bc.registry.auth.prodPackageRejectedNotification'
+    PRODUCT_APPROVED_NOTIFICATION_DETAILED = 'bc.registry.auth.productApprovedNotificationDetailed'
+    PRODUCT_REJECTED_NOTIFICATION_DETAILED = 'bc.registry.auth.productRejectedNotificationDetailed'
     RESUBMIT_BCEID_ORG_NOTIFICATION = 'bc.registry.auth.resubmitBceidOrg'
     RESUBMIT_BCEID_ADMIN_NOTIFICATION = 'bc.registry.auth.resubmitBceidAdmin'
     AFFILIATION_INVITATION_REQUEST = 'bc.registry.auth.affiliationInvitationRequest'
@@ -100,6 +102,10 @@ class SubjectType(Enum):
                                          '{product_name} Has Been Approved'
     PROD_PACKAGE_REJECTED_NOTIFICATION = '[BC Registries and Online Services] YOUR ACTION REQUIRED: ' \
                                          'Your Product Request {product_name} Has Been Rejected'
+    PRODUCT_APPROVED_NOTIFICATION_DETAILED = '[BC Registries and Online Services] Your {subject_descriptor} ' \
+                                                  'Access Has Been Approved'
+    PRODUCT_REJECTED_NOTIFICATION_DETAILED = '[BC Registries and Online Services] Your {subject_descriptor} ' \
+                                                  'Access Has Been Rejected'
     RESUBMIT_BCEID_ORG_NOTIFICATION = '[BC Registries and Online Services] YOUR ACTION REQUIRED: ' \
                                       'Update your information.'
     RESUBMIT_BCEID_ADMIN_NOTIFICATION = '[BC Registries and Online Services] YOUR ACTION REQUIRED: ' \
@@ -129,6 +135,8 @@ class TitleType(Enum):
     GOVM_REJECTED_NOTIFICATION = 'Your BC Registries Account Has Been Rejected'
     PROD_PACKAGE_APPROVED_NOTIFICATION = 'Your Product Request Has Been Approved'
     PROD_PACKAGE_REJECTED_NOTIFICATION = 'Your Product Request Has Been Rejected'
+    PRODUCT_APPROVED_NOTIFICATION_DETAILED = 'Your Product Request Has Been Approved'
+    PRODUCT_REJECTED_NOTIFICATION_DETAILED = 'Your Product Request Has Been Rejected'
     RESUBMIT_BCEID_ORG_NOTIFICATION = 'Your Account Creation Request is On hold '
     RESUBMIT_BCEID_ADMIN_NOTIFICATION = 'Your Team Member Request is On hold '
     AFFILIATION_INVITATION = 'Invitation to manage a business with your account.'
@@ -170,6 +178,8 @@ class TemplateType(Enum):
     GOVM_REJECTED_NOTIFICATION_TEMPLATE_NAME = 'govm_rejected_notification'
     PROD_PACKAGE_APPROVED_NOTIFICATION_TEMPLATE_NAME = 'prod_package_approved_notification'
     PROD_PACKAGE_REJECTED_NOTIFICATION_TEMPLATE_NAME = 'prod_package_rejected_notification'
+    PRODUCT_APPROVED_NOTIFICATION_DETAILED_TEMPLATE_NAME = 'product_approved_notification_detailed'
+    PRODUCT_REJECTED_NOTIFICATION_DETAILED_TEMPLATE_NAME = 'product_rejected_notification_detailed'
     RESUBMIT_BCEID_ORG_NOTIFICATION_TEMPLATE_NAME = 'resubmit_bceid_org'
     RESUBMIT_BCEID_ADMIN_NOTIFICATION_TEMPLATE_NAME = 'resubmit_bceid_admin'
     AFFILIATION_INVITATION_REQUEST_TEMPLATE_NAME = 'affiliation_invitation_request'

--- a/queue_services/account-mailer/src/account_mailer/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/worker.py
@@ -219,6 +219,25 @@ async def process_event(event_message: dict, flask_app):
                     'is_authorized': email_msg.get('isAuthorized', None),
                     'additional_message': email_msg.get('additionalMessage', None)
                 })
+        elif message_type in {MessageType.PRODUCT_APPROVED_NOTIFICATION_DETAILED.value,
+                              MessageType.PRODUCT_REJECTED_NOTIFICATION_DETAILED.value}:
+            subject_descriptor = email_msg.get('subjectDescriptor')
+            subject_type = SubjectType[MessageType(message_type).name].value
+            email_dict = common_mailer.process(
+                **{
+                    'org_id': None,
+                    'recipients': email_msg.get('emailAddresses'),
+                    'template_name': TemplateType[f'{MessageType(message_type).name}_TEMPLATE_NAME'].value,
+                    'subject': subject_type.format(subject_descriptor=subject_descriptor),
+                    'logo_url': logo_url,
+                    'product_access_descriptor': email_msg.get('productAccessDescriptor'),
+                    'category_descriptor': email_msg.get('categoryDescriptor'),
+                    'is_reapproved': email_msg.get('isReapproved', None),
+                    'product_name': email_msg.get('productName', None),
+                    'access_disclaimer': email_msg.get('accessDisclaimer', None),
+                    'remarks': email_msg.get('remarks', None),
+                    'contact_type': email_msg.get('contactType', None)
+                })
 
         else:
             if any(x for x in MessageType if x.value == message_type):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17525
https://github.com/bcgov/entity/issues/17526
https://github.com/bcgov/entity/issues/17527

*Description of changes:*
- Product subscription qualified supplier emails - approved / rejected / re-approved
- refactor to fall back on default notifications used by other product codes
- refactor adding data classes for some methods that have a large amount of params
- fix an existing issue where putting a task on hold would send a rejection email
- tests specifically to test messages for mailer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
