### PR TITLE
17528 - Qualified supplier confirmation email

### DIFF
--- a/auth-api/src/auth_api/services/products.py
+++ b/auth-api/src/auth_api/services/products.py
@@ -137,6 +137,11 @@ class Product:
                                                                   user_id=user.id,
                                                                   external_source_id=external_source_id
                                                                   ))
+                    Product._send_product_subscription_confirmation(ProductNotificationInfo(
+                        product_model=product_model,
+                        product_sub_model=product_subscription,
+                        is_confirmation=True
+                    ), org.id)
 
             else:
                 raise BusinessException(Error.DATA_NOT_FOUND, None)
@@ -145,6 +150,13 @@ class Product:
             db.session.commit()
 
         return Product.get_all_product_subscription(org_id=org_id, skip_auth=True)
+
+    @staticmethod
+    def _send_product_subscription_confirmation(product_notification_info: ProductNotificationInfo, org_id: int):
+        admin_emails = UserService.get_admin_emails_for_org(org_id)
+        product_notification_info.recipient_emails = admin_emails
+
+        Product.send_product_subscription_notification(product_notification_info)
 
     @staticmethod
     def _update_parent_subscription(org_id, sub_product_model, subscription_status):

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -349,6 +349,6 @@ class NotificationTypes(Enum):
 
     DEFAULT_APPROVED_PRODUCT = 'prodPackageApprovedNotification'
     DEFAULT_REJECTED_PRODUCT = 'prodPackageRejectedNotification'
-    DETAILED_CONFIRMATION_PRODUCT = 'productConfirmationNotificationDetailed'
+    DETAILED_CONFIRMATION_PRODUCT = 'productConfirmationNotification'
     DETAILED_APPROVED_PRODUCT = 'productApprovedNotificationDetailed'
     DETAILED_REJECTED_PRODUCT = 'productRejectedNotificationDetailed'

--- a/auth-api/tests/unit/services/test_product_notifications.py
+++ b/auth-api/tests/unit/services/test_product_notifications.py
@@ -30,7 +30,8 @@ from auth_api.services import Task as TaskService
 from auth_api.services.user import User as UserService
 from auth_api.utils.enums import (
     LoginSource, NotificationTypes, TaskAction, TaskRelationshipStatus, TaskRelationshipType, TaskStatus)
-from auth_api.utils.notifications import ProductAccessDescriptor, ProductCategoryDescriptor, ProductSubjectDescriptor
+from auth_api.utils.notifications import (
+    NotificationAttachmentType, ProductAccessDescriptor, ProductCategoryDescriptor, ProductSubjectDescriptor)
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestOrgProductsInfo, TestUserInfo
 from tests.utilities.factory_utils import factory_user_model_with_contact, patch_token_info
 
@@ -347,7 +348,7 @@ def test_detailed_rejected_notification(mock_mailer, session, auth_mock, keycloa
 ])
 @patch.object(auth_api.services.products, 'publish_to_mailer')
 def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
-    """Assert product approved notification with details is created."""
+    """Assert product notification is not created for on hold state."""
     user_with_token = TestUserInfo.user_bceid_tester
     user_with_token['keycloak_guid'] = TestJwtClaims.public_bceid_user['sub']
     user_with_token['idp_userid'] = TestJwtClaims.public_bceid_user['idp_userid']
@@ -400,7 +401,7 @@ def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monke
     assert task.relationship_id == org_prod_sub.id
     assert task.action == TaskAction.QUALIFIED_SUPPLIER_REVIEW.value
 
-    # Approve task and check for publish to mailer
+    # Hold task and check publish to mailer is not called
     task_info = {
         'relationshipStatus': TaskRelationshipStatus.PENDING_STAFF_REVIEW.value,
         'status': TaskStatus.HOLD.value
@@ -409,3 +410,91 @@ def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monke
     with patch.object(UserService, 'get_admin_emails_for_org', return_value='test@test.com'):
         TaskService.update_task(TaskService(task), task_info=task_info)
         mock_mailer.assert_not_called
+
+
+@pytest.mark.parametrize('org_product_info, contact_type', [
+    (TestOrgProductsInfo.mhr_qs_lawyer_and_notaries, 'BCOL'),
+    (TestOrgProductsInfo.mhr_qs_home_manufacturers, 'BCREG'),
+    (TestOrgProductsInfo.mhr_qs_home_dealers, 'BCREG')
+])
+@patch.object(auth_api.services.products, 'publish_to_mailer')
+def test_confirmation_notification(mock_mailer, session, auth_mock, keycloak_mock,
+                                   monkeypatch, org_product_info, contact_type):
+    """Assert product confirmation notification is properly created."""
+    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_bceid_user['sub']
+    user_with_token['idp_userid'] = TestJwtClaims.public_bceid_user['idp_userid']
+    user = factory_user_model_with_contact(user_with_token)
+
+    patch_token_info(TestJwtClaims.public_bceid_user, monkeypatch)
+
+    org = OrgService.create_org(TestOrgInfo.org_premium, user_id=user.id)
+    assert org
+    dictionary = org.as_dict()
+    assert dictionary['name'] == TestOrgInfo.org_premium['name']
+
+    product_code = org_product_info['subscriptions'][0]['productCode']
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    if product_code_model.parent_code:
+        # Create parent product subscription
+        ProductService.create_product_subscription(org_id=dictionary['id'],
+                                                   subscription_data={'subscriptions': [
+                                                       {'productCode': product_code_model.parent_code}]},
+                                                   skip_auth=True)
+
+    with patch.object(UserService, 'get_admin_emails_for_org', return_value='test@test.com'):
+        # Subscribe to product
+        ProductService.create_product_subscription(org_id=dictionary['id'],
+                                                   subscription_data=org_product_info,
+                                                   skip_auth=True)
+
+        expected_data = {
+            'subjectDescriptor': ProductSubjectDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+            'productAccessDescriptor': ProductAccessDescriptor.MHR_QUALIFIED_SUPPLIER.value,
+            'categoryDescriptor': ProductCategoryDescriptor.MHR.value,
+            'productName': product_code_model.description,
+            'emailAddresses': 'test@test.com',
+            'contactType': contact_type,
+            'hasAgreementAttachment': True,
+            'attachmentType': NotificationAttachmentType.MHR_QS.value
+        }
+
+        mock_mailer.assert_called_with(NotificationTypes.DETAILED_CONFIRMATION_PRODUCT.value,
+                                       data=expected_data)
+
+
+@pytest.mark.parametrize('org_product_info', [
+    TestOrgProductsInfo.org_products_vs
+])
+@patch.object(auth_api.services.products, 'publish_to_mailer')
+def test_no_confirmation_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
+    """Assert product confirmation notification not created."""
+    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token['keycloak_guid'] = TestJwtClaims.public_bceid_user['sub']
+    user_with_token['idp_userid'] = TestJwtClaims.public_bceid_user['idp_userid']
+    user = factory_user_model_with_contact(user_with_token)
+
+    patch_token_info(TestJwtClaims.public_bceid_user, monkeypatch)
+
+    org = OrgService.create_org(TestOrgInfo.org_premium, user_id=user.id)
+    assert org
+    dictionary = org.as_dict()
+    assert dictionary['name'] == TestOrgInfo.org_premium['name']
+
+    product_code = org_product_info['subscriptions'][0]['productCode']
+    product_code_model = ProductCodeModel.find_by_code(product_code)
+
+    if product_code_model.parent_code:
+        # Create parent product subscription
+        ProductService.create_product_subscription(org_id=dictionary['id'],
+                                                   subscription_data={'subscriptions': [
+                                                       {'productCode': product_code_model.parent_code}]},
+                                                   skip_auth=True)
+
+    with patch.object(UserService, 'get_admin_emails_for_org', return_value='test@test.com'):
+        # Subscribe to product
+        ProductService.create_product_subscription(org_id=dictionary['id'],
+                                                   subscription_data=org_product_info,
+                                                   skip_auth=True)
+        mock_mailer.assert_not_called()

--- a/queue_services/account-mailer/src/account_mailer/config.py
+++ b/queue_services/account-mailer/src/account_mailer/config.py
@@ -138,6 +138,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     AUTH_WEB_TOKEN_CONFIRM_PATH = os.getenv('AUTH_WEB_TOKEN_CONFIRM_PATH')
     # PAD TOS PDF file name.
     PAD_TOS_FILE = os.getenv('PAD_TOS_FILE', 'BCROS-Business-Pre-Authorized-Debit-Agreement.pdf')
+    MHR_QS_AGREEMENT_FILE = os.getenv('MHR_QS_AGREEMENT_FILE', 'MHR_QualifiedSuppliersAgreement.pdf')
 
     # If any value is present in this flag, starts up a keycloak docker
     USE_TEST_KEYCLOAK_DOCKER = os.getenv('USE_TEST_KEYCLOAK_DOCKER', None)

--- a/queue_services/account-mailer/src/account_mailer/config.py
+++ b/queue_services/account-mailer/src/account_mailer/config.py
@@ -138,6 +138,7 @@ class _Config():  # pylint: disable=too-few-public-methods
     AUTH_WEB_TOKEN_CONFIRM_PATH = os.getenv('AUTH_WEB_TOKEN_CONFIRM_PATH')
     # PAD TOS PDF file name.
     PAD_TOS_FILE = os.getenv('PAD_TOS_FILE', 'BCROS-Business-Pre-Authorized-Debit-Agreement.pdf')
+    # MHR QUALIFIED SUPPLIER PDF File name
     MHR_QS_AGREEMENT_FILE = os.getenv('MHR_QS_AGREEMENT_FILE', 'MHR_QualifiedSuppliersAgreement.pdf')
 
     # If any value is present in this flag, starts up a keycloak docker

--- a/queue_services/account-mailer/src/account_mailer/email_processors/product_confirmation.py
+++ b/queue_services/account-mailer/src/account_mailer/email_processors/product_confirmation.py
@@ -1,0 +1,61 @@
+# Copyright © 2023 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A processor for the product confirmation email."""
+
+import base64
+
+from flask import current_app
+
+from account_mailer.enums import AttachmentTypes
+from account_mailer.services import minio_service
+
+
+def process_attachment(email_dict: dict, attachment_type: str) -> dict:
+    """Process any attachments for a product confirmation notification."""
+    if attachment_type is None:
+        return email_dict
+
+    attachment_name = _get_attachment_name(attachment_type)
+
+    if attachment_name is None:
+        return email_dict
+
+    pdf_attachment = _get_pdf(attachment_name)
+    email_dict['content']['attachments'] = [
+        {
+            'fileName': attachment_name,
+            'fileBytes': pdf_attachment.decode('utf-8'),
+            'fileUrl': '',
+            'attachOrder': '1'
+        }
+    ]
+
+    return email_dict
+
+
+def _get_attachment_name(attachment_type: str) -> str:
+    if attachment_type == AttachmentTypes.QUALIFIED_SUPPLIER:
+        return current_app.config['MHR_QS_AGREEMENT_FILE']
+
+    return None
+
+
+def _get_pdf(file_name: str):
+    read_pdf = None
+    mino_object = minio_service.MinioService.get_minio_file(current_app.config['MINIO_BUCKET'],
+                                                            file_name)
+    if mino_object:
+        read_pdf = base64.b64encode(mino_object.data)
+
+    return read_pdf

--- a/queue_services/account-mailer/src/account_mailer/email_processors/product_confirmation.py
+++ b/queue_services/account-mailer/src/account_mailer/email_processors/product_confirmation.py
@@ -45,7 +45,7 @@ def process_attachment(email_dict: dict, attachment_type: str) -> dict:
 
 
 def _get_attachment_name(attachment_type: str) -> str:
-    if attachment_type == AttachmentTypes.QUALIFIED_SUPPLIER:
+    if attachment_type == AttachmentTypes.QUALIFIED_SUPPLIER.value:
         return current_app.config['MHR_QS_AGREEMENT_FILE']
 
     return None

--- a/queue_services/account-mailer/src/account_mailer/email_templates/product_confirmation_notification.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/product_confirmation_notification.html
@@ -1,0 +1,15 @@
+# Your application for {{ product_access_descriptor }} access to {{ category_descriptor }} has been received.
+
+BC Registries staff have received your application to have {{ product_name }} access to {{ category_descriptor }}, and your request is under review.
+
+{% if has_agreement_attachment %}
+Please find a copy of the {{ product_access_descriptor }} Agreement attached for your records.
+{% endif %}
+
+You will be notified by email once your application has been reviewed.
+
+{% if contact_type == 'BCOL' %}
+Please contact BC OnLine at 1-800-663-6102 or email bcolhelp@gov.bc.ca to discuss further actions.
+{% else %}
+Please contact BC Registries at 1-877-526-1526 or email bcregistries@gov.bc.ca to discuss further actions.
+{% endif %}

--- a/queue_services/account-mailer/src/account_mailer/enums.py
+++ b/queue_services/account-mailer/src/account_mailer/enums.py
@@ -55,6 +55,7 @@ class MessageType(Enum):
     PROD_PACKAGE_REJECTED_NOTIFICATION = 'bc.registry.auth.prodPackageRejectedNotification'
     PRODUCT_APPROVED_NOTIFICATION_DETAILED = 'bc.registry.auth.productApprovedNotificationDetailed'
     PRODUCT_REJECTED_NOTIFICATION_DETAILED = 'bc.registry.auth.productRejectedNotificationDetailed'
+    PRODUCT_CONFIRMATION_NOTIFICATION = 'bc.registry.auth.productConfirmationNotification'
     RESUBMIT_BCEID_ORG_NOTIFICATION = 'bc.registry.auth.resubmitBceidOrg'
     RESUBMIT_BCEID_ADMIN_NOTIFICATION = 'bc.registry.auth.resubmitBceidAdmin'
     AFFILIATION_INVITATION_REQUEST = 'bc.registry.auth.affiliationInvitationRequest'
@@ -106,6 +107,8 @@ class SubjectType(Enum):
                                              'Access Has Been Approved'
     PRODUCT_REJECTED_NOTIFICATION_DETAILED = '[BC Registries and Online Services] Your {subject_descriptor} ' \
                                              'Access Has Been Rejected'
+    PRODUCT_CONFIRMATION_NOTIFICATION = '[BC Registries and Online Services] {subject_descriptor} ' \
+                                        'Application Confirmation'
     RESUBMIT_BCEID_ORG_NOTIFICATION = '[BC Registries and Online Services] YOUR ACTION REQUIRED: ' \
                                       'Update your information.'
     RESUBMIT_BCEID_ADMIN_NOTIFICATION = '[BC Registries and Online Services] YOUR ACTION REQUIRED: ' \
@@ -137,6 +140,7 @@ class TitleType(Enum):
     PROD_PACKAGE_REJECTED_NOTIFICATION = 'Your Product Request Has Been Rejected'
     PRODUCT_APPROVED_NOTIFICATION_DETAILED = 'Your Product Request Has Been Approved'
     PRODUCT_REJECTED_NOTIFICATION_DETAILED = 'Your Product Request Has Been Rejected'
+    PRODUCT_CONFIRMATION_NOTIFICATION = 'Your Product Request Application Has Been Received'
     RESUBMIT_BCEID_ORG_NOTIFICATION = 'Your Account Creation Request is On hold '
     RESUBMIT_BCEID_ADMIN_NOTIFICATION = 'Your Team Member Request is On hold '
     AFFILIATION_INVITATION = 'Invitation to manage a business with your account.'
@@ -180,6 +184,7 @@ class TemplateType(Enum):
     PROD_PACKAGE_REJECTED_NOTIFICATION_TEMPLATE_NAME = 'prod_package_rejected_notification'
     PRODUCT_APPROVED_NOTIFICATION_DETAILED_TEMPLATE_NAME = 'product_approved_notification_detailed'
     PRODUCT_REJECTED_NOTIFICATION_DETAILED_TEMPLATE_NAME = 'product_rejected_notification_detailed'
+    PRODUCT_CONFIRMATION_NOTIFICATION_TEMPLATE_NAME = 'product_confirmation_notification'
     RESUBMIT_BCEID_ORG_NOTIFICATION_TEMPLATE_NAME = 'resubmit_bceid_org'
     RESUBMIT_BCEID_ADMIN_NOTIFICATION_TEMPLATE_NAME = 'resubmit_bceid_admin'
     AFFILIATION_INVITATION_REQUEST_TEMPLATE_NAME = 'affiliation_invitation_request'
@@ -190,3 +195,9 @@ class Constants(Enum):
     """Constants."""
 
     RESET_PASSCODE_HEADER = 'BC Registries have generated a new passcode for your business.'
+
+
+class AttachmentTypes(Enum):
+    """Notification Attachment Types."""
+
+    QUALIFIED_SUPPLIER = 'QUALIFIED_SUPPLIER'

--- a/queue_services/account-mailer/src/account_mailer/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/worker.py
@@ -40,11 +40,11 @@ from flask import Flask  # pylint: disable=wrong-import-order
 
 from account_mailer import config  # pylint: disable=wrong-import-order
 from account_mailer.auth_utils import get_member_emails
-from account_mailer.email_processors import common_mailer  # pylint: disable=wrong-import-order
 from account_mailer.email_processors import ejv_failures  # pylint: disable=wrong-import-order
 from account_mailer.email_processors import pad_confirmation  # pylint: disable=wrong-import-order
 from account_mailer.email_processors import payment_completed  # pylint: disable=wrong-import-order
 from account_mailer.email_processors import refund_requested  # pylint: disable=wrong-import-order
+from account_mailer.email_processors import common_mailer, product_confirmation  # pylint: disable=wrong-import-order
 from account_mailer.enums import Constants, MessageType, SubjectType, TemplateType, TitleType
 from account_mailer.services import minio_service  # pylint: disable=wrong-import-order
 from account_mailer.services import notification_service  # pylint: disable=wrong-import-order
@@ -220,9 +220,11 @@ async def process_event(event_message: dict, flask_app):
                     'additional_message': email_msg.get('additionalMessage', None)
                 })
         elif message_type in {MessageType.PRODUCT_APPROVED_NOTIFICATION_DETAILED.value,
-                              MessageType.PRODUCT_REJECTED_NOTIFICATION_DETAILED.value}:
+                              MessageType.PRODUCT_REJECTED_NOTIFICATION_DETAILED.value,
+                              MessageType.PRODUCT_CONFIRMATION_NOTIFICATION.value}:
             subject_descriptor = email_msg.get('subjectDescriptor')
             subject_type = SubjectType[MessageType(message_type).name].value
+            attachment_type = email_msg.get('attachmentType', None)
             email_dict = common_mailer.process(
                 **{
                     'org_id': None,
@@ -236,8 +238,12 @@ async def process_event(event_message: dict, flask_app):
                     'product_name': email_msg.get('productName', None),
                     'access_disclaimer': email_msg.get('accessDisclaimer', None),
                     'remarks': email_msg.get('remarks', None),
-                    'contact_type': email_msg.get('contactType', None)
+                    'contact_type': email_msg.get('contactType', None),
+                    'has_agreement_attachment': email_msg.get('hasAgreementAttachment', None),
+                    'attachment_type': attachment_type
                 })
+
+            email_dict = product_confirmation.process_attachment(email_dict, attachment_type)
 
         else:
             if any(x for x in MessageType if x.value == message_type):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17528

*Description of changes:*
- qualified supplier agreement added to account mailer minio bucket as part of this update
- implement confirmation email for MHR qualified supplier product subscriptions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
