### PR TITLE
17332-Preserve ModalDialog Action Slot

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.4.16",
+      "version": "2.4.17",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/common/ModalDialog.vue
+++ b/auth-web/src/components/auth/common/ModalDialog.vue
@@ -50,15 +50,15 @@
 
       <!-- actions -->
       <v-card-actions v-if="showActions">
-        <span
-          id="help-button"
-          class="pl-2 pr-2 mr-auto"
-          @click.stop="openHelp()"
-        >
-          <v-icon>mdi-help-circle-outline</v-icon>
-          Help
-        </span>
         <slot name="actions">
+          <span
+            id="help-button"
+            class="pl-2 pr-2 mr-auto"
+            @click.stop="openHelp()"
+          >
+            <v-icon>mdi-help-circle-outline</v-icon>
+            Help
+          </span>
           <v-btn
             large
             color="success"


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17332

*Description of changes:*
* Relocate help button within `Actions` slot, so that the slot override is preserved. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
