### PR TITLE
17776 - Soft delete support for accepted affiliation invitations

### DIFF
--- a/auth-api/migrations/versions/2023_09_20_4a6eb0fcc93e_affiliation_invitation_deleted_flag.py
+++ b/auth-api/migrations/versions/2023_09_20_4a6eb0fcc93e_affiliation_invitation_deleted_flag.py
@@ -1,0 +1,25 @@
+"""affiliation invitation deleted flag
+
+Revision ID: 4a6eb0fcc93e
+Revises: 98bee9969323
+Create Date: 2023-09-20 10:32:24.804185
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '4a6eb0fcc93e'
+down_revision = '98bee9969323'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('affiliation_invitations', sa.Column('is_deleted', sa.Boolean(), nullable=False,
+                                                       server_default=sa.false()))
+
+
+def downgrade():
+    op.drop_column('affiliation_invitations', 'is_deleted')

--- a/auth-api/src/auth_api/models/affiliation_invitation.py
+++ b/auth-api/src/auth_api/models/affiliation_invitation.py
@@ -15,7 +15,7 @@
 
 from datetime import datetime, timedelta
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, or_
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, or_
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 
@@ -50,6 +50,7 @@ class AffiliationInvitation(BaseModel):  # pylint: disable=too-many-instance-att
     invitation_status_code = Column(ForeignKey('invitation_statuses.code'), nullable=False, default='PENDING')
     type = Column(ForeignKey('affiliation_invitation_types.code'), nullable=False, default='EMAIL')
     additional_message = Column(String(4000), nullable=True)
+    is_deleted = Column(Boolean(), default=False)
 
     invitation_status = relationship('InvitationStatus', foreign_keys=[invitation_status_code])
     sender = relationship('User', foreign_keys=[sender_id])
@@ -147,6 +148,8 @@ class AffiliationInvitation(BaseModel):  # pylint: disable=too-many-instance-att
         if search_filter.invitation_types:
             results = results.filter(AffiliationInvitation.type.in_(search_filter.invitation_types))
             filter_set = True
+
+        results = results.filter(AffiliationInvitation.is_deleted == search_filter.is_deleted)
 
         if not filter_set:
             raise ValueError('At least one filter has to be set!')

--- a/auth-api/src/auth_api/models/dataclass.py
+++ b/auth-api/src/auth_api/models/dataclass.py
@@ -52,6 +52,7 @@ class AffiliationInvitationSearch:  # pylint: disable=too-many-instance-attribut
     approver_id: Optional[str] = None
     entity_id: Optional[str] = None
     affiliation_id: Optional[str] = None
+    is_deleted: bool = False
 
 
 @dataclass

--- a/auth-api/src/auth_api/resources/v1/affiliation_invitation.py
+++ b/auth-api/src/auth_api/resources/v1/affiliation_invitation.py
@@ -105,8 +105,9 @@ def post_affiliation_invitation():
 @_jwt.requires_auth
 def get_affiliation_invitation(affiliation_invitation_id):
     """Get the affiliation invitation specified by the provided id."""
-    if not (affiliation_invitation := AffiliationInvitationService.
-            find_affiliation_invitation_by_id(affiliation_invitation_id)):
+    affiliation_invitation = AffiliationInvitationService.find_affiliation_invitation_by_id(affiliation_invitation_id)
+
+    if not affiliation_invitation or affiliation_invitation.as_dict().get('is_deleted'):
         response, status = {'message': 'The requested affiliation invitation could not be found.'}, \
             http_status.HTTP_404_NOT_FOUND
     else:

--- a/auth-api/src/auth_api/schemas/affiliation_invitation.py
+++ b/auth-api/src/auth_api/schemas/affiliation_invitation.py
@@ -30,7 +30,7 @@ class AffiliationInvitationSchema(BaseSchema):  # pylint: disable=too-many-ances
         model = AffiliationInvitationModel
         fields = (
             'id', 'from_org', 'to_org', 'business_identifier', 'recipient_email', 'sent_date', 'expires_on',
-            'accepted_date', 'status', 'token', 'type', 'affiliation_id', 'additional_message')
+            'accepted_date', 'status', 'token', 'type', 'affiliation_id', 'additional_message', 'is_deleted')
 
     from_org = fields.Nested('OrgSchema', only=('id', 'name', 'org_type'))
     to_org = fields.Nested('OrgSchema', only=('id', 'name', 'org_type'), allow_none=True, required=False)

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -369,12 +369,13 @@ class AffiliationInvitation:
         if not (invitation := AffiliationInvitationModel.find_invitation_by_id(invitation_id)):
             raise BusinessException(Error.DATA_NOT_FOUND, None)
 
-        if invitation.status == InvitationStatus.ACCEPTED.value:
-            raise BusinessException(Error.ACTIONED_AFFILIATION_INVITATION, None)
-
         check_auth(org_id=invitation.from_org_id, one_of_roles=(ADMIN, COORDINATOR, STAFF))
 
-        invitation.delete()
+        if invitation.status == InvitationStatus.ACCEPTED.value:
+            invitation.is_deleted = True
+            invitation.save()
+        else:
+            invitation.delete()
 
     @staticmethod
     def search_invitations(search_filter: AffiliationInvitationSearch, mask_email=True):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17776

*Description of changes:*
- add is_deleted flag to affiliation_invitations table (default to false)
- update DELETE to soft delete on accepted affiliation invitations
- update searches and GET to not return soft deleted affiliation invitations 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
