### PR TITLE
17777 - Remove 'business authorized' message

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.4.24",
+  "version": "2.4.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.4.24",
+      "version": "2.4.25",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.4.24",
+  "version": "2.4.25",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/manage-business/AffiliationAction.vue
+++ b/auth-web/src/components/auth/manage-business/AffiliationAction.vue
@@ -461,11 +461,21 @@ export default defineComponent({
       }
     }
 
-    const handleBusinessRedirect = (item): boolean => {
+    /** Remove Accepted affiliation invitations from business. */
+    const removeAcceptedAffiliationInvitations = (business: Business) => {
+      for (const affiliationInvitation of business.affiliationInvites) {
+        if (affiliationInvitation.status === AffiliationInvitationStatus.Accepted) {
+          AffiliationInvitationService.removeAffiliationInvitation(affiliationInvitation.id)
+        }
+      }
+    }
+
+    const handleBusinessRedirect = (item: Business): boolean => {
       if (isNameRequest(item)) {
         return false
       }
       if (isModernizedEntity(item)) {
+        removeAcceptedAffiliationInvitations(item)
         goToDashboard(item.businessIdentifier)
         return true
       } else if (isSocieties(item)) {


### PR DESCRIPTION
*Issue #:17777 *
https://github.com/bcgov/entity/issues/17777 

*Description of changes:*
- Remove 'business authorized' message after first access to Manage Business page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
