### PR TITLE
17778 & 17788 - Org Admin/Coordinator for affiliation invitation updates

### DIFF
--- a/auth-api/src/auth_api/resources/v1/affiliation_invitation.py
+++ b/auth-api/src/auth_api/resources/v1/affiliation_invitation.py
@@ -223,5 +223,5 @@ def _verify_permissions(user, affiliation_invitation_id):
         raise BusinessException(Error.DATA_NOT_FOUND, None)
 
     to_org_id = affiliation_invitation.as_dict()['to_org']['id']
-    if not UserService.is_user_member_of_org(user=user, org_id=to_org_id):
+    if not UserService.is_user_admin_or_coordinator(user=user, org_id=to_org_id):
         raise BusinessException(Error.NOT_AUTHORIZED_TO_PERFORM_THIS_ACTION, None)

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -365,8 +365,7 @@ class AffiliationInvitation:
 
     @staticmethod
     def _filter_request_invites_role_based(affiliation_invitation_models: List[AffiliationInvitationModel],
-                                           org_id: int,
-                                           user: UserService = None) -> List[AffiliationInvitationModel]:
+                                           org_id: int) -> List[AffiliationInvitationModel]:
         """Filter out affiliation invitations of type REQUEST if current user is not staff or org admin/coordinator."""
         if UserService.is_context_user_staff():
             return affiliation_invitation_models
@@ -374,9 +373,8 @@ class AffiliationInvitation:
         if org_id is None:
             return []
 
-        current_user: UserService = user or UserService.find_by_jwt_token()
-        is_org_admin_or_coordinator = UserService.is_user_admin_or_coordinator(user=current_user, org_id=org_id)
-        if is_org_admin_or_coordinator:
+        current_user: UserService = UserService.find_by_jwt_token()
+        if UserService.is_user_admin_or_coordinator(user=current_user, org_id=org_id):
             return affiliation_invitation_models
 
         # filter out affiliation invitations of type request
@@ -389,7 +387,7 @@ class AffiliationInvitation:
         """Search affiliation invitations."""
         try:
             org_id = int(search_filter.to_org_id or search_filter.from_org_id)
-        except ValueError:
+        except (TypeError, ValueError):
             org_id = None
 
         searched_invitations = AffiliationInvitationModel().filter_by(search_filter=search_filter)

--- a/auth-api/src/auth_api/services/user.py
+++ b/auth-api/src/auth_api/services/user.py
@@ -648,6 +648,20 @@ class User:  # pylint: disable=too-many-instance-attributes disable=too-many-pub
         return user_from_context.is_staff()
 
     @staticmethod
+    def is_user_admin_or_coordinator(user, org_id: int) -> bool:
+        """Check if user(userservice wrapper) provided is admin or coordinator for the given org id."""
+        current_user_membership: MembershipModel = \
+            MembershipModel.find_membership_by_user_and_org(user_id=user.identifier, org_id=org_id)
+
+        if current_user_membership is None:
+            return False
+
+        if current_user_membership.status != Status.ACTIVE.value:
+            return False
+
+        return current_user_membership.membership_type_code in CLIENT_ADMIN_ROLES
+
+    @staticmethod
     def is_user_member_of_org(user, org_id: int) -> bool:
         """Verify if user (UserService wrapper) is active member of the provided org."""
         if not user:

--- a/auth-api/src/auth_api/services/user.py
+++ b/auth-api/src/auth_api/services/user.py
@@ -660,14 +660,3 @@ class User:  # pylint: disable=too-many-instance-attributes disable=too-many-pub
             return False
 
         return current_user_membership.membership_type_code in CLIENT_ADMIN_ROLES
-
-    @staticmethod
-    def is_user_member_of_org(user, org_id: int) -> bool:
-        """Verify if user (UserService wrapper) is active member of the provided org."""
-        if not user:
-            return False
-
-        current_user_membership: MembershipModel = \
-            MembershipModel.find_membership_by_user_and_org(user_id=user.identifier, org_id=org_id)
-
-        return current_user_membership is not None and current_user_membership.status == Status.ACTIVE.value


### PR DESCRIPTION
*Issue #:17778 & 17788*
https://github.com/bcgov/entity/issues/17778
https://github.com/bcgov/entity/issues/17788

*Description of changes:*
- updating how emails are fetched for affiliation invitation of type REQUEST (going to all admins/coordinators)
- updating who can see affiliation invitations of type REQUEST (only admin/coordinators now)
- updating who can accept affiliation invitations of type REQUEST (only admin/coordinators now)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
