### PR TITLE
OPS#3093 - Fix for affidavit error

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.4.28",
+      "version": "2.4.29",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/stores/staff.ts
+++ b/auth-web/src/stores/staff.ts
@@ -158,9 +158,15 @@ export const useStaffStore = defineStore('staff', () => {
         break
     }
 
-    const affidavitResponse = await UserService.getAffidavitInfo(taskUserGuid, status)
-    if (affidavitResponse?.data && affidavitResponse?.status === 200) {
-      state.accountUnderReviewAffidavitInfo = affidavitResponse.data
+    try {
+      const affidavitResponse = await UserService.getAffidavitInfo(taskUserGuid, status)
+      if (affidavitResponse?.data && affidavitResponse?.status === 200) {
+        state.accountUnderReviewAffidavitInfo = affidavitResponse.data
+      }
+    } catch (err) {
+      // eslint-disable-line no-console
+      console.log(err)
+      state.accountUnderReviewAffidavitInfo = null
     }
   }
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov-registries/ops-support/issues/3093

*Description of changes:*
Allow failure of affidavit GET to still allow code to set value

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
