### PR TITLE
18091- update MHR_QSHD product code keycloak group

### DIFF
--- a/auth-api/migrations/versions/2023_10_10_9e8d6b3de6d5_18091_mhr_product_code_update.py
+++ b/auth-api/migrations/versions/2023_10_10_9e8d6b3de6d5_18091_mhr_product_code_update.py
@@ -1,0 +1,28 @@
+"""18091-mhr-product-code-update
+
+Revision ID: 9e8d6b3de6d5
+Revises: 0f7e04a673f7
+Create Date: 2023-10-10 07:36:07.599629
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9e8d6b3de6d5'
+down_revision = '0f7e04a673f7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE public.product_codes "
+               "SET keycloak_group='mhr_dealership' "
+               "WHERE code='MHR_QSHD'")
+
+
+def downgrade():
+    op.execute("UPDATE public.product_codes "
+               "SET keycloak_group='mhr_general_user' "
+               "WHERE code='MHR_QSHD'")


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/18091

*Description of changes:*
- update MHR home dealers product code keycloak group to mhr_dealership

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
