### PR TITLE
17224 - Payment reminder notifications for EFT

### DIFF
--- a/queue_services/account-mailer/src/account_mailer/email_templates/payment_due_notification.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/payment_due_notification.html
@@ -1,0 +1,15 @@
+# Payment Due Today
+
+There's an amount owing on your recent statement due on {{ due_date }}.
+
+To avoid any disruptions to your services, please make your payment as soon as possible.
+
+[Log in to view your {{ statement_frequency }} statement]({{ payment_statement_url }})
+
+If you've recently made a payment, please disregard this message.
+
+**Business Registry**
+BC Registries and Online Services
+Toll Free: 1-877-370-1033
+Victoria Office: 250-370-1033
+Email: BCRegistries@gov.bc.ca

--- a/queue_services/account-mailer/src/account_mailer/email_templates/payment_reminder_notification.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/payment_reminder_notification.html
@@ -1,0 +1,13 @@
+# Payment Reminder
+
+There's an amount owing on your recent statement due on {{ due_date }}.
+
+[Log in to view your {{ statement_frequency }} statement]({{ payment_statement_url }})
+
+If you've recently made a payment, please disregard this message.
+
+**Business Registry**
+BC Registries and Online Services
+Toll Free: 1-877-370-1033
+Victoria Office: 250-370-1033
+Email: BCRegistries@gov.bc.ca

--- a/queue_services/account-mailer/src/account_mailer/enums.py
+++ b/queue_services/account-mailer/src/account_mailer/enums.py
@@ -61,6 +61,8 @@ class MessageType(Enum):
     AFFILIATION_INVITATION_REQUEST = 'bc.registry.auth.affiliationInvitationRequest'
     AFFILIATION_INVITATION_REQUEST_AUTHORIZATION = 'bc.registry.auth.affiliationInvitationRequestAuthorization'
     STATEMENT_NOTIFICATION = 'bc.registry.payment.statementNotification'
+    PAYMENT_REMINDER_NOTIFICATION = 'bc.registry.payment.statementReminderNotification'
+    PAYMENT_DUE_NOTIFICATION = 'bc.registry.payment.statementDueNotification'
 
 
 class SubjectType(Enum):
@@ -118,6 +120,8 @@ class SubjectType(Enum):
     AFFILIATION_INVITATION_REQUEST_AUTHORIZATION = '[BC Registries and Online Services] ' \
                                                    'Request to manage {business_name}'
     STATEMENT_NOTIFICATION = 'Your BC Registries statement is available'
+    PAYMENT_REMINDER_NOTIFICATION = 'Your BC Registries payment reminder'
+    PAYMENT_DUE_NOTIFICATION = 'Your BC Registries payment is due'
 
 
 class TitleType(Enum):
@@ -192,6 +196,8 @@ class TemplateType(Enum):
     AFFILIATION_INVITATION_REQUEST_TEMPLATE_NAME = 'affiliation_invitation_request'
     AFFILIATION_INVITATION_REQUEST_AUTHORIZATION_TEMPLATE_NAME = 'affiliation_invitation_request_authorization'
     STATEMENT_NOTIFICATION_TEMPLATE_NAME = 'statement_notification'
+    PAYMENT_REMINDER_NOTIFICATION_TEMPLATE_NAME = 'payment_reminder_notification'
+    PAYMENT_DUE_NOTIFICATION_TEMPLATE_NAME = 'payment_due_notification'
 
 
 class Constants(Enum):

--- a/queue_services/account-mailer/src/account_mailer/version.py
+++ b/queue_services/account-mailer/src/account_mailer/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.18.1'  # pylint: disable=invalid-name
+__version__ = '2.18.2'  # pylint: disable=invalid-name

--- a/queue_services/account-mailer/src/account_mailer/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/worker.py
@@ -257,6 +257,21 @@ async def process_event(event_message: dict, flask_app):
                     'total_amount_owing': format_currency(email_msg.get('totalAmountOwing')),
                     'statement_frequency': email_msg.get('statementFrequency').lower()
                 })
+        elif message_type in {MessageType.PAYMENT_REMINDER_NOTIFICATION.value,
+                              MessageType.PAYMENT_DUE_NOTIFICATION.value}:
+            due_date = datetime.fromisoformat(email_msg.get('dueDate'))
+
+            email_dict = common_mailer.process(
+                **{
+                    'org_id': email_msg.get('accountId'),
+                    'recipients': email_msg.get('emailAddresses'),
+                    'template_name': TemplateType[f'{MessageType(message_type).name}_TEMPLATE_NAME'].value,
+                    'subject': SubjectType[MessageType(message_type).name].value,
+                    'logo_url': logo_url,
+                    'due_date': due_date.strftime('%B ') + format_day_with_suffix(due_date.day) + f' {due_date.year}',
+                    'total_amount_owing': format_currency(email_msg.get('totalAmountOwing')),
+                    'statement_frequency': email_msg.get('statementFrequency').lower()
+                })
 
         else:
             if any(x for x in MessageType if x.value == message_type):

--- a/queue_services/account-mailer/tests/integration/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/integration/test_worker_queue.py
@@ -623,7 +623,8 @@ async def test_statement_notification_email(app, session, stan_server, event_loo
 
 
 @pytest.mark.asyncio
-async def test_payment_reminder_notification_email(app, session, stan_server, event_loop, client_id, events_stan, future):
+async def test_payment_reminder_notification_email(app, session, stan_server, event_loop, client_id, events_stan,
+                                                   future):
     """Assert that payment reminder notification events can be retrieved and decoded from the Queue."""
     # Call back for the subscription
     from account_mailer.worker import cb_subscription_handler


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/17224

*Description of changes:*
- added email templates for statement payment notifications (reminder and due)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
