### PR TITLE
18761, 18763 - EFT statement settings updates

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.4.51",
+  "version": "2.4.52",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.4.51",
+      "version": "2.4.52",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",
@@ -50,7 +50,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/eslint-config-typescript": "^4.0.0",
         "@vue/test-utils": "1.3.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.4.51",
+  "version": "2.4.52",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/account-settings/statement/Statements.vue
+++ b/auth-web/src/components/auth/account-settings/statement/Statements.vue
@@ -18,7 +18,6 @@
         Statements
       </h2>
       <v-btn
-        v-if="!enableEFTPaymentMethod"
         large
         depressed
         aria-label="Statement Settings"


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/18761
https://github.com/bcgov/entity/issues/18763

*Description of changes:*
- Fix issue where statement settings are always hidden when the feature flag for eft payment method is enabled. Statements settings are now always shown, but the statement frequency will be locked if the feature flag is enabled and payment method is EFT
- Fix some styling issues as per UXPIN

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
