### PR TITLE
19530 - Add in test_request_context, that way we have a request context that …

### DIFF
--- a/queue_services/account-mailer/src/account_mailer/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/worker.py
@@ -69,7 +69,8 @@ async def process_event(event_message: dict, flask_app):
         email_msg = event_message.get('data')
         logo_url = email_msg['logo_url'] = minio_service.MinioService.get_minio_public_url('bc_logo_for_email.png')
         email_dict = None
-        token = RestService.get_service_account_token()
+        with flask_app.test_request_context('service_token'):
+            token = RestService.get_service_account_token()
         logger.debug('message_type recieved %s', message_type)
         if message_type == 'account.mailer':
             email_dict = payment_completed.process(email_msg)

--- a/queue_services/account-mailer/src/account_mailer/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/worker.py
@@ -69,6 +69,7 @@ async def process_event(event_message: dict, flask_app):
         email_msg = event_message.get('data')
         logo_url = email_msg['logo_url'] = minio_service.MinioService.get_minio_public_url('bc_logo_for_email.png')
         email_dict = None
+        token = None
         with flask_app.test_request_context('service_token'):
             token = RestService.get_service_account_token()
         logger.debug('message_type recieved %s', message_type)

--- a/queue_services/names-events-listener/src/names_events_listener/worker.py
+++ b/queue_services/names-events-listener/src/names_events_listener/worker.py
@@ -68,10 +68,10 @@ async def process_event(event_message, flask_app):
         message_type = event_message.get('type', None)
 
         if message_type == 'bc.registry.names.events':
-            await process_name_events(event_message)
+            await process_name_events(event_message, flask_app)
 
 
-async def process_name_events(event_message: Dict[str, any]):
+async def process_name_events(event_message: Dict[str, any], flask_app):
     """Process name events.
 
     1. Check if the NR already exists in entities table, if yes apply changes. If not create entity record.
@@ -117,31 +117,33 @@ async def process_name_events(event_message: Dict[str, any]):
     if nr_status == 'DRAFT' and not AffiliationModel.find_affiliations_by_business_identifier(nr_number, None):
         logger.info('Status is DRAFT, getting invoices for account')
         # Find account details for the NR.
-        invoices = RestService.get(
-            f'{APP_CONFIG.PAY_API_URL}/payment-requests?businessIdentifier={nr_number}',
-            token=RestService.get_service_account_token()
-        ).json()
+        with flask_app.test_request_context('service_token'):
+            invoices = RestService.get(
+                f'{APP_CONFIG.PAY_API_URL}/payment-requests?businessIdentifier={nr_number}',
+                token=RestService.get_service_account_token()
+            ).json()
 
-        # Ideally there should be only one or two (priority fees) payment request for the NR.
-        if invoices and invoices['invoices'] \
-                and (auth_account_id := invoices['invoices'][0].get('paymentAccount').get('accountId')) \
-                and str(auth_account_id).isnumeric():
-            logger.info('Account ID received : %s', auth_account_id)
-            # Auth account id can be service account value too, so doing a query lookup than find_by_id
-            org: OrgModel = db.session.query(OrgModel).filter(OrgModel.id == auth_account_id).one_or_none()
-            # If account is present and is not a gov account, then affiliate.
-            if org and org.access_type != AccessType.GOVM.value:
-                nr_entity.pass_code_claimed = True
-                # Create an affiliation.
-                logger.info('Creating affiliation between Entity : %s and Org : %s', nr_entity, org)
-                affiliation: AffiliationModel = AffiliationModel(entity=nr_entity, org=org)
-                affiliation.flush()
-                activity: ActivityModel = ActivityModel(org_id=org.id, action=ActivityAction.CREATE_AFFILIATION.value,
-                                                        item_name=nr_entity.business_identifier,
-                                                        item_id=nr_entity.business_identifier,
-                                                        item_type=None, item_value=None, actor_id=None
-                                                        )
-                activity.flush()
+            # Ideally there should be only one or two (priority fees) payment request for the NR.
+            if invoices and invoices['invoices'] \
+                    and (auth_account_id := invoices['invoices'][0].get('paymentAccount').get('accountId')) \
+                    and str(auth_account_id).isnumeric():
+                logger.info('Account ID received : %s', auth_account_id)
+                # Auth account id can be service account value too, so doing a query lookup than find_by_id
+                org: OrgModel = db.session.query(OrgModel).filter(OrgModel.id == auth_account_id).one_or_none()
+                # If account is present and is not a gov account, then affiliate.
+                if org and org.access_type != AccessType.GOVM.value:
+                    nr_entity.pass_code_claimed = True
+                    # Create an affiliation.
+                    logger.info('Creating affiliation between Entity : %s and Org : %s', nr_entity, org)
+                    affiliation: AffiliationModel = AffiliationModel(entity=nr_entity, org=org)
+                    affiliation.flush()
+                    activity: ActivityModel = ActivityModel(org_id=org.id, 
+                                                            action=ActivityAction.CREATE_AFFILIATION.value,
+                                                            item_name=nr_entity.business_identifier,
+                                                            item_id=nr_entity.business_identifier,
+                                                            item_type=None, item_value=None, actor_id=None
+                                                            )
+                    activity.flush()
 
     nr_entity.save()
     logger.debug('<<<<<<<process_name_events<<<<<<<<<<')

--- a/queue_services/names-events-listener/src/names_events_listener/worker.py
+++ b/queue_services/names-events-listener/src/names_events_listener/worker.py
@@ -116,34 +116,36 @@ async def process_name_events(event_message: Dict[str, any], flask_app):
     # Future - None needs to be replaced with whatever we decide to fill the data with.
     if nr_status == 'DRAFT' and not AffiliationModel.find_affiliations_by_business_identifier(nr_number, None):
         logger.info('Status is DRAFT, getting invoices for account')
+        token = None
         # Find account details for the NR.
         with flask_app.test_request_context('service_token'):
-            invoices = RestService.get(
-                f'{APP_CONFIG.PAY_API_URL}/payment-requests?businessIdentifier={nr_number}',
-                token=RestService.get_service_account_token()
-            ).json()
+            token=RestService.get_service_account_token()
+        invoices = RestService.get(
+            f'{APP_CONFIG.PAY_API_URL}/payment-requests?businessIdentifier={nr_number}',
+            token=token
+        ).json()
 
-            # Ideally there should be only one or two (priority fees) payment request for the NR.
-            if invoices and invoices['invoices'] \
-                    and (auth_account_id := invoices['invoices'][0].get('paymentAccount').get('accountId')) \
-                    and str(auth_account_id).isnumeric():
-                logger.info('Account ID received : %s', auth_account_id)
-                # Auth account id can be service account value too, so doing a query lookup than find_by_id
-                org: OrgModel = db.session.query(OrgModel).filter(OrgModel.id == auth_account_id).one_or_none()
-                # If account is present and is not a gov account, then affiliate.
-                if org and org.access_type != AccessType.GOVM.value:
-                    nr_entity.pass_code_claimed = True
-                    # Create an affiliation.
-                    logger.info('Creating affiliation between Entity : %s and Org : %s', nr_entity, org)
-                    affiliation: AffiliationModel = AffiliationModel(entity=nr_entity, org=org)
-                    affiliation.flush()
-                    activity: ActivityModel = ActivityModel(org_id=org.id,
-                                                            action=ActivityAction.CREATE_AFFILIATION.value,
-                                                            item_name=nr_entity.business_identifier,
-                                                            item_id=nr_entity.business_identifier,
-                                                            item_type=None, item_value=None, actor_id=None
-                                                            )
-                    activity.flush()
+        # Ideally there should be only one or two (priority fees) payment request for the NR.
+        if invoices and invoices['invoices'] \
+                and (auth_account_id := invoices['invoices'][0].get('paymentAccount').get('accountId')) \
+                and str(auth_account_id).isnumeric():
+            logger.info('Account ID received : %s', auth_account_id)
+            # Auth account id can be service account value too, so doing a query lookup than find_by_id
+            org: OrgModel = db.session.query(OrgModel).filter(OrgModel.id == auth_account_id).one_or_none()
+            # If account is present and is not a gov account, then affiliate.
+            if org and org.access_type != AccessType.GOVM.value:
+                nr_entity.pass_code_claimed = True
+                # Create an affiliation.
+                logger.info('Creating affiliation between Entity : %s and Org : %s', nr_entity, org)
+                affiliation: AffiliationModel = AffiliationModel(entity=nr_entity, org=org)
+                affiliation.flush()
+                activity: ActivityModel = ActivityModel(org_id=org.id,
+                                                        action=ActivityAction.CREATE_AFFILIATION.value,
+                                                        item_name=nr_entity.business_identifier,
+                                                        item_id=nr_entity.business_identifier,
+                                                        item_type=None, item_value=None, actor_id=None
+                                                        )
+                activity.flush()
 
     nr_entity.save()
     logger.debug('<<<<<<<process_name_events<<<<<<<<<<')

--- a/queue_services/names-events-listener/src/names_events_listener/worker.py
+++ b/queue_services/names-events-listener/src/names_events_listener/worker.py
@@ -119,7 +119,7 @@ async def process_name_events(event_message: Dict[str, any], flask_app):
         token = None
         # Find account details for the NR.
         with flask_app.test_request_context('service_token'):
-            token=RestService.get_service_account_token()
+            token = RestService.get_service_account_token()
         invoices = RestService.get(
             f'{APP_CONFIG.PAY_API_URL}/payment-requests?businessIdentifier={nr_number}',
             token=token

--- a/queue_services/names-events-listener/src/names_events_listener/worker.py
+++ b/queue_services/names-events-listener/src/names_events_listener/worker.py
@@ -137,7 +137,7 @@ async def process_name_events(event_message: Dict[str, any], flask_app):
                     logger.info('Creating affiliation between Entity : %s and Org : %s', nr_entity, org)
                     affiliation: AffiliationModel = AffiliationModel(entity=nr_entity, org=org)
                     affiliation.flush()
-                    activity: ActivityModel = ActivityModel(org_id=org.id, 
+                    activity: ActivityModel = ActivityModel(org_id=org.id,
                                                             action=ActivityAction.CREATE_AFFILIATION.value,
                                                             item_name=nr_entity.business_identifier,
                                                             item_id=nr_entity.business_identifier,


### PR DESCRIPTION
…populates the flask-cache cache key, it's based off of request.args and request.path - which wouldn't exist in asyncio loop (not calling from a route)


https://github.com/bcgov/entity/issues/19530

See also: 
https://github.com/bcgov/sbc-auth/pull/2692

Error this fixes:

```
16:34:43,260-flask_caching-ERROR > __init__:__init__.py:395-decorated_function:Exception possibly due to cache backend.
Traceback (most recent call last):
  File "/home/trav/work/sbc-auth/queue_services/account-mailer/venv/lib/python3.8/site-packages/flask_caching/__init__.py", line 361, in decorated_function
    cache_key = decorated_function.make_cache_key(*args, use_request=True, **kwargs)
  File "/home/trav/work/sbc-auth/queue_services/account-mailer/venv/lib/python3.8/site-packages/flask_caching/__init__.py", line 429, in default_make_cache_key
    return _make_cache_key(args, kwargs, use_request=use_request)
  File "/home/trav/work/sbc-auth/queue_services/account-mailer/venv/lib/python3.8/site-packages/flask_caching/__init__.py", line 474, in _make_cache_key
    return _make_cache_key_query_string()
  File "/home/trav/work/sbc-auth/queue_services/account-mailer/venv/lib/python3.8/site-packages/flask_caching/__init__.py", line 451, in _make_cache_key_query_string
    sorted(pair for pair in request.args.items(multi=True))
  File "/home/trav/work/sbc-auth/queue_services/account-mailer/venv/lib/python3.8/site-packages/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
  File "/home/trav/work/sbc-auth/queue_services/account-mailer/venv/lib/python3.8/site-packages/werkzeug/local.py", line 306, in _get_current_object
    return self.__local()
  File "/home/trav/work/sbc-auth/queue_services/account-mailer/venv/lib/python3.8/site-packages/flask/globals.py", line 38, in _lookup_req_object
    raise RuntimeError(_request_ctx_err_msg)
RuntimeError: Working outside of request context.
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
