### PR TITLE
revert mdi/fonts version - caused regression issues

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "auth-web",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",
         "@bcrs-shared-components/corp-type-module": "1.0.13",
         "@bcrs-shared-components/enums": "1.1.7",
         "@bcrs-shared-components/interfaces": "1.0.71",
-        "@mdi/font": "^5.9.55",
+        "@mdi/font": "^4.5.95",
         "@sentry/vue": "^7.49.0",
         "@vue/compiler-dom": "^3.2.45",
         "@vue/composition-api": "^1.7.1",
@@ -1489,9 +1489,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@mdi/font": {
-      "version": "5.9.55",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-5.9.55.tgz",
-      "integrity": "sha512-jswRF6q3eq8NWpWiqct6q+6Fg/I7nUhrxYJfiEM8JJpap0wVJLQdbKtyS65GdlK7S7Ytnx3TTi/bmw+tBhkGmg=="
+      "version": "4.9.95",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-4.9.95.tgz",
+      "integrity": "sha512-m2sbAs+SMwRnWpkMriBxEulwuhmqRyh6X+hdOZlqSxYZUM2C2TaDnQ4gcilzdoAgru2XYnWViZ/xPuSDGgRXVw=="
     },
     "node_modules/@nicolo-ribaudo/semver-v6": {
       "version": "6.3.3",
@@ -10958,11 +10958,6 @@
         "vuex": "^3.1.2"
       }
     },
-    "node_modules/sbc-common-components/node_modules/@mdi/font": {
-      "version": "4.9.95",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-4.9.95.tgz",
-      "integrity": "sha512-m2sbAs+SMwRnWpkMriBxEulwuhmqRyh6X+hdOZlqSxYZUM2C2TaDnQ4gcilzdoAgru2XYnWViZ/xPuSDGgRXVw=="
-    },
     "node_modules/sbc-common-components/node_modules/axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -14495,9 +14490,9 @@
       }
     },
     "@mdi/font": {
-      "version": "5.9.55",
-      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-5.9.55.tgz",
-      "integrity": "sha512-jswRF6q3eq8NWpWiqct6q+6Fg/I7nUhrxYJfiEM8JJpap0wVJLQdbKtyS65GdlK7S7Ytnx3TTi/bmw+tBhkGmg=="
+      "version": "4.9.95",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-4.9.95.tgz",
+      "integrity": "sha512-m2sbAs+SMwRnWpkMriBxEulwuhmqRyh6X+hdOZlqSxYZUM2C2TaDnQ4gcilzdoAgru2XYnWViZ/xPuSDGgRXVw=="
     },
     "@nicolo-ribaudo/semver-v6": {
       "version": "6.3.3",
@@ -17671,7 +17666,7 @@
     },
     "fas-ui": {
       "version": "git+ssh://git@github.com/bcgov/fas-ui.git#33a30715048733a06db89723be6c52e04a69a653",
-      "from": "fas-ui@git://github.com/bcgov/fas-ui#fix_library_code",
+      "from": "fas-ui@github:bcgov/fas-ui#fix_library_code",
       "requires": {
         "@bcrs-shared-components/base-address": "^2.0.3",
         "@bcrs-shared-components/enums": "^1.0.51",
@@ -21476,11 +21471,6 @@
         "vuex": "^3.1.2"
       },
       "dependencies": {
-        "@mdi/font": {
-          "version": "4.9.95",
-          "resolved": "https://registry.npmjs.org/@mdi/font/-/font-4.9.95.tgz",
-          "integrity": "sha512-m2sbAs+SMwRnWpkMriBxEulwuhmqRyh6X+hdOZlqSxYZUM2C2TaDnQ4gcilzdoAgru2XYnWViZ/xPuSDGgRXVw=="
-        },
         "axios": {
           "version": "0.21.4",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,
@@ -20,7 +20,7 @@
     "@bcrs-shared-components/corp-type-module": "1.0.13",
     "@bcrs-shared-components/enums": "1.1.7",
     "@bcrs-shared-components/interfaces": "1.0.71",
-    "@mdi/font": "^5.9.55",
+    "@mdi/font": "^4.5.95",
     "@sentry/vue": "^7.49.0",
     "@vue/compiler-dom": "^3.2.45",
     "@vue/composition-api": "^1.7.1",


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
