### PR TITLE
19107 updated name on draft amalgamations

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/src/composables/affiliations-factory.ts
+++ b/auth-web/src/composables/affiliations-factory.ts
@@ -112,6 +112,11 @@ export const useAffiliations = () => {
     )
   }
 
+  /** Returns true if the affiliation is a numbered amalgamation application. */
+  const isNumberedAmalgamationApplication = (business: Business): boolean => {
+    return (business.corpType?.code || business.corpType) === CorpTypes.AMALGAMATION_APPLICATION
+  }
+
   /** Returns the identifier of the affiliation. */
   const number = (business: Business): string => {
     if (isNumberedIncorporationApplication(business)) {
@@ -138,6 +143,10 @@ export const useAffiliations = () => {
     }
     if (item.nameRequest) {
       return getApprovedName(item)
+    }
+    if (item.name == 'Numbered Amalgamated Company' && isNumberedAmalgamationApplication(item)) {
+      const legalType: unknown = item.corpSubType?.code
+      return GetCorpNumberedDescription(legalType as CorpTypeCd) || 'Numbered Amalgamated Company'
     }
     return item.name
   }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<19107>

*Description of changes:*

- changed draft amalgamations name from 'Numbered Amalgamated Company" to specific corp sub type. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
