### PR TITLE
Auth Stats reports to include new accounts setup - counting accounts using BCeID or BCSC 3596

### DIFF
--- a/jobs/notebook-report/Makefile
+++ b/jobs/notebook-report/Makefile
@@ -7,6 +7,7 @@ MKFILE_PATH:=$(abspath $(lastword $(MAKEFILE_LIST)))
 CURRENT_ABS_DIR:=$(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
 PROJECT_NAME:=notebook-report
+DOCKER_NAME:=notebook-report
 
 #################################################################################
 # COMMANDS -- Setup                                                             #

--- a/jobs/notebook-report/vaults.json
+++ b/jobs/notebook-report/vaults.json
@@ -1,9 +1,0 @@
-[
-    {
-        "vault": "relationship",
-        "application": [
-            "postgres-auth",
-            "notebook-report"
-        ]
-    }
-]


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/3596

Amend weekly Auth Stats reports to include new accounts setup - counting accounts using BCeID or BCSC


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
