### PR TITLE
Code to update the api access property of the org via API call

### DIFF
--- a/auth-api/src/auth_api/resources/v1/org.py
+++ b/auth-api/src/auth_api/resources/v1/org.py
@@ -219,7 +219,7 @@ def delete_organization(org_id):
 @bp.route('/<int:org_id>', methods=['PATCH'])
 @cross_origin(origins='*')
 @TRACER.trace()
-@_jwt.has_one_of_roles([Role.STAFF_MANAGE_ACCOUNTS.value])
+@_jwt.has_one_of_roles([Role.STAFF_MANAGE_ACCOUNTS.value, Role.SYSTEM.value])
 def patch_organization(org_id):
     """Patch an account."""
     request_json = request.get_json()

--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -931,6 +931,15 @@ class Org:  # pylint: disable=too-many-public-methods
         current_app.logger.debug('change_org_access_type>')
         return Org(org_model)
 
+    def change_org_api_access(self, has_api_access):
+        """Update the org API access."""
+        current_app.logger.debug('<change_org_api_access')
+        org_model = self._model
+        org_model.has_api_access = has_api_access
+        org_model.save()
+        current_app.logger.debug('change_org_api_access>')
+        return Org(org_model)
+
     def patch_org(self, action: str = None, request_json: Dict[str, any] = None):
         """Update Org."""
         if (patch_action := PatchActions.from_value(action)) is None:
@@ -951,4 +960,7 @@ class Org:  # pylint: disable=too-many-public-methods
                                                           AccessType.EXTRA_PROVINCIAL.value, AccessType.GOVN.value]:
                 raise BusinessException(Error.INVALID_INPUT, None)
             return self.change_org_access_type(access_type).as_dict()
+        if patch_action == PatchActions.UPDATE_API_ACCESS:
+            has_api_access = request_json.get('hasApiAccess', False)
+            return self.change_org_api_access(has_api_access).as_dict()
         return None

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -332,6 +332,7 @@ class PatchActions(Enum):
 
     UPDATE_STATUS = 'updateStatus'
     UPDATE_ACCESS_TYPE = 'updateAccessType'
+    UPDATE_API_ACCESS = 'updateApiAccess'
 
     @classmethod
     def from_value(cls, value):


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*
To refactor '_src/auth_api/resources/v1/org_api_keys.py_' to a separate service, we have to support updating the 'has_api_access' property of the org via an API call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
