### PR TITLE
20417-UXA-Fixes

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.7",
+      "version": "2.6.8",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/pay/eft/ShortNameAccountLink.vue
+++ b/auth-web/src/components/pay/eft/ShortNameAccountLink.vue
@@ -110,7 +110,9 @@
       v-else
       class="d-flex justify-space-between pa-5 unlinked-text"
     >
-      This short name is not linked with an account.
+      <span class="pt-1">
+        This short name is not linked with an account.
+      </span>
       <v-btn
         id="link-shortname-btn"
         color="primary"

--- a/auth-web/src/components/pay/eft/ShortNameTransactions.vue
+++ b/auth-web/src/components/pay/eft/ShortNameTransactions.vue
@@ -45,7 +45,7 @@
       </span>
     </template>
     <template #item-slot-transactionAmount="{ item }">
-      <span>{{ formatCurrency(item.transactionAmount) }}</span>
+      <span>{{ formatTransactionAmount(item) }}</span>
     </template>
   </BaseVDataTable>
 </template>
@@ -87,13 +87,13 @@ export default defineComponent({
       {
         col: 'statementId',
         hasFilter: false,
-        minWidth: '200px',
+        minWidth: '175px',
         value: 'Related Statement Number'
       },
       {
         col: 'transactionAmount',
         hasFilter: false,
-        minWidth: '125px',
+        minWidth: '355px',
         value: 'Amount'
       }
     ]
@@ -150,8 +150,17 @@ export default defineComponent({
       return item?.transactionDescription === ShortNameTransactionRowType.STATEMENT_PAID
     }
 
+    function formatTransactionAmount (item: any) {
+      if (item.transactionAmount === undefined) return ''
+      let amount = CommonUtils.formatAmount(item.transactionAmount)
+      if (isStatementPaid(item)) {
+        amount = `-${amount}`
+      }
+      return amount
+    }
+
     return {
-      formatCurrency: CommonUtils.formatAmount,
+      formatTransactionAmount,
       formatDate: CommonUtils.formatDisplayDate,
       formatAccountDisplayName: CommonUtils.formatAccountDisplayName,
       headers,

--- a/auth-web/tests/unit/components/ShortNameTransactions.spec.ts
+++ b/auth-web/tests/unit/components/ShortNameTransactions.spec.ts
@@ -121,7 +121,7 @@ describe('ShortNameTransactions.vue', () => {
       expect(columns.at(1).text()).toContain(transactionsResponse.items[i].transactionDescription)
       expect(columns.at(2).text()).toBe(transactionsResponse.items[i].statementId
         ? transactionsResponse.items[i].statementId.toString() : '')
-      expect(columns.at(3).text()).toBe(
+      expect(columns.at(3).text()).toContain(
         CommonUtils.formatAmount(transactionsResponse.items[i].transactionAmount))
     }
   })


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/20417
*Description of changes:*
- align statement and amount columns on link and transaction tables
- Fix text padding when there is no links
- update transaction amount formatting to be negative for paid statement rows

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
