### PR TITLE
Fix dockerfile for auth-queue

### DIFF
--- a/queue_services/auth-queue/Dockerfile
+++ b/queue_services/auth-queue/Dockerfile
@@ -32,4 +32,4 @@ ENV PYTHONPATH=/opt/app-root/src
 
 #EXPOSE 8080
 
-CMD ["gunicorn", "-b 0.0.0.0:8080", "wsgi:application"]
+CMD ["gunicorn", "-b 0.0.0.0:8080", "app:app"]


### PR DESCRIPTION
Fix dockerfile for auth-queue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
