### PR TITLE
21204 - Create migration that add EFT and PAD into suspension_reason_codes

### DIFF
--- a/auth-api/migrations/versions/2024_05_29_41fa6588c76e_add_eft_pad_to_suspension_reason_code.py
+++ b/auth-api/migrations/versions/2024_05_29_41fa6588c76e_add_eft_pad_to_suspension_reason_code.py
@@ -17,15 +17,16 @@ depends_on = None
 
 
 def upgrade():
-    op.execute("INSERT INTO suspension_reason_codes "
-            "(code, description,\"default\") "
-            "VALUES "
-            "('EFT_NSF', 'EFT NSF', false)")
-    op.execute("INSERT INTO suspension_reason_codes "
+        op.execute("INSERT INTO suspension_reason_codes "
+                "(code, description,\"default\") "
+                "VALUES "
+                "('EFT_NSF', 'EFT NSF', false)")
+        op.execute("INSERT INTO suspension_reason_codes "
             "(code, description,\"default\") "
             "VALUES "
             "('PAD_NSF', 'PAD NSF', false)")
-
+        op.execute("update orgs set suspension_reason_code = 'PAD_NSF' where status_code = 'NSF_SUSPENDED'")
 
 def downgrade():
-    op.execute("DELETE FROM suspension_reason_codes WHERE code in ('EFT_NSF', 'PAD_NSF')")
+        op.execute("DELETE FROM suspension_reason_codes WHERE code in ('EFT_NSF', 'PAD_NSF')")
+        op.execute("update orgs set suspension_reason_code = NULL where status_code = 'NSF_SUSPENDED'")

--- a/auth-api/migrations/versions/2024_05_29_41fa6588c76e_add_eft_pad_to_suspension_reason_code.py
+++ b/auth-api/migrations/versions/2024_05_29_41fa6588c76e_add_eft_pad_to_suspension_reason_code.py
@@ -20,12 +20,12 @@ def upgrade():
     op.execute("INSERT INTO suspension_reason_codes "
             "(code, description,\"default\") "
             "VALUES "
-            "('EFT', 'Electronic Funds Transfer', false)")
+            "('EFT_NSF', 'EFT NSF', false)")
     op.execute("INSERT INTO suspension_reason_codes "
             "(code, description,\"default\") "
             "VALUES "
-            "('PAD', 'Pre-Authorized Debit', false)")
+            "('PAD_NSF', 'PAD NSF', false)")
 
 
 def downgrade():
-    op.execute("DELETE FROM suspension_reason_codes WHERE code in ('EFT', 'PAD')")
+    op.execute("DELETE FROM suspension_reason_codes WHERE code in ('EFT_NSF', 'PAD_NSF')")

--- a/auth-api/migrations/versions/2024_05_29_41fa6588c76e_add_eft_pad_to_suspension_reason_code.py
+++ b/auth-api/migrations/versions/2024_05_29_41fa6588c76e_add_eft_pad_to_suspension_reason_code.py
@@ -1,0 +1,31 @@
+"""Add EFT PAD to suspension_reason_code
+
+Revision ID: 41fa6588c76e
+Revises: 1e4b6359f470
+Create Date: 2024-05-29 10:36:53.016963
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '41fa6588c76e'
+down_revision = '1e4b6359f470'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("INSERT INTO suspension_reason_codes "
+            "(code, description,\"default\") "
+            "VALUES "
+            "('EFT', 'Electronic Funds Transfer', false)")
+    op.execute("INSERT INTO suspension_reason_codes "
+            "(code, description,\"default\") "
+            "VALUES "
+            "('PAD', 'Pre-Authorized Debit', false)")
+
+
+def downgrade():
+    op.execute("DELETE FROM suspension_reason_codes WHERE code in ('EFT', 'PAD')")


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21204

*Description of changes:* Create migration that updates suspension_reason_code


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
