### PR TITLE
Add in handling for letters in ID

### DIFF
--- a/auth-api/src/auth_api/resources/v1/org.py
+++ b/auth-api/src/auth_api/resources/v1/org.py
@@ -42,7 +42,7 @@ from auth_api.utils.endpoints_enums import EndpointEnum
 from auth_api.utils.enums import AccessType, NotificationType, OrgStatus, OrgType, PatchActions, Status
 from auth_api.utils.role_validator import validate_roles
 from auth_api.utils.roles import ALL_ALLOWED_ROLES, CLIENT_ADMIN_ROLES, STAFF, USER, Role  # noqa: I005
-from auth_api.utils.util import get_request_environment
+from auth_api.utils.util import extract_numbers, get_request_environment
 
 
 bp = Blueprint('ORGS', __name__, url_prefix=f'{EndpointEnum.API_V1.value}/orgs')
@@ -64,7 +64,7 @@ def search_organizations():
         request.args.getlist('status', None),
         request.args.getlist('accessType', None),
         request.args.get('bcolAccountId', None),
-        request.args.get('id', None),
+        extract_numbers(request.args.get('id', None)),
         request.args.get('decisionMadeBy', None),
         request.args.get('orgType', None),
         int(request.args.get('page', 1)),

--- a/auth-api/src/auth_api/utils/util.py
+++ b/auth-api/src/auth_api/utils/util.py
@@ -79,3 +79,10 @@ def get_request_environment():
     if os.getenv('FLASK_ENV') == 'production' and sandbox_host in request.host_url:
         env = 'sandbox'
     return env
+
+
+def extract_numbers(input_string: str):
+    """Extract numbers from an input string."""
+    if input_string is None:
+        return None
+    return ''.join([char for char in input_string if char.isdigit()])

--- a/auth-api/tests/unit/api/test_org.py
+++ b/auth-api/tests/unit/api/test_org.py
@@ -96,6 +96,12 @@ def test_search_org_by_client(client, jwt, session, keycloak_mock):  # pylint:di
                      headers=headers, content_type='application/json')
     assert rv.status_code == http_status.HTTP_201_CREATED
 
+    # Ensure no exception is thrown by including letters in the id.
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.system_role)
+    rv = client.get('/api/v1/orgs?id={}'.format('FFF1234'),
+                    headers=headers, content_type='application/json')
+    assert rv.status_code == http_status.HTTP_200_OK
+
     # system search
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.system_role)
     rv = client.get('/api/v1/orgs?name={}'.format(TestOrgInfo.org1.get('name')),


### PR DESCRIPTION
Fixes:

```
sqlalchemy.exc.DataError: (psycopg2.errors.InvalidTextRepresentation) invalid input syntax for type integer: "M"
LINE 5: ...ND orgs.access_type = 'GOVM')) ORDER BY orgs.id = 'M' DESC, ...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
