### PR TITLE
19414 - Fixed filter issue on Active and Inactive Tab

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.30",
+  "version": "2.6.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.30",
+      "version": "2.6.31",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",
@@ -53,7 +53,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/eslint-config-typescript": "^4.0.0",
         "@vue/test-utils": "1.3.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.30",
+  "version": "2.6.31",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/common/StaffAccountsTable.vue
+++ b/auth-web/src/components/auth/common/StaffAccountsTable.vue
@@ -211,6 +211,10 @@ export default defineComponent({
     accountStatus: {
       type: String as PropType<AccountStatus>,
       default: AccountStatus.ACTIVE
+    },
+    sessionStorageKeys: {
+      type: String as PropType<SessionStorageKeys>,
+      default: SessionStorageKeys.OrgSearchFilter
     }
   },
   setup (props, { root }) {
@@ -310,7 +314,7 @@ export default defineComponent({
 
     function mounted () {
       state.tableDataOptions = DEFAULT_DATA_OPTIONS
-      const orgSearchFilter = ConfigHelper.getFromSession(SessionStorageKeys.OrgSearchFilter) || ''
+      const orgSearchFilter = ConfigHelper.getFromSession(props.sessionStorageKeys) || ''
       try {
         state.searchParams = JSON.parse(orgSearchFilter)
       } catch {
@@ -403,7 +407,7 @@ export default defineComponent({
     })
 
     function setSearchFilterToStorage (val: string): void {
-      ConfigHelper.addToSession(SessionStorageKeys.OrgSearchFilter, val)
+      ConfigHelper.addToSession(props.sessionStorageKeys, val)
     }
 
     function doSearchParametersExist (params: OrgFilterParams): boolean {

--- a/auth-web/src/components/auth/staff/account-management/StaffActiveAccountsTable.vue
+++ b/auth-web/src/components/auth/staff/account-management/StaffActiveAccountsTable.vue
@@ -1,9 +1,9 @@
 <template>
-  <StaffAccountsTable :accountStatus="accountStatus" />
+  <StaffAccountsTable :accountStatus="accountStatus" :sessionStorageKeys="sessionStorageKeys" />
 </template>
 
 <script lang="ts">
-import { AccountStatus } from '@/util/constants'
+import { AccountStatus, SessionStorageKeys } from '@/util/constants'
 import StaffAccountsTable from '@/components/auth/common/StaffAccountsTable.vue'
 import { defineComponent } from '@vue/composition-api'
 
@@ -14,7 +14,8 @@ export default defineComponent({
   },
   data () {
     return {
-      accountStatus: AccountStatus.ACTIVE as AccountStatus
+      accountStatus: AccountStatus.ACTIVE as AccountStatus,
+      sessionStorageKeys: SessionStorageKeys.OrgSearchFilter
     }
   }
 })

--- a/auth-web/src/components/auth/staff/account-management/StaffInactiveAccountsTable.vue
+++ b/auth-web/src/components/auth/staff/account-management/StaffInactiveAccountsTable.vue
@@ -1,9 +1,9 @@
 <template>
-  <StaffAccountsTable :accountStatus="accountStatus" />
+  <StaffAccountsTable :accountStatus="accountStatus" :sessionStorageKeys="sessionStorageKeys" />
 </template>
 
 <script lang="ts">
-import { AccountStatus } from '@/util/constants'
+import { AccountStatus, SessionStorageKeys } from '@/util/constants'
 import StaffAccountsTable from '@/components/auth/common/StaffAccountsTable.vue'
 import { defineComponent } from '@vue/composition-api'
 
@@ -14,7 +14,8 @@ export default defineComponent({
   },
   data () {
     return {
-      accountStatus: AccountStatus.INACTIVE as AccountStatus
+      accountStatus: AccountStatus.INACTIVE as AccountStatus,
+      sessionStorageKeys: SessionStorageKeys.InactiveSearchFilter
     }
   }
 })

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -11,6 +11,7 @@ export enum SessionStorageKeys {
     PaginationOptions = 'PAGINATION_OPTIONS',
     PaginationNumberOfItems = 'PAGINATION_NUMBER_OF_ITEMS',
     OrgSearchFilter = 'ORG_SEARCH_FILTER',
+    InactiveSearchFilter = 'INACTIVE_SEARCH_FILTER',
     ShortNamesSummaryFilter = 'SHORT_NAMES_SUMMARY_FILTER',
     LinkedShortNamesFilter = 'LINKED_SHORT_NAMES_FILTER',
     ShortNamesTabIndex = 'SHORT_NAMES_TAB_INDEX',


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/19414

*Description of changes:* Clicking the "Inactive" tab does not display inactive accounts when applying a filter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
