### PR TITLE
21878  - AUTH WEB - Mailing address not update when switch accounts

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.31",
+  "version": "2.6.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.31",
+      "version": "2.6.32",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.31",
+  "version": "2.6.32",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountInfo.vue
@@ -389,7 +389,6 @@ export default class AccountInfo extends Mixins(
   private async setup () {
     this.setAccountDetails()
     await this.syncAddress()
-
     // show this part only account is not anon
     if (!this.anonAccount) {
       this.originalAddress = this.currentOrgAddress
@@ -402,6 +401,9 @@ export default class AccountInfo extends Mixins(
         this.$refs.editAccountForm?.validate() // validate form fields and show error message
         // SBTODO create a method in child comp
         this.$refs.mailingAddress?.triggerValidate() // validate form fields and show error message for address component from sbc-common-comp
+      } else {
+        this.isCompleteAccountInfo = true
+        this.errorMessage = ''
       }
     } else {
       // inorder to hide the address if not premium account

--- a/auth-web/src/components/auth/account-settings/account-info/AccountMailingAddress.vue
+++ b/auth-web/src/components/auth/account-settings/account-info/AccountMailingAddress.vue
@@ -17,7 +17,7 @@
         <div class="details">
           <div class="with-change-icon">
             <div class="mb-3">
-              <base-address-form
+              <BaseAddressForm
                 ref="mailingAddress"
                 :editing="!viewOnlyMode"
                 :schema="baseAddressSchema"
@@ -79,41 +79,53 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
+import { defineComponent, ref } from '@vue/composition-api'
 import BaseAddressForm from '@/components/auth/common/BaseAddressForm.vue'
 import { addressSchema } from '@/schemas'
 
-@Component({
+export default defineComponent({
+  name: 'AccountMailingAddress',
   components: {
     BaseAddressForm
+  },
+  props: {
+    baseAddress: {
+      type: Object,
+      default: () => null
+    },
+    viewOnlyMode: {
+      type: Boolean,
+      default: true
+    }
+  },
+  emit: ['valid', 'update:address'],
+  setup (props, { emit }) {
+    const baseAddressSchema = ref(addressSchema)
+
+    const mailingAddress = ref<HTMLFormElement | null>(null)
+
+    function updateAddress (address) {
+      emit('update:address', address)
+    }
+
+    function checkBaseAddressValidity (isValid) {
+      emit('valid', isValid)
+    }
+
+    function triggerValidate (): boolean {
+      // validate form fields and show error message for address component from sbc-common-component
+      return mailingAddress.value?.$refs.baseAddress?.$refs.addressForm?.validate()
+    }
+
+    return {
+      baseAddressSchema,
+      mailingAddress,
+      updateAddress,
+      checkBaseAddressValidity,
+      triggerValidate
+    }
   }
 })
-export default class AccountMailingAddress extends Vue {
-  @Prop({ default: null }) baseAddress: any
-  @Prop({ default: true }) viewOnlyMode: boolean
-
-  public baseAddressSchema = addressSchema
-
-  $refs: {
-    mailingAddress: HTMLFormElement
-  }
-
-  /** Emits an update message, so that we can sync with parent */
-  @Emit('update:address')
-  public updateAddress (address) {
-    return address
-  }
-
-  @Emit('valid')
-  public checkBaseAddressValidity (isValid) {
-    return isValid
-  }
-
-  triggerValidate (): boolean {
-    // validate form fields and show error message for address component from sbc-common-component
-    return this.$refs.mailingAddress?.$refs.baseAddress?.$refs.addressForm?.validate()
-  }
-}
 </script>
 
 <style lang="scss" scoped>

--- a/auth-web/src/components/auth/common/BaseAddressForm.vue
+++ b/auth-web/src/components/auth/common/BaseAddressForm.vue
@@ -11,52 +11,79 @@
 
 <script lang="ts">
 import { Address, BaseAddressModel } from '@/models/address'
-import { Component, Emit, Prop, Vue, Watch } from 'vue-property-decorator'
+import { PropType, defineComponent, onMounted, ref, watch } from '@vue/composition-api'
 import BaseAddress from '@bcrs-shared-components/base-address/BaseAddress.vue'
 import CommonUtils from '@/util/common-util'
 
-@Component({
+export default defineComponent({
+  name: 'BaseAddressForm',
   components: {
     BaseAddress
+  },
+  props: {
+    editing: {
+      type: Boolean,
+      default: true
+    },
+    schema: {
+      type: Object,
+      default: () => ({})
+    },
+    address: {
+      type: Object as PropType<Address>,
+      default: () => ({})
+    }
+  },
+  emit: ['valid', 'update:address'],
+  setup (props, { emit }) {
+    const inputaddress = ref<BaseAddressModel>({} as BaseAddressModel)
+
+    function loadAddressIntoInputAddress () {
+      // convert to address format to component
+      inputaddress.value = CommonUtils.convertAddressForComponent(props.address)
+      emitUpdateAddress(inputaddress.value)
+    }
+
+    function emitUpdateAddress (iaddress: BaseAddressModel): Address {
+      // convert back to Address
+      const address = CommonUtils.convertAddressForAuth(iaddress)
+      emit('update:address', address)
+      return address
+    }
+
+    function emitAddressValidity (isValid: boolean) {
+      emit('valid', isValid)
+      return isValid
+    }
+
+    function watchEditing (editing: boolean) {
+      if (!editing) {
+        loadAddressIntoInputAddress()
+      }
+    }
+
+    // Watch the editing prop
+    watch(() => props.editing, watchEditing)
+
+    // Watch the address prop
+    watch(() => props.address, () => {
+      loadAddressIntoInputAddress()
+    })
+
+    onMounted(() => {
+      if (props.address) {
+        loadAddressIntoInputAddress()
+      }
+    })
+
+    return {
+      inputaddress,
+      loadAddressIntoInputAddress,
+      emitUpdateAddress,
+      emitAddressValidity
+    }
   }
 })
-export default class BaseAddressForm extends Vue {
-  @Prop({ default: true }) editing: boolean
-  @Prop({ default: {} }) schema: any
-  @Prop({ default: () => ({} as Address) }) address: Address
-  private inputaddress: BaseAddressModel = {} as BaseAddressModel
-
-  mounted () {
-    if (this.address) {
-      this.loadAddressIntoInputAddress()
-    }
-  }
-
-  @Watch('editing')
-  private watchEditing (editing) {
-    if (!editing) {
-      this.loadAddressIntoInputAddress()
-    }
-  }
-
-  @Emit('update:address')
-  private emitUpdateAddress (iaddress): Address {
-    // convert back to Address
-    const address = CommonUtils.convertAddressForAuth(iaddress)
-    return address
-  }
-
-  @Emit('valid')
-  emitAddressValidity (isValid) {
-    return isValid
-  }
-
-  loadAddressIntoInputAddress () {
-    // convert to address format to component
-    this.inputaddress = CommonUtils.convertAddressForComponent(this.address)
-    this.emitUpdateAddress(this.inputaddress)
-  }
-}
 </script>
 
 <style lang="scss" scoped></style>

--- a/auth-web/src/components/auth/common/BaseAddressForm.vue
+++ b/auth-web/src/components/auth/common/BaseAddressForm.vue
@@ -56,19 +56,13 @@ export default defineComponent({
       return isValid
     }
 
-    function watchEditing (editing: boolean) {
+    watch(() => props.editing, (editing) => {
       if (!editing) {
         loadAddressIntoInputAddress()
       }
-    }
-
-    // Watch the editing prop
-    watch(() => props.editing, watchEditing)
-
-    // Watch the address prop
-    watch(() => props.address, () => {
-      loadAddressIntoInputAddress()
     })
+
+    watch(() => props.address, loadAddressIntoInputAddress)
 
     onMounted(() => {
       if (props.address) {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21878

*Description of changes:*
1. fix for: Mailing address not update when switch accounts
2. update relate components BaseAddressForm.vue and AccountMailingAddress.vue to composition-api

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
