### PR TITLE
21984 - Create migration that remove EFT_NSF from suspension_reason_codes

### DIFF
--- a/auth-api/migrations/versions/2024_06_24_acc7e2e2c2d7_remove_eft_nsf_from_suspension_reason_.py
+++ b/auth-api/migrations/versions/2024_06_24_acc7e2e2c2d7_remove_eft_nsf_from_suspension_reason_.py
@@ -1,0 +1,27 @@
+"""remove EFT_NSF from suspension_reason_codes
+
+Revision ID: acc7e2e2c2d7
+Revises: 7bf8428e568e
+Create Date: 2024-06-24 12:41:33.684863
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'acc7e2e2c2d7'
+down_revision = '7bf8428e568e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DELETE FROM suspension_reason_codes WHERE code = 'EFT_NSF'")
+
+
+def downgrade():
+    op.execute("INSERT INTO suspension_reason_codes "
+        "(code, description,\"default\") "
+        "VALUES "
+        "('EFT_NSF', 'EFT NSF', false)")


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21984

*Description of changes:* AUTH-API - Create migration that remove EFT_NSF from suspension_reason_codes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
