### PR TITLE
add install docker-compose to auth-api-ci.yml, auth-queue-ci.yml, account-mailer-ci.yml

### DIFF
--- a/.github/workflows/account-mailer-ci.yml
+++ b/.github/workflows/account-mailer-ci.yml
@@ -88,6 +88,11 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install docker-compose
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
       - name: Install dependencies
         run: |
           make setup

--- a/.github/workflows/auth-api-ci.yml
+++ b/.github/workflows/auth-api-ci.yml
@@ -36,11 +36,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install docker-compose
-        run: |
-          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-          docker-compose version
       - name: Install dependencies
         run: |
           make setup
@@ -100,6 +95,11 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install docker-compose
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
       - name: Install dependencies
         run: |
           make setup

--- a/.github/workflows/auth-api-ci.yml
+++ b/.github/workflows/auth-api-ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install docker-compose
         run: |
           make setup
       - name: Lint with pylint

--- a/.github/workflows/auth-api-ci.yml
+++ b/.github/workflows/auth-api-ci.yml
@@ -38,6 +38,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install docker-compose
         run: |
+          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
+      - name: Install dependencies
+        run: |
           make setup
       - name: Lint with pylint
         id: pylint

--- a/.github/workflows/auth-queue-ci.yml
+++ b/.github/workflows/auth-queue-ci.yml
@@ -81,6 +81,11 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install docker-compose
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose version
       - name: Install dependencies
         run: |
           make setup


### PR DESCRIPTION


adding the following to CI files:
```
- name: Install docker-compose
        run: |
          sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
          sudo chmod +x /usr/local/bin/docker-compose
          docker-compose version
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
