### PR TITLE
updating release version number to 2.10.4

### DIFF
--- a/auth-api/src/auth_api/version.py
+++ b/auth-api/src/auth_api/version.py
@@ -22,4 +22,4 @@ Post-release segment: .postN
 Development release segment: .devN
 """
 
-__version__ = '2.10.3'  # pylint: disable=invalid-name
+__version__ = '2.10.4'  # pylint: disable=invalid-name


### PR DESCRIPTION
updating version number for release, going from 2.10.3 to 2.10.4


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
