### PR TITLE
20415 Linking modal fix, update page limit to match account list size

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.70",
+  "version": "2.6.71",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.70",
+      "version": "2.6.71",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.70",
+  "version": "2.6.71",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/pay/ShortNameLookup.vue
+++ b/auth-web/src/components/pay/ShortNameLookup.vue
@@ -201,7 +201,8 @@ export default defineComponent({
         const accountIds = eftAccounts.map((org) => org.accountId)
 
         const eftShortNamesResponse = await PaymentService.getEFTShortNames(
-          { 'filterPayload': { 'accountIdList': accountIds.join(',') } }
+          { 'filterPayload': { 'accountIdList': accountIds.join(',') },
+            'pageLimit': accountIds.length }
         )
 
         const eftShortNames = eftShortNamesResponse.data.items


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/20415

*Description of changes:*
- update short name search page limit to be the account list size


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
