### PR TITLE
Update sbc-common-components 3.0.15

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -30,7 +30,7 @@
         "pinia": "^2.1.6",
         "pinia-class": "^0.0.3",
         "sanitize-html": "^2.13.0",
-        "sbc-common-components": "3.0.12",
+        "sbc-common-components": "3.0.15",
         "vue": "2.6.14",
         "vue-auto-resize": "^1.0.1",
         "vue-debounce-decorator": "^1.0.1",
@@ -10943,9 +10943,9 @@
       }
     },
     "node_modules/sbc-common-components": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-3.0.12.tgz",
-      "integrity": "sha512-xi+zRXCyhnlKQgqbDoPd64Mrs/peB3+TwBv8H3VoEAVkVVr+z6mxfn+ej4WIlGv8KPQkL30LGBQRuZ0TG/JwxQ==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-3.0.15.tgz",
+      "integrity": "sha512-tmh7rXm1RelAGsU+Vjt6u7dDbKGZoVOxvKnJA+YRPp1Qem+L6ta6xAn9asJfg48Dn+haGVhPnEAVwhqwDCJeYg==",
       "dependencies": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.21.1",
@@ -21442,9 +21442,9 @@
       }
     },
     "sbc-common-components": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-3.0.12.tgz",
-      "integrity": "sha512-xi+zRXCyhnlKQgqbDoPd64Mrs/peB3+TwBv8H3VoEAVkVVr+z6mxfn+ej4WIlGv8KPQkL30LGBQRuZ0TG/JwxQ==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/sbc-common-components/-/sbc-common-components-3.0.15.tgz",
+      "integrity": "sha512-tmh7rXm1RelAGsU+Vjt6u7dDbKGZoVOxvKnJA+YRPp1Qem+L6ta6xAn9asJfg48Dn+haGVhPnEAVwhqwDCJeYg==",
       "requires": {
         "@mdi/font": "^4.5.95",
         "axios": "^0.21.1",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -37,7 +37,7 @@
     "pinia": "^2.1.6",
     "pinia-class": "^0.0.3",
     "sanitize-html": "^2.13.0",
-    "sbc-common-components": "3.0.12",
+    "sbc-common-components": "3.0.15",
     "vue": "2.6.14",
     "vue-auto-resize": "^1.0.1",
     "vue-debounce-decorator": "^1.0.1",


### PR DESCRIPTION
Update sbc-common-components 3.0.15

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
