### PR TITLE
21539/23102 - EFT Wire and EFT Refund updates

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.90",
+  "version": "2.6.91",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.90",
+      "version": "2.6.91",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",
@@ -58,7 +58,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/eslint-config-typescript": "^4.0.0",
         "@vue/test-utils": "1.3.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.90",
+  "version": "2.6.91",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/assets/scss/ShortnameTables.scss
+++ b/auth-web/src/assets/scss/ShortnameTables.scss
@@ -12,6 +12,10 @@
   .base-table__header__filter {
     padding-left: 16px;
     padding-right: 4px;
+    .v-input {
+      font-size: 14px;
+      color: #495057;
+    }
   }
   .base-table__item-row {
     color: #495057;

--- a/auth-web/src/components/pay/LinkedShortNameTable.vue
+++ b/auth-web/src/components/pay/LinkedShortNameTable.vue
@@ -41,6 +41,9 @@
           </v-icon>
         </v-btn>
       </template>
+      <template #item-slot-shortNameType="{ item }">
+        <span>{{ getShortNameTypeDescription(item.shortNameType) }}</span>
+      </template>
       <template #item-slot-accountName="{ item }">
         <span>{{ item.accountName }}</span>
         <v-chip
@@ -77,13 +80,20 @@
   </div>
 </template>
 <script lang="ts">
-import { AccountStatus, CfsAccountStatus, SessionStorageKeys, ShortNameStatus, SuspensionReason } from '@/util/constants'
+import {
+  AccountStatus,
+  CfsAccountStatus,
+  SessionStorageKeys,
+  ShortNameStatus,
+  SuspensionReason
+} from '@/util/constants'
 import { defineComponent, onMounted, reactive, toRefs, watch } from '@vue/composition-api'
 import { BaseVDataTable } from '..'
 import CommonUtils from '@/util/common-util'
 import ConfigHelper from '@/util/config-helper'
 import { DEFAULT_DATA_OPTIONS } from '../datatable/resources'
 import { LinkedShortNameState } from '@/models/pay/short-name'
+import ShortNameUtils from '@/util/short-name-utils'
 import _ from 'lodash'
 import { useShortNameTable } from '@/composables/short-name-table-factory'
 
@@ -113,22 +123,26 @@ export default defineComponent({
     })
 
     const { infiniteScrollCallback, loadTableData, updateFilter } = useShortNameTable(state, emit)
-    const createHeader = (col, label, type, value, filterValue = '', hasFilter = true, minWidth = '125px') => ({
+    const createHeader = (col, label, type, value, filterValue = '', hasFilter = true, minWidth = '125px',
+      width = '125px', filterItems = []) => ({
       col,
       customFilter: {
         filterApiFn: hasFilter ? (val: any) => loadTableData(col, val || '') : null,
         clearable: true,
+        items: filterItems.length > 0 ? filterItems : undefined,
         label,
         type,
         value: filterValue
       },
       hasFilter,
       minWidth,
+      width,
       value
     })
 
     const {
       shortName = '',
+      shortNameType = '',
       accountName = '',
       accountBranch = '',
       accountId = '',
@@ -145,6 +159,17 @@ export default defineComponent({
         shortName,
         true,
         '180px'
+      ),
+      createHeader(
+        'shortNameType',
+        'Type',
+        'select',
+        'Type',
+        shortNameType,
+        true,
+        '200px',
+        '200px',
+        ShortNameUtils.ShortNameTypeItems
       ),
       createHeader(
         'accountName',
@@ -212,6 +237,7 @@ export default defineComponent({
       return {
         accountName: '',
         shortName: '',
+        shortNameType: '',
         accountBranch: '',
         accountId: '',
         state: ShortNameStatus.LINKED
@@ -264,7 +290,8 @@ export default defineComponent({
       formatAmount,
       CfsAccountStatus,
       AccountStatus,
-      SuspensionReason
+      SuspensionReason,
+      getShortNameTypeDescription: ShortNameUtils.getShortNameTypeDescription
     }
   }
 })

--- a/auth-web/src/components/pay/ShortNameSummaryTable.vue
+++ b/auth-web/src/components/pay/ShortNameSummaryTable.vue
@@ -95,7 +95,7 @@
         </v-btn>
       </template>
       <template #item-slot-lastPaymentReceivedDate="{ item }">
-        <span>{{ formatDate(item.lastPaymentReceivedDate) }}</span>
+        <span>{{ formatDate(item.lastPaymentReceivedDate, dateDisplayFormat) }}</span>
       </template>
       <template #item-slot-shortNameType="{ item }">
         <span>{{ getShortNameTypeDescription(item.shortNameType) }}</span>
@@ -187,6 +187,7 @@ export default defineComponent({
   },
   emits: ['on-link-account'],
   setup (props, { emit, root }) {
+    const dateDisplayFormat = 'MMMM DD, YYYY'
     const datePicker = ref(null)
     const accountLinkingDialog: Ref<InstanceType<typeof ModalDialog>> = ref(null)
     const accountLinkingErrorDialog: Ref<InstanceType<typeof ModalDialog>> = ref(null)
@@ -308,10 +309,6 @@ export default defineComponent({
 
     function formatAmount (amount: number) {
       return amount !== undefined ? CommonUtils.formatAmount(amount) : ''
-    }
-
-    function formatDate (date: string) {
-      return date ? CommonUtils.formatDisplayDate(date, 'MMMM DD, YYYY') : ''
     }
 
     function openAccountLinkingDialog (item: EFTShortnameResponse) {
@@ -437,7 +434,8 @@ export default defineComponent({
       headers,
       updateFilter,
       formatAmount,
-      formatDate,
+      formatDate: CommonUtils.formatUtcToPacificDate,
+      dateDisplayFormat,
       updateDateRange,
       onLinkAccount,
       clickDatePicker,

--- a/auth-web/src/components/pay/eft/ShortNameLinkingDialog.vue
+++ b/auth-web/src/components/pay/eft/ShortNameLinkingDialog.vue
@@ -12,6 +12,9 @@
       @close-dialog="resetAccountLinkingDialog"
     >
       <template #text>
+        <p class="mb-1">
+          Short Name Type: {{ getShortNameTypeDescription(currentShortName.shortNameType) }}
+        </p>
         <p>After the account has been linked, payment will be applied at 6:00 p.m. Pacific Time.</p>
         <h4>
           Search by Account ID or Name to Link:
@@ -103,6 +106,7 @@ import ModalDialog from '@/components/auth/common/ModalDialog.vue'
 import PaymentService from '@/services/payment.services'
 import ShortNameLookup from '@/components/pay/ShortNameLookup.vue'
 import { ShortNameResponseStatus } from '@/util/constants'
+import ShortNameUtils from '@/util/short-name-utils'
 import { useOrgStore } from '@/stores/org'
 
 interface ShortNameLinkingDialog {
@@ -223,7 +227,8 @@ export default defineComponent({
       cancelAndResetAccountLinkingDialog,
       closeAccountAlreadyLinkedDialog,
       linkAccount,
-      isUnsettledAmountAndOwingAmountMatch
+      isUnsettledAmountAndOwingAmountMatch,
+      getShortNameTypeDescription: ShortNameUtils.getShortNameTypeDescription
     }
   }
 })
@@ -272,5 +277,4 @@ h4 {
       color: var(--v-primary-base);
   }
 }
-
 </style>

--- a/auth-web/src/components/pay/eft/ShortNamePaymentHistory.vue
+++ b/auth-web/src/components/pay/eft/ShortNamePaymentHistory.vue
@@ -133,14 +133,14 @@
           </template>
           <template v-if="showRefundDetailAction(item)">
             <v-btn
-                small
-                color="primary"
-                min-width="5rem"
-                min-height="2rem"
-                class="open-action-btn single-action-btn"
-                data-test="reverse-payment-button"
-                :loading="loading"
-                @click="showConfirmReversePaymentModal(item)"
+              small
+              color="primary"
+              min-width="5rem"
+              min-height="2rem"
+              class="open-action-btn single-action-btn"
+              data-test="reverse-payment-button"
+              :loading="loading"
+              @click="viewRefundDetails(item.eftRefundId)"
             >
               Refund Detail
             </v-btn>
@@ -178,7 +178,7 @@ export default defineComponent({
       })
     }
   },
-  setup (props, { emit }) {
+  setup (props, { emit, root }) {
     const enum ConfirmationType {
       REVERSE_PAYMENT = 'reversePayment',
     }
@@ -293,10 +293,6 @@ export default defineComponent({
       return `${height}px`
     }
 
-    function isStatementTransaction (item: any) {
-      return item?.statementNumber
-    }
-
     function showRefundDetailAction (item: any) {
       return shortNameRefundTypes.includes(item.transactionType)
     }
@@ -345,6 +341,16 @@ export default defineComponent({
     function formatTransactionDate (str: string): string {
       const date = moment.utc(str).toDate()
       return (date) ? moment(date).tz('America/Vancouver').format('MMMM D, YYYY') : ''
+    }
+
+    function viewRefundDetails (id: string) {
+      if (!id) return
+      root.$router?.push({
+        name: 'shortnamerefund',
+        params: {
+          eftRefundId: id
+        }
+      })
     }
 
     async function reversePayment (item: any) {
@@ -437,7 +443,7 @@ export default defineComponent({
       state,
       infiniteScrollCallback,
       calculateTableHeight,
-      isStatementTransaction
+      viewRefundDetails
     }
   }
 })

--- a/auth-web/src/components/pay/eft/ShortNamePaymentHistory.vue
+++ b/auth-web/src/components/pay/eft/ShortNamePaymentHistory.vue
@@ -100,7 +100,7 @@
       </template>
       <template #header-filter-slot />
       <template #item-slot-transactionDate="{ item }">
-        <span>{{ formatDate(item.transactionDate, 'MMMM DD, YYYY') }}</span>
+        <span>{{ formatDate(item.transactionDate, dateDisplayFormat) }}</span>
       </template>
       <template #item-slot-transactionDescription="{ item }">
         <span>{{ formatDescription(item) }}</span>
@@ -165,7 +165,6 @@ import { EFTTransactionState } from '@/models/eft-transaction'
 import ModalDialog from '@/components/auth/common/ModalDialog.vue'
 import PaymentService from '@/services/payment.services'
 import _ from 'lodash'
-import moment from 'moment-timezone'
 
 export default defineComponent({
   name: 'ShortNamePaymentHistory',
@@ -179,6 +178,7 @@ export default defineComponent({
     }
   },
   setup (props, { emit, root }) {
+    const dateDisplayFormat = 'MMMM D, YYYY'
     const enum ConfirmationType {
       REVERSE_PAYMENT = 'reversePayment',
     }
@@ -338,11 +338,6 @@ export default defineComponent({
       return ShortNameHistoryTypeDescription[item.transactionType]
     }
 
-    function formatTransactionDate (str: string): string {
-      const date = moment.utc(str).toDate()
-      return (date) ? moment(date).tz('America/Vancouver').format('MMMM D, YYYY') : ''
-    }
-
     function viewRefundDetails (id: string) {
       if (!id) return
       root.$router?.push({
@@ -431,7 +426,8 @@ export default defineComponent({
       historyTable,
       formatBalanceAmount,
       formatTransactionAmount,
-      formatDate: formatTransactionDate,
+      formatDate: CommonUtils.formatUtcToPacificDate,
+      dateDisplayFormat,
       formatAdditionalDescription,
       formatDescription,
       dialogConfirm,

--- a/auth-web/src/components/pay/eft/ShortNameRefund.vue
+++ b/auth-web/src/components/pay/eft/ShortNameRefund.vue
@@ -70,8 +70,7 @@ export default defineComponent({
       root.$router?.push({
         name: 'shortnamerefund',
         params: {
-          'shortNameDetails': JSON.stringify(props.shortNameDetails),
-          'unsettledAmount': props.unsettledAmount
+          shortNameId: props.shortNameDetails.id
         }
       })
     }

--- a/auth-web/src/models/pay/short-name.ts
+++ b/auth-web/src/models/pay/short-name.ts
@@ -77,3 +77,27 @@ export interface ShortNameSummaryState {
   snackbar: boolean
   highlightIndex: number
 }
+
+export interface ShortNameDetails {
+  shortName: string;
+  creditsRemaining?: number;
+  linkedAccountsCount: number;
+  lastPaymentReceivedDate: Date;
+}
+
+export interface EFTRefund {
+  id: number;
+  casSupplierNumber?: string;
+  comment?: string;
+  createdBy?: string;
+  createdName?: string;
+  createdOn?: Date;
+  declineReason?: string;
+  refundAmount?: number;
+  refundEmail?: string;
+  shortnameId?: number;
+  status?: string;
+  updatedBy?: string;
+  updatedName?: string;
+  updatedOn?: Date;
+}

--- a/auth-web/src/routes/router.ts
+++ b/auth-web/src/routes/router.ts
@@ -883,7 +883,7 @@ export function getRoutes (): RouteConfig[] {
       props: (route) => ({ shortNameId: route.params.shortNameId })
     },
     {
-      path: '/pay/shortname-details/:shortNameId/refund',
+      path: '/pay/shortname-details/:shortNameId/refund/:eftRefundId',
       name: 'shortnamerefund',
       component: ShortNameRefundView,
       meta: {
@@ -899,8 +899,7 @@ export function getRoutes (): RouteConfig[] {
       },
       props: route => ({
         shortNameId: Number(route.params.shortNameId),
-        shortNameDetails: route.params.shortNameDetails ? JSON.parse(route.params.shortNameDetails) : {},
-        unsettledAmount: route.params.unsettledAmount || ''
+        eftRefundId: route.params.eftRefundId ? Number(route.params.shortNameId) : undefined
       })
     },
     {

--- a/auth-web/src/routes/router.ts
+++ b/auth-web/src/routes/router.ts
@@ -883,7 +883,7 @@ export function getRoutes (): RouteConfig[] {
       props: (route) => ({ shortNameId: route.params.shortNameId })
     },
     {
-      path: '/pay/shortname-details/:shortNameId/refund/:eftRefundId',
+      path: '/pay/shortname-details/:shortNameId/refund/:eftRefundId?',
       name: 'shortnamerefund',
       component: ShortNameRefundView,
       meta: {
@@ -898,7 +898,7 @@ export function getRoutes (): RouteConfig[] {
         showNavBar: true
       },
       props: route => ({
-        shortNameId: Number(route.params.shortNameId),
+        shortNameId: route.params.shortNameId,
         eftRefundId: route.params.eftRefundId ? Number(route.params.shortNameId) : undefined
       })
     },

--- a/auth-web/src/routes/router.ts
+++ b/auth-web/src/routes/router.ts
@@ -898,7 +898,7 @@ export function getRoutes (): RouteConfig[] {
         showNavBar: true
       },
       props: route => ({
-        shortNameId: route.params.shortNameId,
+        shortNameId: Number(route.params.shortNameId),
         eftRefundId: route.params.eftRefundId ? Number(route.params.shortNameId) : undefined
       })
     },

--- a/auth-web/src/services/payment.services.ts
+++ b/auth-web/src/services/payment.services.ts
@@ -301,8 +301,13 @@ export default class PaymentService {
     return axios.get(url, { params })
   }
 
-  static getEFTShortnameSummary (shortNameId: string): AxiosPromise<EFTShortnameResponse> {
+  static getEFTShortnameSummary (shortNameId: string | number): AxiosPromise<EFTShortnameResponse> {
     const url = `${ConfigHelper.getPayAPIURL()}/eft-shortnames/summaries?shortNameId=${shortNameId}`
+    return axios.get(url)
+  }
+
+  static getEFTRefund (eftRefundId: number): AxiosPromise<EFTShortnameResponse> {
+    const url = `${ConfigHelper.getPayAPIURL()}/eft-shortnames/shortname-refund/${eftRefundId}`
     return axios.get(url)
   }
 

--- a/auth-web/src/util/common-util.ts
+++ b/auth-web/src/util/common-util.ts
@@ -1,3 +1,4 @@
+import 'moment-timezone'
 import { Address, BaseAddressModel } from '@/models/address'
 import { NrRequestActionCodes, NrRequestTypeCodes } from '@bcrs-shared-components/enums'
 import { NrRequestTypeStrings, Permission } from '@/util/constants'
@@ -150,6 +151,13 @@ export default class CommonUtils {
   // Formatting date in the desired format for vue date pickers
   static formatCurrentDate () {
     return moment(new Date()).format('MMMM DD, YYYY')
+  }
+
+  static formatUtcToPacificDate (dateStr: string, format: string): string {
+    if (!dateStr) return ''
+    const date = moment.utc(dateStr).toDate()
+    return (date) ? moment(date).tz('America/Vancouver')
+      .format(format) : ''
   }
 
   static formatStatementString (fromDate: string, toDate: string) {

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -705,14 +705,20 @@ export enum ShortNameHistoryType {
     FUNDS_RECEIVED = 'FUNDS_RECEIVED',
     INVOICE_REFUND = 'INVOICE_REFUND',
     STATEMENT_PAID = 'STATEMENT_PAID',
-    STATEMENT_REVERSE = 'STATEMENT_REVERSE'
+    STATEMENT_REVERSE = 'STATEMENT_REVERSE',
+    SN_REFUND_PENDING_APPROVAL = 'SN_REFUND_PENDING_APPROVAL',
+    SN_REFUND_APPROVED = 'SN_REFUND_APPROVED',
+    SN_REFUND_REJECTED = 'SN_REFUND_REJECTED'
 }
 
 export enum ShortNameHistoryTypeDescription {
     FUNDS_RECEIVED = 'Funds Received',
     INVOICE_REFUND = 'Invoice Refund',
     STATEMENT_PAID = 'Statement Paid',
-    STATEMENT_REVERSE = 'Payment Reversed'
+    STATEMENT_REVERSE = 'Payment Reversed',
+    SN_REFUND_PENDING_APPROVAL = 'Short Name Refund Request',
+    SN_REFUND_APPROVED = 'Short Name Refund Request',
+    SN_REFUND_REJECTED = 'Short Name Refund Request'
 }
 
 export enum CfsAccountStatus {

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -691,6 +691,16 @@ export enum ShortNameResponseStatus {
     EFT_SHORT_NAME_ALREADY_MAPPED = 'EFT_SHORT_NAME_ALREADY_MAPPED'
 }
 
+export enum ShortNameType {
+    EFT = 'EFT',
+    WIRE = 'WIRE'
+}
+
+export enum ShortNameTypeDescription {
+    EFT = 'EFT',
+    WIRE = 'Wire Transfer'
+}
+
 export enum ShortNameHistoryType {
     FUNDS_RECEIVED = 'FUNDS_RECEIVED',
     INVOICE_REFUND = 'INVOICE_REFUND',

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -691,6 +691,18 @@ export enum ShortNameResponseStatus {
     EFT_SHORT_NAME_ALREADY_MAPPED = 'EFT_SHORT_NAME_ALREADY_MAPPED'
 }
 
+export enum EFTRefundType {
+    APPROVED = 'APPROVED',
+    PENDING_APPROVAL = 'PENDING_APPROVAL',
+    REJECTED = 'REJECTED'
+}
+
+export enum EFTRefundTypeDescription {
+    APPROVED = 'Approved',
+    PENDING_APPROVAL = 'Requested',
+    REJECTED = 'Declined'
+}
+
 export enum ShortNameType {
     EFT = 'EFT',
     WIRE = 'WIRE'

--- a/auth-web/src/util/short-name-utils.ts
+++ b/auth-web/src/util/short-name-utils.ts
@@ -1,4 +1,4 @@
-import { ShortNameType, ShortNameTypeDescription } from '@/util/constants'
+import { EFTRefundTypeDescription, ShortNameType, ShortNameTypeDescription } from '@/util/constants'
 
 /**
  * A class to put all the common short name utility methods.
@@ -12,5 +12,9 @@ export default class ShortNameUtils {
 
   static getShortNameTypeDescription (type: string) {
     return type ? ShortNameTypeDescription[type] : type
+  }
+
+  static getEFTRefundTypeDescription (type: string) {
+    return type ? EFTRefundTypeDescription[type] : type
   }
 }

--- a/auth-web/src/util/short-name-utils.ts
+++ b/auth-web/src/util/short-name-utils.ts
@@ -5,7 +5,7 @@ import { EFTRefundTypeDescription, ShortNameType, ShortNameTypeDescription } fro
  */
 export default class ShortNameUtils {
   // Header Filter item definitions used for drop down select
-  static ShortNameTypeItems = [
+  static readonly ShortNameTypeItems = [
     { text: ShortNameTypeDescription[ShortNameType.EFT], value: ShortNameType.EFT },
     { text: ShortNameTypeDescription[ShortNameType.WIRE], value: ShortNameType.WIRE }
   ]

--- a/auth-web/src/util/short-name-utils.ts
+++ b/auth-web/src/util/short-name-utils.ts
@@ -1,0 +1,16 @@
+import { ShortNameType, ShortNameTypeDescription } from '@/util/constants'
+
+/**
+ * A class to put all the common short name utility methods.
+ */
+export default class ShortNameUtils {
+  // Header Filter item definitions used for drop down select
+  static ShortNameTypeItems = [
+    { text: ShortNameTypeDescription[ShortNameType.EFT], value: ShortNameType.EFT },
+    { text: ShortNameTypeDescription[ShortNameType.WIRE], value: ShortNameType.WIRE }
+  ]
+
+  static getShortNameTypeDescription (type: string) {
+    return type ? ShortNameTypeDescription[type] : type
+  }
+}

--- a/auth-web/src/views/pay/eft/ShortNameDetailsView.vue
+++ b/auth-web/src/views/pay/eft/ShortNameDetailsView.vue
@@ -16,12 +16,16 @@
         <h1 class="view-header__title">
           {{ shortNameDetails.shortName }}
         </h1>
-        <p class="mt-3 mb-0">
+        <p class="mt-6 mb-0">
           <span class="font-weight-bold">Unsettled Amount: </span>{{ unsettledAmount }}
         </p>
       </div>
       <div class="shortname-info">
-        <div class="mb-6 overflow-wrap">
+        <div class="mb-2 overflow-wrap">
+          <span class="font-weight-bold">Type: </span>
+          {{ getShortNameTypeDescription(shortName.shortNameType) }}
+        </div>
+        <div class="mb-2 overflow-wrap">
           <span class="font-weight-bold">CAS Supplier Number: </span>
           {{ shortName.casSupplierNumber || 'N/A' }}
           <span
@@ -113,6 +117,7 @@ import ShortNameAccountLink from '@/components/pay/eft/ShortNameAccountLink.vue'
 import ShortNameFinancialDialog from '@/components/pay/eft/ShortNameFinancialDialog.vue'
 import ShortNamePaymentHistory from '@/components/pay/eft/ShortNamePaymentHistory.vue'
 import ShortNameRefund from '@/components/pay/eft/ShortNameRefund.vue'
+import ShortNameUtils from '@/util/short-name-utils'
 import moment from 'moment'
 import { useUserStore } from '@/stores/user'
 
@@ -232,7 +237,8 @@ export default defineComponent({
       openShortNameSupplierNumberDialog,
       formatCurrency: CommonUtils.formatAmount,
       unsettledAmountHeader,
-      closeShortNameLinkingDialog
+      closeShortNameLinkingDialog,
+      getShortNameTypeDescription: ShortNameUtils.getShortNameTypeDescription
     }
   }
 })

--- a/auth-web/src/views/pay/eft/ShortNameDetailsView.vue
+++ b/auth-web/src/views/pay/eft/ShortNameDetailsView.vue
@@ -114,19 +114,13 @@ import CommonUtils from '@/util/common-util'
 import PaymentService from '@/services/payment.services'
 import { Role } from '@/util/constants'
 import ShortNameAccountLink from '@/components/pay/eft/ShortNameAccountLink.vue'
+import { ShortNameDetails } from '@/models/pay/short-name'
 import ShortNameFinancialDialog from '@/components/pay/eft/ShortNameFinancialDialog.vue'
 import ShortNamePaymentHistory from '@/components/pay/eft/ShortNamePaymentHistory.vue'
 import ShortNameRefund from '@/components/pay/eft/ShortNameRefund.vue'
 import ShortNameUtils from '@/util/short-name-utils'
 import moment from 'moment'
 import { useUserStore } from '@/stores/user'
-
-interface ShortNameDetails {
-  shortName: string;
-  creditsRemaining?: number;
-  linkedAccountsCount: number;
-  lastPaymentReceivedDate: Date;
-}
 
 export default defineComponent({
   name: 'ShortNameMappingView',

--- a/auth-web/src/views/pay/eft/ShortNameRefundView.vue
+++ b/auth-web/src/views/pay/eft/ShortNameRefundView.vue
@@ -27,10 +27,19 @@
 
               <v-row>
                 <v-col class="col-6 col-sm-3 font-weight-bold">
+                  Type
+                </v-col>
+                <v-col class="pl-0">
+                  {{ getShortNameTypeDescription(shortNameDetails.shortNameType) }}
+                </v-col>
+              </v-row>
+
+              <v-row v-if="!readOnly">
+                <v-col class="col-6 col-sm-3 font-weight-bold">
                   Unsettled Amount on Short Name
                 </v-col>
                 <v-col class="pl-0">
-                  {{ unsettledAmount }}
+                  {{ formatAmount(shortNameDetails.creditsRemaining) }}
                 </v-col>
               </v-row>
 
@@ -38,7 +47,14 @@
                 <v-col class="col-6 col-sm-3 font-weight-bold">
                   Refund Amount
                 </v-col>
+                <v-col
+                  v-if="readOnly"
+                  class="pl-0"
+                >
+                  {{ formatAmount(refundDetails.refundAmount) }}
+                </v-col>
                 <v-text-field
+                  v-else
                   v-model.trim="refundAmount"
                   filled
                   label="Refund Amount"
@@ -53,7 +69,14 @@
                 <v-col class="col-6 col-sm-3 font-weight-bold">
                   CAS Supplier Number
                 </v-col>
+                <v-col
+                  v-if="readOnly"
+                  class="pl-0"
+                >
+                  {{ refundDetails.casSupplierNumber }}
+                </v-col>
                 <v-text-field
+                  v-else
                   v-model.trim="casSupplierNum"
                   hint="This number should be created in CAS before issuing a refund"
                   filled
@@ -69,7 +92,14 @@
                 <v-col class="col-6 col-sm-3 font-weight-bold">
                   Email
                 </v-col>
+                <v-col
+                  v-if="readOnly"
+                  class="pl-0"
+                >
+                  {{ refundDetails.refundEmail }}
+                </v-col>
                 <v-text-field
+                  v-else
                   v-model.trim="email"
                   hint="The email provided in the client's Direct Deposit Application form"
                   filled
@@ -81,11 +111,18 @@
                 />
               </v-row>
 
-              <v-row>
+              <v-row v-if="!readOnly">
                 <v-col class="col-6 col-sm-3 font-weight-bold">
                   Reason for Refund
                 </v-col>
+                <v-col
+                  v-if="readOnly"
+                  class="pl-0"
+                >
+                  {{ refundDetails.comment }}
+                </v-col>
                 <v-text-field
+                  v-else
                   v-model.trim="staffComment"
                   filled
                   label="Reason for Refund"
@@ -97,8 +134,43 @@
               </v-row>
             </v-col>
           </v-row>
+          <v-row v-if="readOnly">
+            <v-col class="col-6 col-sm-3 font-weight-bold">
+              Requested By Qualified Receiver
+            </v-col>
+            <v-col class="pl-0">
+              {{ refundDetails.createdBy }} {{ formatDate(refundDetails.createdOn) }}
+            </v-col>
+          </v-row>
+          <v-row v-if="readOnly">
+            <v-col class="col-6 col-sm-3 font-weight-bold">
+              Qualified Receiver Comment
+            </v-col>
+            <v-col class="pl-0">
+              {{ refundDetails.comment }}
+            </v-col>
+          </v-row>
+          <v-row v-if="readOnly && isApproved()">
+            <v-col class="col-6 col-sm-3 font-weight-bold">
+              Approved By Expense Authority
+            </v-col>
+            <v-col class="pl-0">
+              {{ refundDetails.updatedBy }} {{ formatDate(refundDetails.updatedOn) }}
+            </v-col>
+          </v-row>
+          <v-row v-if="readOnly">
+            <v-col class="col-6 col-sm-3 font-weight-bold">
+              Refund Status
+            </v-col>
+            <v-col class="pl-0">
+              {{ getEFTRefundTypeDescription(refundDetails.status) }}
+            </v-col>
+          </v-row>
         </v-card-text>
-        <v-card-actions class="pr-4 justify-end pa-3 pb-5">
+        <v-card-actions
+          v-if="!readOnly"
+          class="pr-4 justify-end pa-3 pb-5"
+        >
           <v-btn
             large
             outlined
@@ -133,39 +205,42 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, reactive, ref, toRefs, watch } from '@vue/composition-api'
+import { EFTRefund, ShortNameDetails } from '@/models/pay/short-name'
+import { computed, defineComponent, onMounted, reactive, ref, toRefs, watch } from '@vue/composition-api'
+import CommonUtils from '@/util/common-util'
+import { EFTRefundType } from '@/util/constants'
 import { EftRefundRequest } from '@/models/refund'
+import PaymentService from '@/services/payment.services'
+import ShortNameUtils from '@/util/short-name-utils'
+import moment from 'moment-timezone'
 import { useOrgStore } from '@/stores/org'
 
 export default defineComponent({
   name: 'ShortNameRefundView',
   props: {
-    shortNameDetails: {
-      type: Object,
-      default: () => ({
-        shortName: ''
-      })
-    },
-    unsettledAmount: {
-      type: String,
-      default: ''
-    },
     shortNameId: {
+      type: Number,
+      default: undefined
+    },
+    eftRefundId: {
       type: Number,
       default: undefined
     }
   },
   setup (props, { root }) {
     const state = reactive({
+      shortNameDetails: {} as ShortNameDetails,
+      refundDetails: {} as EFTRefund,
       refundAmount: undefined,
       casSupplierNum: '',
       email: '',
       staffComment: '',
       isLoading: false,
+      readOnly: true,
       refundAmountRules: [
         v => !!v || 'Refund Amount is required',
         v => parseFloat(v) > 0 || 'Refund Amount must be greater than zero',
-        v => parseFloat(v) <= parseFloat(props.shortNameDetails?.creditsRemaining) || 'Amount must be less than unsettled amount on short name',
+        v => parseFloat(v) <= parseFloat(state.shortNameDetails?.creditsRemaining) || 'Amount must be less than unsettled amount on short name',
         v => /^\d+(\.\d{1,2})?$/.test(v) || 'Amounts must be less than 2 decimal places'
       ],
       casSupplierNumRules: [
@@ -185,6 +260,55 @@ export default defineComponent({
       ],
       isSubmitted: false
     })
+
+    function isApproved () {
+      return state.refundDetails?.status === EFTRefundType.APPROVED
+    }
+
+    onMounted(async () => {
+      await loadShortnameDetails(props.shortNameId)
+
+      if (props.eftRefundId) {
+        state.readOnly = true
+        await loadShortnameRefund(props.eftRefundId)
+      }
+    })
+
+    function formatDate (str: string): string {
+      const date = moment.utc(str).toDate()
+      return (date) ? moment(date).tz('America/Vancouver')
+        .format('MMM DD, YYYY h:mm A [Pacific Time]') : ''
+    }
+
+    async function loadShortnameDetails (shortnameId: number): Promise<void> {
+      try {
+        const response = await PaymentService.getEFTShortnameSummary(shortnameId)
+        if (response?.data) {
+          state.shortNameDetails = response.data['items'][0]
+          const eftShortNameResponse = await PaymentService.getEFTShortName(state.shortNameDetails.id)
+          state.shortName = eftShortNameResponse.data
+        } else {
+          throw new Error('No response from getEFTShortname')
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to getEFTShortname.', error)
+      }
+    }
+
+    async function loadShortnameRefund (eftRefundId: number): Promise<void> {
+      try {
+        const response = await PaymentService.getEFTRefund(eftRefundId)
+        if (response?.data) {
+          state.refundDetails = response.data
+        } else {
+          throw new Error('No response from getEFTRefund')
+        }
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to getEFTRefund.', error)
+      }
+    }
 
     const refundForm = ref(null)
     const isFormValid = ref(false)
@@ -245,13 +369,18 @@ export default defineComponent({
 
     return {
       ...toRefs(state),
+      isApproved,
       refundForm,
       isFormDisabled,
       isFormValid,
       submitRefundRequest,
       buttonText,
       buttonColor,
-      handleCancelButton
+      handleCancelButton,
+      formatAmount: CommonUtils.formatAmount,
+      getShortNameTypeDescription: ShortNameUtils.getShortNameTypeDescription,
+      getEFTRefundTypeDescription: ShortNameUtils.getEFTRefundTypeDescription,
+      formatDate
     }
   }
 })

--- a/auth-web/src/views/pay/eft/ShortNameRefundView.vue
+++ b/auth-web/src/views/pay/eft/ShortNameRefundView.vue
@@ -139,7 +139,7 @@
               Requested By Qualified Receiver
             </v-col>
             <v-col class="pl-0">
-              {{ refundDetails.createdBy }} {{ formatDate(refundDetails.createdOn) }}
+              {{ refundDetails.createdBy }} {{ formatDate(refundDetails.createdOn, dateDisplayFormat) }}
             </v-col>
           </v-row>
           <v-row v-if="readOnly">
@@ -155,7 +155,7 @@
               Approved By Expense Authority
             </v-col>
             <v-col class="pl-0">
-              {{ refundDetails.updatedBy }} {{ formatDate(refundDetails.updatedOn) }}
+              {{ refundDetails.updatedBy }} {{ formatDate(refundDetails.updatedOn, dateDisplayFormat) }}
             </v-col>
           </v-row>
           <v-row v-if="readOnly">
@@ -212,7 +212,6 @@ import { EFTRefundType } from '@/util/constants'
 import { EftRefundRequest } from '@/models/refund'
 import PaymentService from '@/services/payment.services'
 import ShortNameUtils from '@/util/short-name-utils'
-import moment from 'moment-timezone'
 import { useOrgStore } from '@/stores/org'
 
 export default defineComponent({
@@ -228,6 +227,7 @@ export default defineComponent({
     }
   },
   setup (props, { root }) {
+    const dateDisplayFormat = 'MMM DD, YYYY h:mm A [Pacific Time]'
     const state = reactive({
       shortNameDetails: {} as ShortNameDetails,
       refundDetails: {} as EFTRefund,
@@ -273,12 +273,6 @@ export default defineComponent({
         await loadShortnameRefund(props.eftRefundId)
       }
     })
-
-    function formatDate (str: string): string {
-      const date = moment.utc(str).toDate()
-      return (date) ? moment(date).tz('America/Vancouver')
-        .format('MMM DD, YYYY h:mm A [Pacific Time]') : ''
-    }
 
     async function loadShortnameDetails (shortnameId: number): Promise<void> {
       try {
@@ -381,7 +375,8 @@ export default defineComponent({
       formatAmount,
       getShortNameTypeDescription: ShortNameUtils.getShortNameTypeDescription,
       getEFTRefundTypeDescription: ShortNameUtils.getEFTRefundTypeDescription,
-      formatDate
+      formatDate: CommonUtils.formatUtcToPacificDate,
+      dateDisplayFormat
     }
   }
 })

--- a/auth-web/src/views/pay/eft/ShortNameRefundView.vue
+++ b/auth-web/src/views/pay/eft/ShortNameRefundView.vue
@@ -236,7 +236,7 @@ export default defineComponent({
       email: '',
       staffComment: '',
       isLoading: false,
-      readOnly: true,
+      readOnly: false,
       refundAmountRules: [
         v => !!v || 'Refund Amount is required',
         v => parseFloat(v) > 0 || 'Refund Amount must be greater than zero',
@@ -285,8 +285,6 @@ export default defineComponent({
         const response = await PaymentService.getEFTShortnameSummary(shortnameId)
         if (response?.data) {
           state.shortNameDetails = response.data['items'][0]
-          const eftShortNameResponse = await PaymentService.getEFTShortName(state.shortNameDetails.id)
-          state.shortName = eftShortNameResponse.data
         } else {
           throw new Error('No response from getEFTShortname')
         }
@@ -310,6 +308,10 @@ export default defineComponent({
       }
     }
 
+    function formatAmount (amount: number) {
+      return amount !== undefined ? CommonUtils.formatAmount(amount) : ''
+    }
+
     const refundForm = ref(null)
     const isFormValid = ref(false)
     const buttonText = ref('Submit Refund Request')
@@ -325,12 +327,11 @@ export default defineComponent({
       state.isLoading = true
       if (refundForm.value.validate()) {
         const refundPayload: EftRefundRequest = {
-          shortNameId: props.shortNameDetails.id,
+          shortNameId: state.shortNameDetails.id,
           refundAmount: state.refundAmount,
           casSupplierNum: state.casSupplierNum,
           refundEmail: state.email,
-          comment: state.staffComment,
-          shortName: props.shortNameDetails.shortName
+          comment: state.staffComment
         }
         try {
           await state.orgStore.refundEFT(refundPayload)
@@ -377,7 +378,7 @@ export default defineComponent({
       buttonText,
       buttonColor,
       handleCancelButton,
-      formatAmount: CommonUtils.formatAmount,
+      formatAmount,
       getShortNameTypeDescription: ShortNameUtils.getShortNameTypeDescription,
       getEFTRefundTypeDescription: ShortNameUtils.getEFTRefundTypeDescription,
       formatDate

--- a/auth-web/tests/unit/components/LinkedShortNameTable.spec.ts
+++ b/auth-web/tests/unit/components/LinkedShortNameTable.spec.ts
@@ -2,6 +2,7 @@ import { Wrapper, createLocalVue, mount } from '@vue/test-utils'
 import { BaseVDataTable } from '@/components'
 import CommonUtils from '@/util/common-util'
 import LinkedShortNameTableVue from '@/components/pay/LinkedShortNameTable.vue'
+import ShortNameUtils from '@/util/short-name-utils'
 import { VueConstructor } from 'vue'
 import Vuetify from 'vuetify'
 import { axios } from '@/util/http-util'
@@ -17,7 +18,15 @@ sessionStorage.setItem('AUTH_API_CONFIG', JSON.stringify({
 const vuetify = new Vuetify({})
 // Selectors
 const { header, headerTitles, itemRow, itemCell } = baseVdataTable
-const headers = ['Short Name', 'Account Name', 'Branch Name', 'Account Number', 'Total Amount Owing', 'Latest Statement Number', 'Actions']
+const headers = [
+  'Short Name',
+  'Type',
+  'Account Name',
+  'Branch Name',
+  'Account Number',
+  'Total Amount Owing',
+  'Latest Statement Number',
+  'Actions']
 
 describe('LinkedShortNameTable.vue', () => {
   setupIntersectionObserverMock()
@@ -38,6 +47,7 @@ describe('LinkedShortNameTable.vue', () => {
           'createdOn': '2023-11-24T21:49:25.833501',
           'id': 2,
           'shortName': 'ODYCHIU',
+          'shortNameType': 'EFT',
           'statementId': 5407509,
           'statusCode': 'LINKED'
         },
@@ -49,6 +59,7 @@ describe('LinkedShortNameTable.vue', () => {
           'createdOn': '2024-02-02T15:57:37.067542',
           'id': 155,
           'shortName': 'SNAME142',
+          'shortNameType': 'WIRE',
           'statementId': 5399172,
           'statusCode': 'LINKED'
         },
@@ -60,6 +71,7 @@ describe('LinkedShortNameTable.vue', () => {
           'createdOn': '2024-01-30T21:43:50.597984',
           'id': 11,
           'shortName': 'TST6',
+          'shortNameType': 'EFT',
           'statementId': 5407288,
           'statusCode': 'LINKED'
         }
@@ -110,11 +122,13 @@ describe('LinkedShortNameTable.vue', () => {
     for (let i = 0; i < linkedShortNameResponse.items.length; i++) {
       const columns = itemRows.at(i).findAll(itemCell)
       expect(columns.at(0).text()).toBe(linkedShortNameResponse.items[i].shortName)
-      expect(columns.at(1).text()).toBe(linkedShortNameResponse.items[i].accountName)
-      expect(columns.at(2).text()).toBe(linkedShortNameResponse.items[i].accountBranch)
-      expect(columns.at(3).text()).toBe(linkedShortNameResponse.items[i].accountId)
-      expect(columns.at(4).text()).toBe(`${CommonUtils.formatAmount(linkedShortNameResponse.items[i].amountOwing)}`)
-      expect(columns.at(5).text()).toBe(linkedShortNameResponse.items[i].statementId.toString())
+      expect(columns.at(1).text()).toBe(
+        ShortNameUtils.getShortNameTypeDescription(linkedShortNameResponse.items[i].shortNameType))
+      expect(columns.at(2).text()).toBe(linkedShortNameResponse.items[i].accountName)
+      expect(columns.at(3).text()).toBe(linkedShortNameResponse.items[i].accountBranch)
+      expect(columns.at(4).text()).toBe(linkedShortNameResponse.items[i].accountId)
+      expect(columns.at(5).text()).toBe(`${CommonUtils.formatAmount(linkedShortNameResponse.items[i].amountOwing)}`)
+      expect(columns.at(6).text()).toBe(linkedShortNameResponse.items[i].statementId.toString())
     }
   })
 })

--- a/auth-web/tests/unit/components/ShortNamePaymentHistory.spec.ts
+++ b/auth-web/tests/unit/components/ShortNamePaymentHistory.spec.ts
@@ -1,5 +1,6 @@
 import { Wrapper, createLocalVue, mount } from '@vue/test-utils'
 import { BaseVDataTable } from '@/components'
+import CommonUtils from '@/util/common-util'
 import ShortNameTransactions from '@/components/pay/eft/ShortNamePaymentHistory.vue'
 import { VueConstructor } from 'vue'
 import Vuetify from 'vuetify'
@@ -139,7 +140,8 @@ describe('ShortNamePaymentHistory.vue', () => {
     expect(itemRows.length).toBe(historyResponse.items.length)
     for (let i = 0; i < historyResponse.items.length; i++) {
       const columns = itemRows.at(i).findAll(itemCell)
-      expect(columns.at(0).text()).toBe(wrapper.vm.formatDate(historyResponse.items[i].transactionDate))
+      expect(columns.at(0).text()).toBe(
+        CommonUtils.formatUtcToPacificDate(historyResponse.items[i].transactionDate, wrapper.vm.dateDisplayFormat))
       expect(columns.at(1).text()).toContain(wrapper.vm.formatDescription(historyResponse.items[i]))
       expect(columns.at(1).text()).toContain(wrapper.vm.formatAdditionalDescription(historyResponse.items[i]))
       expect(columns.at(2).text()).toBe(historyResponse.items[i].statementNumber

--- a/auth-web/tests/unit/components/ShortNameSummaryTable.spec.ts
+++ b/auth-web/tests/unit/components/ShortNameSummaryTable.spec.ts
@@ -127,7 +127,7 @@ describe('ShortNameSummaryTable.vue', () => {
       expect(columns.at(1).text()).toBe(
         ShortNameUtils.getShortNameTypeDescription(shortNameSummaryResponse.items[i].shortNameType))
       expect(columns.at(2).text()).toBe(
-        CommonUtils.formatDisplayDate(shortNameSummaryResponse.items[i].lastPaymentReceivedDate, 'MMMM DD, YYYY'))
+        CommonUtils.formatUtcToPacificDate(shortNameSummaryResponse.items[i].lastPaymentReceivedDate, 'MMMM DD, YYYY'))
       expect(columns.at(3).text()).toBe(
         CommonUtils.formatAmount(shortNameSummaryResponse.items[i].creditsRemaining))
       expect(columns.at(4).text()).toBe(shortNameSummaryResponse.items[i].linkedAccountsCount.toString())

--- a/auth-web/tests/unit/components/ShortNameSummaryTable.spec.ts
+++ b/auth-web/tests/unit/components/ShortNameSummaryTable.spec.ts
@@ -2,6 +2,7 @@ import { Wrapper, createLocalVue, mount } from '@vue/test-utils'
 import { BaseVDataTable } from '@/components'
 import CommonUtils from '@/util/common-util'
 import ShortNameSummaryTableVue from '@/components/pay/ShortNameSummaryTable.vue'
+import ShortNameUtils from '@/util/short-name-utils'
 import { VueConstructor } from 'vue'
 import Vuetify from 'vuetify'
 import { axios } from '@/util/http-util'
@@ -23,9 +24,10 @@ const itemCell = baseVdataTable.itemCell
 
 const headers = [
   'Short Name',
+  'Type',
   'Last Payment Received Date',
   'Unsettled Amount',
-  'Number of Linked Accounts',
+  'Linked Accounts',
   'Actions'
 ]
 
@@ -44,35 +46,40 @@ describe('ShortNameSummaryTable.vue', () => {
           id: 142,
           lastPaymentReceivedDate: '2024-01-28T10:00:00',
           linkedAccountsCount: 0,
-          shortName: 'SNAME129'
+          shortName: 'SNAME129',
+          shortNameType: 'EFT'
         },
         {
           creditsRemaining: 151.5,
           id: 123,
           lastPaymentReceivedDate: '2024-01-28T10:00:00',
           linkedAccountsCount: 0,
-          shortName: 'SNAME110'
+          shortName: 'SNAME110',
+          shortNameType: 'WIRE'
         },
         {
           creditsRemaining: 204.0,
           id: 158,
           lastPaymentReceivedDate: '2024-01-27T10:00:00',
           linkedAccountsCount: 1,
-          shortName: 'SNAME145'
+          shortName: 'SNAME145',
+          shortNameType: 'WIRE'
         },
         {
           creditsRemaining: 50.25,
           id: 156,
           lastPaymentReceivedDate: '2024-01-27T10:00:00',
           linkedAccountsCount: 1,
-          shortName: 'SNAME143'
+          shortName: 'SNAME143',
+          shortNameType: 'EFT'
         },
         {
           creditsRemaining: 0.0,
           id: 134,
           lastPaymentReceivedDate: '2023-11-24T10:00:00',
           linkedAccountsCount: 2,
-          shortName: 'SNAME121'
+          shortName: 'SNAME121',
+          shortNameType: 'EFT'
         }
       ],
       total: 5
@@ -118,10 +125,12 @@ describe('ShortNameSummaryTable.vue', () => {
       const columns = itemRows.at(i).findAll(itemCell)
       expect(columns.at(0).text()).toBe(shortNameSummaryResponse.items[i].shortName)
       expect(columns.at(1).text()).toBe(
-        CommonUtils.formatDisplayDate(shortNameSummaryResponse.items[i].lastPaymentReceivedDate, 'MMMM DD, YYYY'))
+        ShortNameUtils.getShortNameTypeDescription(shortNameSummaryResponse.items[i].shortNameType))
       expect(columns.at(2).text()).toBe(
+        CommonUtils.formatDisplayDate(shortNameSummaryResponse.items[i].lastPaymentReceivedDate, 'MMMM DD, YYYY'))
+      expect(columns.at(3).text()).toBe(
         CommonUtils.formatAmount(shortNameSummaryResponse.items[i].creditsRemaining))
-      expect(columns.at(3).text()).toBe(shortNameSummaryResponse.items[i].linkedAccountsCount.toString())
+      expect(columns.at(4).text()).toBe(shortNameSummaryResponse.items[i].linkedAccountsCount.toString())
     }
   })
 })

--- a/auth-web/tests/unit/views/ShortNameRefundView.spec.ts
+++ b/auth-web/tests/unit/views/ShortNameRefundView.spec.ts
@@ -1,3 +1,4 @@
+import { axios } from '@/util/http-util'
 import { createLocalVue, mount } from '@vue/test-utils'
 import ShortNameRefundView from '@/views/pay/eft/ShortNameRefundView.vue'
 import Vue from 'vue'
@@ -9,17 +10,33 @@ Vue.use(Vuetify)
 Vue.use(VueRouter)
 
 describe('ShortNameRefundView.vue', () => {
-  let wrapper
+  let wrapper: any
   const localVue = createLocalVue()
   const vuetify = new Vuetify({})
-  let sandbox
+  let sandbox: any
+  let summaryResponse: any
 
   beforeEach(() => {
+    summaryResponse = {
+      'items': [
+        {
+          'creditsRemaining': 300.0,
+          'id': 2,
+          'lastPaymentReceivedDate': '2023-11-24T13:47:47',
+          'linkedAccountsCount': 0,
+          'refundStatus': 'PENDING_REFUND',
+          'shortName': 'SNAME100',
+          'shortNameType': 'EFT'
+        }
+      ]
+    }
+
     sandbox = sinon.createSandbox()
+    const get = sandbox.stub(axios, 'get')
+    get.returns(new Promise(resolve => resolve({ data: summaryResponse })))
     wrapper = mount(ShortNameRefundView, {
       propsData: {
-        shortNameDetails: { shortName: 'TEST', creditsRemaining: '500.0' },
-        unsettledAmount: '100.0'
+        shortNameDetails: { shortName: 'TEST', creditsRemaining: '500.0' }
       },
       localVue,
       vuetify
@@ -47,8 +64,7 @@ describe('ShortNameRefundView.vue', () => {
     const router = new VueRouter()
     wrapper = mount(ShortNameRefundView, {
       propsData: {
-        shortNameDetails: { shortName: 'TEST', creditsRemaining: '500.0' },
-        unsettledAmount: '100.0'
+        shortNameDetails: { shortName: 'TEST', creditsRemaining: '500.0' }
       },
       localVue,
       vuetify,

--- a/auth-web/tests/unit/views/ShortNameRefundView.spec.ts
+++ b/auth-web/tests/unit/views/ShortNameRefundView.spec.ts
@@ -1,9 +1,9 @@
-import { axios } from '@/util/http-util'
 import { createLocalVue, mount } from '@vue/test-utils'
 import ShortNameRefundView from '@/views/pay/eft/ShortNameRefundView.vue'
 import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Vuetify from 'vuetify'
+import { axios } from '@/util/http-util'
 import sinon from 'sinon'
 
 Vue.use(Vuetify)

--- a/auth-web/tests/unit/views/ShortNameRefundView.spec.ts
+++ b/auth-web/tests/unit/views/ShortNameRefundView.spec.ts
@@ -33,7 +33,7 @@ describe('ShortNameRefundView.vue', () => {
 
     sandbox = sinon.createSandbox()
     const get = sandbox.stub(axios, 'get')
-    get.returns(new Promise(resolve => resolve({ data: summaryResponse })))
+    get.returns(Promise.resolve({ data: summaryResponse }))
     wrapper = mount(ShortNameRefundView, {
       propsData: {
         shortNameDetails: { shortName: 'TEST', creditsRemaining: '500.0' }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21539
https://github.com/bcgov/entity/issues/23102

*Description of changes:*
- Payment history table to support short name refunds
- Add read only view for refund details
- Update screens to show short name type for WIRE implementation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
