### PR TITLE
21594 - UXA Refund label

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.93",
+  "version": "2.6.94",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.93",
+      "version": "2.6.94",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",
@@ -58,7 +58,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/eslint-config-typescript": "^4.0.0",
         "@vue/test-utils": "1.3.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.93",
+  "version": "2.6.94",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/pay/ShortNameSummaryTable.vue
+++ b/auth-web/src/components/pay/ShortNameSummaryTable.vue
@@ -54,15 +54,6 @@
       </template>
       <template #item-slot-shortName="{ item }">
         <span>{{ item.shortName }}</span>
-        <v-chip
-          v-if="item.refundStatus === ShortNameRefundStatus.PENDING_REFUND"
-          small
-          label
-          color="info"
-          class="item-chip"
-        >
-          {{ ShortNameRefundLabel.PENDING_REFUND }}
-        </v-chip>
       </template>
       <template #header-filter-slot-lastPaymentReceivedDate>
         <div @click="clickDatePicker()">
@@ -101,7 +92,16 @@
         <span>{{ getShortNameTypeDescription(item.shortNameType) }}</span>
       </template>
       <template #item-slot-creditsRemaining="{ item }">
-        <span>{{ formatAmount(item.creditsRemaining) }}</span>
+        <span class="pr-2">{{ formatAmount(item.creditsRemaining) }}</span>
+        <v-chip
+            v-if="item.refundStatus === ShortNameRefundStatus.PENDING_REFUND"
+            small
+            label
+            text-color="white"
+            class="primary pl-2 pr-2"
+        >
+          {{ ShortNameRefundLabel.PENDING_REFUND }}
+        </v-chip>
       </template>
       <template #item-slot-linkedAccountsCount="{ item }">
         <span>{{ item.linkedAccountsCount }}</span>
@@ -276,6 +276,7 @@ export default defineComponent({
         'Last Payment Received Date',
         lastPaymentReceivedDate,
         false,
+        '275px',
         '275px'
       ),
       createHeader(
@@ -285,8 +286,8 @@ export default defineComponent({
         'Unsettled Amount',
         creditsRemaining,
         true,
-        '185px',
-        '185px'
+        '215px',
+        '215px'
       ),
       createHeader(
         'linkedAccountsCount',
@@ -295,8 +296,8 @@ export default defineComponent({
         'Linked Accounts',
         linkedAccountsCount,
         true,
-        '170px',
-        '170px'
+        '175px',
+        '175px'
       ),
       {
         col: 'actions',
@@ -479,9 +480,5 @@ export default defineComponent({
   .v-list {
     width:180px
   }
-}
-
-.item-chip {
-  margin-left: 4px
 }
 </style>


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21594

*Description of changes:*
- move refund label to unsettled amount due to limited room from adding short name type
- adjust column sizes
- update / clean up styling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
