### PR TITLE
21536 - sync refund label statuses with backend changes

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.97",
+  "version": "2.6.98",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.97",
+      "version": "2.6.98",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",
@@ -58,7 +58,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/eslint-config-typescript": "^4.0.0",
         "@vue/test-utils": "1.3.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.97",
+  "version": "2.6.98",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/pay/ShortNameSummaryTable.vue
+++ b/auth-web/src/components/pay/ShortNameSummaryTable.vue
@@ -94,13 +94,13 @@
       <template #item-slot-creditsRemaining="{ item }">
         <span class="pr-2">{{ formatAmount(item.creditsRemaining) }}</span>
         <v-chip
-            v-if="item.refundStatus === ShortNameRefundStatus.PENDING_REFUND"
+            v-if="item.refundStatus === ShortNameRefundStatus.PENDING_APPROVAL"
             small
             label
             text-color="white"
             class="primary pl-2 pr-2"
         >
-          {{ ShortNameRefundLabel.PENDING_REFUND }}
+          {{ ShortNameRefundLabel.PENDING_APPROVAL }}
         </v-chip>
       </template>
       <template #item-slot-linkedAccountsCount="{ item }">

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -765,9 +765,9 @@ export enum OrgNameLabel {
 }
 
 export enum ShortNameRefundStatus {
-    PENDING_REFUND = 'PENDING_REFUND'
+    PENDING_APPROVAL = 'PENDING_APPROVAL'
 }
 
 export enum ShortNameRefundLabel {
-    PENDING_REFUND = 'REFUND REQUEST'
+    PENDING_APPROVAL = 'REFUND REQUEST'
 }


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/21536

*Description of changes:*
- sync refund label statuses with backend refund status changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
