### PR TITLE
BCOL API errors have different format than internal exceptions, so we…

### DIFF
--- a/auth-api/src/auth_api/exceptions/__init__.py
+++ b/auth-api/src/auth_api/exceptions/__init__.py
@@ -9,4 +9,9 @@ status_code - where possible use HTTP Error Codes
 
 from auth_api.exceptions.errors import Error  # noqa: I001, I003
 from auth_api.exceptions.exception_handler import ExceptionHandler
-from auth_api.exceptions.exceptions import BusinessException, CustomException, ServiceUnavailableException
+from auth_api.exceptions.exceptions import (
+    BCOLException,
+    BusinessException,
+    CustomException,
+    ServiceUnavailableException,
+)

--- a/auth-api/src/auth_api/exceptions/exceptions.py
+++ b/auth-api/src/auth_api/exceptions/exceptions.py
@@ -34,6 +34,16 @@ class ServiceUnavailableException(Exception):  # noqa: N818
         self.status_code = Error.SERVICE_UNAVAILABLE.name
 
 
+class BCOLException(Exception):  # noqa: N818
+    """Exception for BCOL API errors."""
+
+    def __init__(self, message, status_code):
+        """Return when error object is coming from BCOL API."""
+        self.message = message
+        self.status_code = status_code
+        self.name = "BCOL API Error"
+
+
 class CustomException:
     """A custom exception object to be used propagate errors."""
 

--- a/auth-api/src/auth_api/services/validators/bcol_credentials.py
+++ b/auth-api/src/auth_api/services/validators/bcol_credentials.py
@@ -17,7 +17,7 @@ from http import HTTPStatus
 
 from flask import current_app
 
-from auth_api.exceptions import BusinessException, Error
+from auth_api.exceptions import BCOLException, BusinessException, Error
 from auth_api.services.rest_service import RestService
 from auth_api.services.validators.validator_response import ValidatorResponse
 from auth_api.utils.user_context import UserContext, user_context
@@ -38,9 +38,9 @@ def validate(is_fatal=False, **kwargs) -> ValidatorResponse:
     )
     if bcol_response.status_code != HTTPStatus.OK:
         error = json.loads(bcol_response.text)
-        validator_response.add_error(BusinessException(error["detail"], bcol_response.status_code))
+        validator_response.add_error(BCOLException(error, bcol_response.status_code))
         if is_fatal:
-            raise BusinessException(error["detail"], bcol_response.status_code)
+            raise BCOLException(error, bcol_response.status_code)
     else:
         bcol_account_number = bcol_response.json().get("accountNumber")
         from auth_api.services.org import Org as OrgService  # pylint:disable=cyclic-import, import-outside-toplevel


### PR DESCRIPTION
… can't expect them to have same attributes as internal errors

*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
