### PR TITLE
24328 - Update short name unsettled amount after decline

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.108",
+  "version": "2.6.109",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.108",
+      "version": "2.6.109",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.108",
+  "version": "2.6.109",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/views/pay/eft/ShortNameDetailsView.vue
+++ b/auth-web/src/views/pay/eft/ShortNameDetailsView.vue
@@ -179,6 +179,8 @@ export default defineComponent({
 
     async function onRefund (refund: any) {
       state.lastRefundId = Number(refund.id)
+      await loadShortname(props.shortNameId)
+      updateState()
     }
 
     async function onLinkAccount (account: any, results: Array<any>) {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/24328

*Description of changes:*
Short name unsettled amount now updates properly after declining a refund inside short name details view.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
