### PR TITLE
24286 - Wrong link for "Review account" in staff notifications for new accoun…

### DIFF
--- a/auth-api/src/auth_api/services/org.py
+++ b/auth-api/src/auth_api/services/org.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from http import HTTPStatus
 from typing import Dict, List, Tuple
 
-from flask import current_app, g
+from flask import current_app, g, request
 from jinja2 import Environment, FileSystemLoader
 from requests.exceptions import HTTPError
 from sbc_common_components.utils.enums import QueueMessageTypes
@@ -907,7 +907,8 @@ class Org:  # pylint: disable=too-many-public-methods
             task_relationship_type=task_relationship_type, relationship_id=relationship_id
         )
         context_path = f"review-account/{task.id}"
-        app_url = f"{g.get('origin_url', '')}/"
+        app_url = request.environ.get("HTTP_ORIGIN", "localhost")
+
         review_url = f"{app_url}/{context_path}"
         first_name = user.firstname
         last_name = user.lastname

--- a/auth-api/tests/conftest.py
+++ b/auth-api/tests/conftest.py
@@ -47,6 +47,13 @@ def app_request():
     return _app
 
 
+@pytest.fixture(scope="function", autouse=True)
+def global_http_origin(app):
+    """Set a global HTTP_ORIGIN for all tests."""
+    with app.test_request_context("/", environ_base={"HTTP_ORIGIN": "https://test.com"}):
+        yield
+
+
 @pytest.fixture(scope="session")
 def client(app):  # pylint: disable=redefined-outer-name
     """Return a session-wide Flask test client."""


### PR DESCRIPTION
…t approvals

*Issue #:*
https://github.com/bcgov/entity/issues/24286

*Description of changes:*
Wrong link for "Review account" in staff notifications for new account approvals

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
