### PR TITLE
24226 - Redirect external links

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.6.125",
+  "version": "2.6.126",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.6.125",
+      "version": "2.6.126",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/bread-crumb": "1.0.8",
@@ -57,7 +57,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/eslint-config-typescript": "^4.0.0",
         "@vue/test-utils": "1.3.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.6.125",
+  "version": "2.6.126",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/pay/eft/ShortNameRefund.vue
+++ b/auth-web/src/components/pay/eft/ShortNameRefund.vue
@@ -306,7 +306,7 @@ export default defineComponent({
       })
     }
 
-    function disableApproveRefund(item) {
+    function disableApproveRefund (item) {
       return item?.createdBy?.toUpperCase() === currentUser.value?.userName?.toUpperCase()
     }
 

--- a/auth-web/src/routes/index.ts
+++ b/auth-web/src/routes/index.ts
@@ -16,6 +16,7 @@ import Router from 'vue-router'
 import { User } from '@/models/user'
 import Vue from 'vue'
 import { getRoutes } from './router'
+import { handleExternalLinkRedirect } from '@/util/navigation'
 import store from '@/stores/vuex'
 import { useOrgStore } from '@/stores/org'
 import { useUserStore } from '@/stores/user'
@@ -172,6 +173,10 @@ router.beforeEach(async (to, from, next) => {
       } else if (orgStore.needMissingBusinessDetailsRedirect) {
         return next({ path: `/${Pages.UPDATE_ACCOUNT}` })
       }
+    }
+
+    if (handleExternalLinkRedirect(to.fullPath)) {
+      return
     }
     next()
   }

--- a/auth-web/src/util/navigation.ts
+++ b/auth-web/src/util/navigation.ts
@@ -55,3 +55,12 @@ export const goToFormPage = (entityType): void => {
 export const goToSocieties = (): void => {
   window.open(appendAccountId(ConfigHelper.getSocietiesUrl()), '_blank')
 }
+
+export const handleExternalLinkRedirect = (path: string): boolean => {
+  if (path.includes('/http')) {
+    const cleanPath = path.replace(/^\//, '')
+    window.location.href = cleanPath
+    return true
+  }
+  return false
+}

--- a/auth-web/src/views/pay/eft/ShortNameRefundView.vue
+++ b/auth-web/src/views/pay/eft/ShortNameRefundView.vue
@@ -322,7 +322,7 @@ export default defineComponent({
       }
     })
 
-    function prepopulateRefund() {
+    function prepopulateRefund () {
       state.email = state.shortNameDetails.email
       state.casSupplierNum = state.shortNameDetails.casSupplierNumber
       state.casSupplierSite = state.shortNameDetails.casSupplierSite


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/24226

*Description of changes:*
Here's why I needed to add this:
`https://dev.account.bcregistry.gov.bc.ca/login?redirect=http%3A%2F%2Flocalhost%3A3000%2Fen-CA%2FmagicLink%3FnrId%3DNR%2B0521856%26phone%3D1112223333`
is being redirected to which is wrong:
`https://dev.account.bcregistry.gov.bc.ca/http://localhost:3000/magicLink?nrId=NR+0521856&phone=1112223333`

The idea is, I want to go back to the new BRD after login. I have a PR upcoming in the new BRD.

This is the finished product where I have both dashboards running locally (you can play it at 2x speed):

https://github.com/user-attachments/assets/8feb1836-900f-4f33-9a62-2249d9c2e084



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
