### PR TITLE
25143 - remove product / add previously approved product support

### DIFF
--- a/auth-api/src/auth_api/exceptions/errors.py
+++ b/auth-api/src/auth_api/exceptions/errors.py
@@ -23,6 +23,7 @@ from http import HTTPStatus
 class Error(Enum):
     """Error Codes."""
 
+    INVALID_ORG = "The organization ID is in an incorrect format.", HTTPStatus.BAD_REQUEST
     INVALID_INPUT = "Invalid input, please check.", HTTPStatus.BAD_REQUEST
     DATA_NOT_FOUND = "No matching record found.", HTTPStatus.NOT_FOUND
     DATA_ALREADY_EXISTS = "The data you want to insert already exists.", HTTPStatus.BAD_REQUEST

--- a/auth-api/src/auth_api/models/product_subscription.py
+++ b/auth-api/src/auth_api/models/product_subscription.py
@@ -15,6 +15,7 @@
 
 The ProductSubscription object connects Org models to one or more ProductSubscription models.
 """
+from typing import Self
 
 from sql_versioning import Versioned
 from sqlalchemy import Column, ForeignKey, Integer, and_
@@ -45,7 +46,7 @@ class ProductSubscription(Versioned, BaseModel):  # pylint: disable=too-few-publ
         ).all()
 
     @classmethod
-    def find_by_org_id_product_code(cls, org_id: int, product_code, valid_statuses=VALID_SUBSCRIPTION_STATUSES):
+    def find_by_org_id_product_code(cls, org_id: int, product_code, valid_statuses=VALID_SUBSCRIPTION_STATUSES) -> Self:
         """Find an product subscription instance that matches the provided id."""
         return cls.query.filter(
             and_(

--- a/auth-api/src/auth_api/models/task.py
+++ b/auth-api/src/auth_api/models/task.py
@@ -115,15 +115,14 @@ class Task(BaseModel):
 
     @classmethod
     def find_by_incomplete_task_relationship_id(
-            cls, relationship_id: int, task_relationship_type: str, relationship_status: str = None) -> Self:
+        cls, relationship_id: int, task_relationship_type: str, relationship_status: str = None
+    ) -> Self:
         """Find a task instance that related to the relationship id ( may be an ORG or a PRODUCT) that is incomplete."""
-        query = (
-            db.session.query(Task)
-            .filter(
-                Task.relationship_id == int(relationship_id or -1),
-                Task.relationship_type == task_relationship_type,
-                Task.status.in_((TaskStatus.OPEN.value, TaskStatus.HOLD.value))
-            ))
+        query = db.session.query(Task).filter(
+            Task.relationship_id == int(relationship_id or -1),
+            Task.relationship_type == task_relationship_type,
+            Task.status.in_((TaskStatus.OPEN.value, TaskStatus.HOLD.value)),
+        )
 
         if relationship_status is not None:
             query = query.filter(Task.relationship_status == relationship_status)

--- a/auth-api/src/auth_api/models/task.py
+++ b/auth-api/src/auth_api/models/task.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """This model manages a Task item in the Auth Service."""
 import datetime as dt
+from typing import Self
 
 import pytz
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, text
@@ -93,14 +94,14 @@ class Task(BaseModel):
         return pagination.items, pagination.total
 
     @classmethod
-    def find_by_task_id(cls, task_id: int):
+    def find_by_task_id(cls, task_id: int) -> Self:
         """Find a task instance that matches the provided id."""
         return db.session.query(Task).filter_by(id=int(task_id or -1)).first()
 
     @classmethod
     def find_by_task_relationship_id(
         cls, relationship_id: int, task_relationship_type: str, task_status: str = TaskStatus.OPEN.value
-    ):
+    ) -> Self:
         """Find a task instance that related to the relationship id ( may be an ORG or a PRODUCT."""
         return (
             db.session.query(Task)
@@ -111,6 +112,23 @@ class Task(BaseModel):
             )
             .first()
         )
+
+    @classmethod
+    def find_by_incomplete_task_relationship_id(
+            cls, relationship_id: int, task_relationship_type: str, relationship_status: str = None) -> Self:
+        """Find a task instance that related to the relationship id ( may be an ORG or a PRODUCT) that is incomplete."""
+        query = (
+            db.session.query(Task)
+            .filter(
+                Task.relationship_id == int(relationship_id or -1),
+                Task.relationship_type == task_relationship_type,
+                Task.status.in_((TaskStatus.OPEN.value, TaskStatus.HOLD.value))
+            ))
+
+        if relationship_status is not None:
+            query = query.filter(Task.relationship_status == relationship_status)
+
+        return query.first()
 
     @classmethod
     def find_by_task_for_account(cls, org_id: int, status):

--- a/auth-api/src/auth_api/resources/v1/org_products.py
+++ b/auth-api/src/auth_api/resources/v1/org_products.py
@@ -18,7 +18,7 @@ from http import HTTPStatus
 from flask import Blueprint, g, request
 from flask_cors import cross_origin
 
-from auth_api.exceptions import BusinessException
+from auth_api.exceptions import BusinessException, Error
 from auth_api.schemas import utils as schema_utils
 from auth_api.services import Product as ProductService
 from auth_api.utils.auth import jwt as _jwt
@@ -34,10 +34,8 @@ bp = Blueprint("ORG_PRODUCTS", __name__, url_prefix=f"{EndpointEnum.API_V1.value
 def get_org_product_subscriptions(org_id):
     """GET a new product subscription to the org using the request body."""
 
-    if not org_id or org_id == "None" or not org_id.isdigit() or int(org_id) < 0:
-        return {"message": "The organization ID is in an incorrect format."}, HTTPStatus.BAD_REQUEST
-
     try:
+        validate_organization(org_id)
         include_hidden = request.args.get("include_hidden", None) == "true"  # used by NDS
         response, status = (
             json.dumps(ProductService.get_all_product_subscription(org_id=int(org_id), include_hidden=include_hidden)),
@@ -54,15 +52,13 @@ def get_org_product_subscriptions(org_id):
 def post_org_product_subscription(org_id):
     """Post a new product subscription to the org using the request body."""
 
-    if not org_id or org_id == "None" or not org_id.isdigit() or int(org_id) < 0:
-        return {"message": "The organization ID is in an incorrect format."}, HTTPStatus.BAD_REQUEST
-
     request_json = request.get_json()
     valid_format, errors = schema_utils.validate(request_json, "org_product_subscription")
     if not valid_format:
         return {"message": schema_utils.serialize(errors)}, HTTPStatus.BAD_REQUEST
 
     try:
+        validate_organization(org_id)
         roles = g.jwt_oidc_token_info.get("realm_access").get("roles")
         subscriptions = ProductService.create_product_subscription(
             int(org_id), request_json, skip_auth=Role.SYSTEM.value in roles, auto_approve=Role.SYSTEM.value in roles
@@ -80,17 +76,35 @@ def post_org_product_subscription(org_id):
 def patch_org_product_subscription(org_id):
     """Patch existing product subscription to resubmit it for review."""
 
-    if not org_id or org_id == "None" or not org_id.isdigit() or int(org_id) < 0:
-        return {"message": "The organization ID is in an incorrect format."}, HTTPStatus.BAD_REQUEST
-
     request_json = request.get_json()
     valid_format, errors = schema_utils.validate(request_json, "org_product_subscription")
     if not valid_format:
         return {"message": schema_utils.serialize(errors)}, HTTPStatus.BAD_REQUEST
 
     try:
+        validate_organization(org_id)
         subscriptions = ProductService.resubmit_product_subscription(int(org_id), request_json)
         response, status = {"subscriptions": subscriptions}, HTTPStatus.OK
     except BusinessException as exception:
         response, status = {"code": exception.code, "message": exception.message}, exception.status_code
     return response, status
+
+
+@bp.route("/<string:product_code>", methods=["DELETE", "OPTIONS"])
+@cross_origin(origins="*", methods=["DELETE"])
+@_jwt.has_one_of_roles([Role.STAFF_CREATE_ACCOUNTS.value, Role.PUBLIC_USER.value, Role.SYSTEM.value])
+def delete_product_subscription(org_id, product_code):
+    """Delete existing product subscription."""
+
+    try:
+        validate_organization(org_id)
+        subscriptions = ProductService.remove_product_subscription(int(org_id), product_code)
+        response, status = {"subscriptions": subscriptions}, HTTPStatus.OK
+    except BusinessException as exception:
+        response, status = {"code": exception.code, "message": exception.message}, exception.status_code
+    return response, status
+
+
+def validate_organization(org_id):
+    if not org_id or org_id == "None" or not org_id.isdigit() or int(org_id) < 0:
+        raise BusinessException(Error.INVALID_ORG, None)

--- a/auth-api/src/auth_api/services/products.py
+++ b/auth-api/src/auth_api/services/products.py
@@ -146,30 +146,30 @@ class Product:
     @staticmethod
     def _is_previously_approved(org_id: int, product_code: str):
         """Check if this product has a task that was previously approved."""
-        inactive_sub = (ProductSubscriptionModel
-                        .find_by_org_id_product_code(org_id=org_id,
-                                                     product_code=product_code,
-                                                     valid_statuses=(ProductSubscriptionStatus.INACTIVE.value,)))
+        inactive_sub = ProductSubscriptionModel.find_by_org_id_product_code(
+            org_id=org_id, product_code=product_code, valid_statuses=(ProductSubscriptionStatus.INACTIVE.value,)
+        )
         if not inactive_sub:
             return False, None
 
         task = TaskModel.find_by_task_relationship_id(
             inactive_sub.id, TaskRelationshipType.PRODUCT.value, TaskStatus.COMPLETED.value
         )
-        if (task is None
-                or (task.relationship_status != TaskRelationshipStatus.ACTIVE.value
-                    and task.action == TaskAction.PRODUCT_REVIEW.value)):
+        if task is None or (
+            task.relationship_status != TaskRelationshipStatus.ACTIVE.value
+            and task.action == TaskAction.PRODUCT_REVIEW.value
+        ):
             return False, None
 
         return True, inactive_sub
 
     @staticmethod
     def create_product_subscription(
-            org_id,
-            subscription_data: Dict[str, Any],  # pylint: disable=too-many-locals
-            is_new_transaction: bool = True,
-            skip_auth=False,
-            auto_approve=False,
+        org_id,
+        subscription_data: Dict[str, Any],  # pylint: disable=too-many-locals
+        is_new_transaction: bool = True,
+        skip_auth=False,
+        auto_approve=False,
     ):
         """Create product subscription for the user.
 
@@ -196,9 +196,9 @@ class Product:
                     check_auth(system_required=True, org_id=org_id)
                 # Check if product needs premium account, if yes skip and continue.
                 if (
-                        flags.is_on("remove-premium-restrictions", default=False) is False
-                        and product_model.premium_only
-                        and org.type_code not in PREMIUM_ORG_TYPES
+                    flags.is_on("remove-premium-restrictions", default=False) is False
+                    and product_model.premium_only
+                    and org.type_code not in PREMIUM_ORG_TYPES
                 ):
                     continue
                 previously_approved, inactive_sub = Product._is_previously_approved(org_id, product_code)
@@ -271,7 +271,7 @@ class Product:
             pending_task = TaskModel.find_by_incomplete_task_relationship_id(
                 relationship_id=existing_sub.id,
                 task_relationship_type=TaskRelationshipType.PRODUCT.value,
-                relationship_status=ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value
+                relationship_status=ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
             )
             if pending_task:
                 pending_task.delete()
@@ -305,8 +305,11 @@ class Product:
 
     @staticmethod
     def _subscribe_and_publish_activity(
-            org_id: int, product_code: str, status_code: str, product_model_description: str,
-            inactive_sub: ProductSubscriptionModel = None
+        org_id: int,
+        product_code: str,
+        status_code: str,
+        product_model_description: str,
+        inactive_sub: ProductSubscriptionModel = None,
     ):
         subscription = None
         if inactive_sub:
@@ -326,8 +329,7 @@ class Product:
 
     @staticmethod
     def _reset_subscription_and_review_task(
-            review_task: TaskModel, product_model: ProductCodeModel, subscription: ProductSubscriptionModel,
-            user_id: str
+        review_task: TaskModel, product_model: ProductCodeModel, subscription: ProductSubscriptionModel, user_id: str
     ):
         review_task.status = TaskStatus.OPEN.value
         review_task.related_to = user_id
@@ -400,8 +402,8 @@ class Product:
                         org_id=org_id, product_code=product_code, status_code=ProductSubscriptionStatus.ACTIVE.value
                     ).flush()
                 elif (
-                        subscription
-                        and (existing_sub := subscription).status_code != ProductSubscriptionStatus.ACTIVE.value
+                    subscription
+                    and (existing_sub := subscription).status_code != ProductSubscriptionStatus.ACTIVE.value
                 ):
                     existing_sub.status_code = ProductSubscriptionStatus.ACTIVE.value
                     existing_sub.flush()
@@ -433,9 +435,9 @@ class Product:
 
         # Include hidden products only for staff and SBC staff
         include_hidden = (
-                user_from_context.is_staff()
-                or org.type_code == OrgType.SBC_STAFF.value
-                or kwargs.get("include_hidden", False)
+            user_from_context.is_staff()
+            or org.type_code == OrgType.SBC_STAFF.value
+            or kwargs.get("include_hidden", False)
         )
 
         products = Product.get_products(include_hidden=include_hidden, staff_check=False)
@@ -505,7 +507,7 @@ class Product:
 
     @staticmethod
     def approve_reject_parent_subscription(
-            parent_product_code: int, is_approved: bool, is_hold: bool, org_id: int, is_new_transaction: bool = True
+        parent_product_code: int, is_approved: bool, is_hold: bool, org_id: int, is_new_transaction: bool = True
     ):
         """Approve or reject Parent Product Subscription."""
         logger.debug("<approve_reject_parent_subscription ")
@@ -568,9 +570,9 @@ class Product:
         2) in PENDING_STAFF_REVIEW, is_approved and is_resubmitted
         """
         return (product_sub_status == ProductSubscriptionStatus.REJECTED.value and is_approved) or (
-                product_sub_status == ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value
-                and is_approved
-                and is_resubmitted
+            product_sub_status == ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value
+            and is_approved
+            and is_resubmitted
         )
 
     @staticmethod

--- a/auth-api/tests/unit/api/test_cors_preflight.py
+++ b/auth-api/tests/unit/api/test_cors_preflight.py
@@ -218,6 +218,10 @@ def test_preflight_org_products(app, client, jwt, session):
     assert rv.status_code == HTTPStatus.OK
     assert_access_control_headers(rv, "*", "GET, PATCH, POST")
 
+    rv = client.options("/api/v1/orgs/1/products/ABC", headers={"Access-Control-Request-Method": "DELETE"})
+    assert rv.status_code == HTTPStatus.OK
+    assert_access_control_headers(rv, "*", "DELETE")
+
 
 def test_preflight_org_permissions(app, client, jwt, session):
     """Assert preflight responses for org permissions are correct."""

--- a/auth-api/tests/unit/api/test_org_products.py
+++ b/auth-api/tests/unit/api/test_org_products.py
@@ -24,7 +24,7 @@ import pytest
 
 from auth_api.models import Task as TaskModel
 from auth_api.schemas import utils as schema_utils
-from auth_api.utils.enums import ProductSubscriptionStatus, TaskRelationshipType, TaskAction, TaskStatus
+from auth_api.utils.enums import ProductSubscriptionStatus, TaskAction, TaskRelationshipType, TaskStatus
 from tests.utilities.factory_scenarios import TestJwtClaims, TestOrgInfo, TestOrgProductsInfo
 from tests.utilities.factory_utils import factory_auth_header
 
@@ -835,9 +835,9 @@ def test_remove_org_product_with_review(client, jwt, session, keycloak_mock):
     )
     assert rv.status_code == HTTPStatus.CREATED
     dictionary = json.loads(rv.data)
-    org_id = dictionary.get('id')
+    org_id = dictionary.get("id")
     product_info = TestOrgProductsInfo.org_products_vs
-    product_code = product_info['subscriptions'][0]['productCode']
+    product_code = product_info["subscriptions"][0]["productCode"]
     rv_products = client.post(
         f"/api/v1/orgs/{org_id}/products",
         data=json.dumps(product_info),
@@ -847,11 +847,14 @@ def test_remove_org_product_with_review(client, jwt, session, keycloak_mock):
     assert rv_products.status_code == HTTPStatus.CREATED
     assert schema_utils.validate(rv_products.json, "org_product_subscriptions_response")[0]
 
-    task = assert_task(client, jwt,
-                       ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
-                       TaskStatus.OPEN.value,
-                       TaskRelationshipType.PRODUCT.value,
-                       TaskAction.PRODUCT_REVIEW.value)
+    task = assert_task(
+        client,
+        jwt,
+        ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
+        TaskStatus.OPEN.value,
+        TaskRelationshipType.PRODUCT.value,
+        TaskAction.PRODUCT_REVIEW.value,
+    )
     client.put(
         "/api/v1/tasks/{}".format(task["id"]),
         data=json.dumps({"relationshipStatus": ProductSubscriptionStatus.ACTIVE.value}),
@@ -859,28 +862,32 @@ def test_remove_org_product_with_review(client, jwt, session, keycloak_mock):
         content_type="application/json",
     )
 
-    assert_task(client, jwt,
-                ProductSubscriptionStatus.ACTIVE.value,
-                TaskStatus.COMPLETED.value,
-                TaskRelationshipType.PRODUCT.value,
-                TaskAction.PRODUCT_REVIEW.value)
+    assert_task(
+        client,
+        jwt,
+        ProductSubscriptionStatus.ACTIVE.value,
+        TaskStatus.COMPLETED.value,
+        TaskRelationshipType.PRODUCT.value,
+        TaskAction.PRODUCT_REVIEW.value,
+    )
 
     assert_product_subscription(client, jwt, org_id, product_code, ProductSubscriptionStatus.ACTIVE.value)
 
     rv_products = client.delete(
-        f"/api/v1/orgs/{org_id}/products/{product_code}",
-        headers=user_headers,
-        content_type="application/json"
+        f"/api/v1/orgs/{org_id}/products/{product_code}", headers=user_headers, content_type="application/json"
     )
     assert rv_products.status_code == HTTPStatus.OK
     assert schema_utils.validate(rv_products.json, "org_product_subscriptions_response")[0]
 
     assert_product_subscription(client, jwt, org_id, product_code, ProductSubscriptionStatus.NOT_SUBSCRIBED.value)
-    assert_task(client, jwt,
-                ProductSubscriptionStatus.ACTIVE.value,
-                TaskStatus.COMPLETED.value,
-                TaskRelationshipType.PRODUCT.value,
-                TaskAction.PRODUCT_REVIEW.value)
+    assert_task(
+        client,
+        jwt,
+        ProductSubscriptionStatus.ACTIVE.value,
+        TaskStatus.COMPLETED.value,
+        TaskRelationshipType.PRODUCT.value,
+        TaskAction.PRODUCT_REVIEW.value,
+    )
 
     rv_products = client.post(
         f"/api/v1/orgs/{org_id}/products",
@@ -894,11 +901,14 @@ def test_remove_org_product_with_review(client, jwt, session, keycloak_mock):
     assert_product_subscription(client, jwt, org_id, product_code, ProductSubscriptionStatus.ACTIVE.value)
 
     # Should not create another task as it was previously approved
-    assert_task(client, jwt,
-                ProductSubscriptionStatus.ACTIVE.value,
-                TaskStatus.COMPLETED.value,
-                TaskRelationshipType.PRODUCT.value,
-                TaskAction.PRODUCT_REVIEW.value)
+    assert_task(
+        client,
+        jwt,
+        ProductSubscriptionStatus.ACTIVE.value,
+        TaskStatus.COMPLETED.value,
+        TaskRelationshipType.PRODUCT.value,
+        TaskAction.PRODUCT_REVIEW.value,
+    )
 
 
 @pytest.mark.parametrize(
@@ -907,9 +917,11 @@ def test_remove_org_product_with_review(client, jwt, session, keycloak_mock):
         (TaskStatus.HOLD.value, ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value, True),
         (TaskStatus.CLOSED.value, ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value, False),
         (None, ProductSubscriptionStatus.REJECTED.value, False),
-    ])
-def test_remove_org_product_with_incomplete_review_state(client, jwt, session, keycloak_mock,
-                                                         task_status, relationship_status, should_remove_previous_task):
+    ],
+)
+def test_remove_org_product_with_incomplete_review_state(
+    client, jwt, session, keycloak_mock, task_status, relationship_status, should_remove_previous_task
+):
     """Assert that removing a product subscription with incomplete review task works properly."""
     staff_headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_role)
     user_headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
@@ -919,9 +931,9 @@ def test_remove_org_product_with_incomplete_review_state(client, jwt, session, k
     )
     assert rv.status_code == HTTPStatus.CREATED
     dictionary = json.loads(rv.data)
-    org_id = dictionary.get('id')
+    org_id = dictionary.get("id")
     product_info = TestOrgProductsInfo.org_products_vs
-    product_code = product_info['subscriptions'][0]['productCode']
+    product_code = product_info["subscriptions"][0]["productCode"]
     rv_products = client.post(
         f"/api/v1/orgs/{org_id}/products",
         data=json.dumps(product_info),
@@ -931,16 +943,19 @@ def test_remove_org_product_with_incomplete_review_state(client, jwt, session, k
     assert rv_products.status_code == HTTPStatus.CREATED
     assert schema_utils.validate(rv_products.json, "org_product_subscriptions_response")[0]
 
-    task = assert_task(client, jwt,
-                       ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
-                       TaskStatus.OPEN.value,
-                       TaskRelationshipType.PRODUCT.value,
-                       TaskAction.PRODUCT_REVIEW.value)
+    task = assert_task(
+        client,
+        jwt,
+        ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
+        TaskStatus.OPEN.value,
+        TaskRelationshipType.PRODUCT.value,
+        TaskAction.PRODUCT_REVIEW.value,
+    )
     payload = {}
     if task_status:
-        payload['status'] = task_status
+        payload["status"] = task_status
     if relationship_status:
-        payload['relationshipStatus'] = relationship_status
+        payload["relationshipStatus"] = relationship_status
 
     client.put(
         "/api/v1/tasks/{}".format(task["id"]),
@@ -949,29 +964,27 @@ def test_remove_org_product_with_incomplete_review_state(client, jwt, session, k
         content_type="application/json",
     )
 
-    task = assert_task(client, jwt,
-                       relationship_status
-                       if relationship_status else ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
-                       task_status
-                       if task_status else TaskStatus.COMPLETED.value,
-                       TaskRelationshipType.PRODUCT.value,
-                       TaskAction.PRODUCT_REVIEW.value)
+    task = assert_task(
+        client,
+        jwt,
+        relationship_status if relationship_status else ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
+        task_status if task_status else TaskStatus.COMPLETED.value,
+        TaskRelationshipType.PRODUCT.value,
+        TaskAction.PRODUCT_REVIEW.value,
+    )
 
     rv_products = client.delete(
-        f"/api/v1/orgs/{org_id}/products/{product_code}",
-        headers=user_headers,
-        content_type="application/json"
+        f"/api/v1/orgs/{org_id}/products/{product_code}", headers=user_headers, content_type="application/json"
     )
     assert rv_products.status_code == HTTPStatus.OK
 
-    assert_product_subscription(client, jwt, org_id, product_code,
-                                ProductSubscriptionStatus.NOT_SUBSCRIBED.value)
+    assert_product_subscription(client, jwt, org_id, product_code, ProductSubscriptionStatus.NOT_SUBSCRIBED.value)
 
-    task_model = TaskModel.find_by_task_id(task['id'])
+    task_model = TaskModel.find_by_task_id(task["id"])
     if should_remove_previous_task:
         assert task_model is None
     else:
-        assert task_model.id == task['id']
+        assert task_model.id == task["id"]
 
     rv_products = client.post(
         f"/api/v1/orgs/{org_id}/products",
@@ -985,17 +998,24 @@ def test_remove_org_product_with_incomplete_review_state(client, jwt, session, k
     assert_product_subscription(client, jwt, org_id, product_code, ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value)
 
     if should_remove_previous_task:
-        task = assert_task(client, jwt,
-                           ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
-                           TaskStatus.OPEN.value,
-                           TaskRelationshipType.PRODUCT.value,
-                           TaskAction.PRODUCT_REVIEW.value)
+        task = assert_task(
+            client,
+            jwt,
+            ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
+            TaskStatus.OPEN.value,
+            TaskRelationshipType.PRODUCT.value,
+            TaskAction.PRODUCT_REVIEW.value,
+        )
     else:
-        task = assert_task(client, jwt,
-                           ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
-                           TaskStatus.OPEN.value,
-                           TaskRelationshipType.PRODUCT.value,
-                           TaskAction.PRODUCT_REVIEW.value, 2)
+        task = assert_task(
+            client,
+            jwt,
+            ProductSubscriptionStatus.PENDING_STAFF_REVIEW.value,
+            TaskStatus.OPEN.value,
+            TaskRelationshipType.PRODUCT.value,
+            TaskAction.PRODUCT_REVIEW.value,
+            2,
+        )
 
     client.put(
         "/api/v1/tasks/{}".format(task["id"]),
@@ -1004,8 +1024,7 @@ def test_remove_org_product_with_incomplete_review_state(client, jwt, session, k
         content_type="application/json",
     )
 
-    assert_product_subscription(client, jwt, org_id, product_code,
-                                ProductSubscriptionStatus.ACTIVE.value)
+    assert_product_subscription(client, jwt, org_id, product_code, ProductSubscriptionStatus.ACTIVE.value)
 
 
 def test_remove_org_product_without_review(client, jwt, session, keycloak_mock):
@@ -1017,9 +1036,9 @@ def test_remove_org_product_without_review(client, jwt, session, keycloak_mock):
     )
     assert rv.status_code == HTTPStatus.CREATED
     dictionary = json.loads(rv.data)
-    org_id = dictionary.get('id')
+    org_id = dictionary.get("id")
     product_info = TestOrgProductsInfo.org_products_business
-    product_code = product_info['subscriptions'][0]['productCode']
+    product_code = product_info["subscriptions"][0]["productCode"]
     rv_products = client.post(
         f"/api/v1/orgs/{org_id}/products",
         data=json.dumps(product_info),
@@ -1032,9 +1051,7 @@ def test_remove_org_product_without_review(client, jwt, session, keycloak_mock):
     assert_product_subscription(client, jwt, org_id, product_code, ProductSubscriptionStatus.ACTIVE.value)
 
     rv_products = client.delete(
-        f"/api/v1/orgs/{org_id}/products/{product_code}",
-        headers=user_headers,
-        content_type="application/json"
+        f"/api/v1/orgs/{org_id}/products/{product_code}", headers=user_headers, content_type="application/json"
     )
     assert rv_products.status_code == HTTPStatus.OK
     assert schema_utils.validate(rv_products.json, "org_product_subscriptions_response")[0]
@@ -1063,12 +1080,11 @@ def assert_product_subscription(client, jwt, org_id, product_code, expected_stat
 
     product = next(prod for prod in list_products if prod.get("code") == product_code)
     assert product
-    assert product['subscriptionStatus'] == expected_status
-    assert product['code'] == product_code
+    assert product["subscriptionStatus"] == expected_status
+    assert product["code"] == product_code
 
 
-def assert_task(client, jwt, relationship_status, task_status, relationship_type, action,
-                expected_task_length=1):
+def assert_task(client, jwt, relationship_status, task_status, relationship_type, action, expected_task_length=1):
     staff_headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_role)
     rv = client.get("/api/v1/tasks", headers=staff_headers, content_type="application/json")
 
@@ -1077,8 +1093,11 @@ def assert_task(client, jwt, relationship_status, task_status, relationship_type
     assert rv.status_code == HTTPStatus.OK
     assert len(item_list["tasks"]) == expected_task_length
     tasks = item_list["tasks"]
-    task = next(task for task in tasks
-                if task.get("relationshipStatus") == relationship_status and task.get("status") == task_status)
+    task = next(
+        task
+        for task in tasks
+        if task.get("relationshipStatus") == relationship_status and task.get("status") == task_status
+    )
     assert task["relationshipStatus"] == relationship_status
     assert task["relationshipType"] == relationship_type
     assert task["status"] == task_status

--- a/queue_services/account-mailer/poetry.lock
+++ b/queue_services/account-mailer/poetry.lock
@@ -1031,7 +1031,7 @@ six = "^1.16.0"
 type = "git"
 url = "https://github.com/seeker25/flask-jwt-oidc.git"
 reference = "main"
-resolved_reference = "d208d4643e3b17358f7295bee0f955e67ba6ac88"
+resolved_reference = "563f01ef6453eb0ea1cc0a2d71c6665350c853ff"
 
 [[package]]
 name = "flask-mail"

--- a/queue_services/auth-queue/poetry.lock
+++ b/queue_services/auth-queue/poetry.lock
@@ -1042,7 +1042,7 @@ six = "^1.16.0"
 type = "git"
 url = "https://github.com/seeker25/flask-jwt-oidc.git"
 reference = "main"
-resolved_reference = "d208d4643e3b17358f7295bee0f955e67ba6ac88"
+resolved_reference = "563f01ef6453eb0ea1cc0a2d71c6665350c853ff"
 
 [[package]]
 name = "flask-mail"


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/25143

*Description of changes:*
- Add ability to remove a product and clean up any pending tasks
- Re-adding a product previously approved will auto approve (no new task is created, will just activate product)
- New tests to for product removal and re-adding product from various states
- clean up on orgId format validation on org_products route (moved to function)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
