### PR TITLE
Document Record Service Continuation In Integration

### DIFF
--- a/auth-web/src/components/auth/staff/continuation-application/HomeJurisdictionInformation.vue
+++ b/auth-web/src/components/auth/staff/continuation-application/HomeJurisdictionInformation.vue
@@ -314,14 +314,28 @@ export default defineComponent({
       if (!documentKey || !documentName) return // safety check
 
       state.isDownloading = true
-      await BusinessService.downloadDocument(documentKey, documentName).catch(error => {
+      const documentClass = 'CORP'
+      try {
+        const docUrl: string = await BusinessService.getDownloadUrl(documentKey, documentClass)
+        const link = document.createElement('a')
+        link.href = docUrl
+        link.download = documentName
+        link.target = '_blank' // This opens the link in a new browser tab
+
+        // Append to the document and trigger the download
+        document.body.appendChild(link)
+        link.click()
+
+        // Remove the link after the download is triggered
+        document.body.removeChild(link)
+        state.isDownloading = false
+      } catch (error) {
         // eslint-disable-next-line no-console
         console.log('downloadDocument() error =', error)
         state.dialogTitle = 'Unable to download document'
         state.dialogText = 'An error occurred while downloading the document. Please try again.'
         const v = errorDialogComponent.value as any; v.open()
-      })
-      state.isDownloading = false
+      }
     }
 
     /**

--- a/auth-web/src/components/auth/staff/continuation-application/HomeJurisdictionInformation.vue
+++ b/auth-web/src/components/auth/staff/continuation-application/HomeJurisdictionInformation.vue
@@ -315,27 +315,14 @@ export default defineComponent({
 
       state.isDownloading = true
       const documentClass = 'CORP'
-      try {
-        const docUrl: string = await BusinessService.getDownloadUrl(documentKey, documentClass)
-        const link = document.createElement('a')
-        link.href = docUrl
-        link.download = documentName
-        link.target = '_blank' // This opens the link in a new browser tab
-
-        // Append to the document and trigger the download
-        document.body.appendChild(link)
-        link.click()
-
-        // Remove the link after the download is triggered
-        document.body.removeChild(link)
-        state.isDownloading = false
-      } catch (error) {
+      await BusinessService.downloadDocument(documentKey, documentName, documentClass).catch(error => {
         // eslint-disable-next-line no-console
         console.log('downloadDocument() error =', error)
         state.dialogTitle = 'Unable to download document'
         state.dialogText = 'An error occurred while downloading the document. Please try again.'
         const v = errorDialogComponent.value as any; v.open()
-      }
+      })
+      state.isDownloading = false
     }
 
     /**

--- a/auth-web/src/services/business.services.ts
+++ b/auth-web/src/services/business.services.ts
@@ -107,7 +107,7 @@ export default class BusinessService {
   static async fetchFiling (url: string): Promise<any> {
     // safety check
     if (!url) throw new Error('Invalid parameters')
-
+    
     return axios.get(url)
       .then(response => {
         const filing = response?.data?.filing
@@ -203,6 +203,29 @@ export default class BusinessService {
       }
 
       return response
+    })
+  }
+
+  /**
+   * Downloads a document from Legal API and prompts browser to open/save it.
+   * @param documentServiceId the unique id on Document Record Service
+   * @param documentName the document filename
+   * @returns a promise to return the axios response or the error response
+   * @see CommonUtils.fileDownload() for a similar method
+   */
+  static async getDownloadUrl (documentKey: string, documentClass: string): Promise<string> {
+    // safety checks
+    if (!documentKey || !documentClass) throw new Error('Invalid parameters')
+
+    const url = `${ConfigHelper.getLegalAPIV2Url()}/documents/drs/${documentClass}/${documentKey}`
+
+    return axios.get(url).then(response => {
+      if (!response) throw new Error('Null response')
+
+      return response.data.documentURL
+    }).catch(error => {
+      console.log(error)
+      return ''
     })
   }
 

--- a/auth-web/src/services/business.services.ts
+++ b/auth-web/src/services/business.services.ts
@@ -207,11 +207,10 @@ export default class BusinessService {
   }
 
   /**
-   * Downloads a document from Legal API and prompts browser to open/save it.
+   * Get download url from Document Record Service
    * @param documentServiceId the unique id on Document Record Service
-   * @param documentName the document filename
-   * @returns a promise to return the axios response or the error response
-   * @see CommonUtils.fileDownload() for a similar method
+   * @param documentClass the document class defined for the document service. e.g. 'CORP'
+   * @returns a promise to return the string of file download.
    */
   static async getDownloadUrl (documentKey: string, documentClass: string): Promise<string> {
     // safety checks

--- a/auth-web/tests/unit/components/HomeJurisdictionInformation.spec.ts
+++ b/auth-web/tests/unit/components/HomeJurisdictionInformation.spec.ts
@@ -120,12 +120,13 @@ describe('HomeJurisdictionInformation component', () => {
   })
 
   it('rendered a functional authorization download button', () => {
-    BusinessService.getDownloadUrl = vi.fn().mockResolvedValue(null)
+    BusinessService.downloadDocument = vi.fn().mockResolvedValue(null)
 
     const button = wrapper.findAll('section').at(5).find('.download-authorization-btn')
     button.trigger('click')
-    expect(BusinessService.getDownloadUrl).toHaveBeenCalledWith(
+    expect(BusinessService.downloadDocument).toHaveBeenCalledWith(
       'DS01000000',
+      'My Authorization Document.pdf',
       documentClass
     )
 

--- a/auth-web/tests/unit/components/HomeJurisdictionInformation.spec.ts
+++ b/auth-web/tests/unit/components/HomeJurisdictionInformation.spec.ts
@@ -12,20 +12,20 @@ const localVue = createLocalVue()
 const vuetify = new Vuetify({})
 
 const review = {}
-
+const documentClass = 'CORP'
 const filing = {
   continuationIn: {
     authorization: {
       date: '2024-07-01',
       files: [
         {
-          fileKey: '0071dbd6-6095-46f6-b5e4-cc859b0ebf27.pdf',
+          fileKey: 'DS01000000',
           fileName: 'My Authorization Document.pdf'
         }
       ]
     },
     foreignJurisdiction: {
-      affidavitFileKey: '007bd7bd-d421-49a9-9925-03ce561d044f.pdf',
+      affidavitFileKey: 'DS99999999',
       affidavitFileName: 'My Director Affidavit.pdf',
       country: 'CA',
       identifier: 'AB-5444',
@@ -120,12 +120,14 @@ describe('HomeJurisdictionInformation component', () => {
   })
 
   it('rendered a functional authorization download button', () => {
-    BusinessService.downloadDocument = vi.fn().mockResolvedValue(null)
+    BusinessService.getDownloadUrl = vi.fn().mockResolvedValue(null)
 
     const button = wrapper.findAll('section').at(5).find('.download-authorization-btn')
     button.trigger('click')
-    expect(BusinessService.downloadDocument).toHaveBeenCalledWith('0071dbd6-6095-46f6-b5e4-cc859b0ebf27.pdf',
-      'My Authorization Document.pdf')
+    expect(BusinessService.getDownloadUrl).toHaveBeenCalledWith(
+      'DS01000000',
+      documentClass
+    )
 
     vi.clearAllMocks()
   })


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/24640

*Description of changes:*
My name is Brandon Galli from Assets team.
Now we do Document Record Service Continuation In integration as a Proof of Concept.
Technically, Cont In. integration is replacing MinIO with Document Record Service.

- Added `getDownloadUrl` function on 
- Replace `downloadDocument` function with `getDownloadUrl` function on `HomeJurisdictionInformation.vue`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
