### PR TITLE
25281 - Updated .env.example to use new BRD domain

### DIFF
--- a/auth-web/.env.example
+++ b/auth-web/.env.example
@@ -34,7 +34,7 @@ VUE_APP_CORPORATE_ONLINE_URL="https://www.corporateonline.gov.bc.ca"
 VUE_APP_NRO_URL="https://dev.bcregistrynames.gov.bc.ca/nro/"
 VUE_APP_REGISTRY_SEARCH_URL="https://dev.search.business.bcregistry.gov.bc.ca/"
 VUE_APP_NAMEX_WEB_URL="https://dev.namex.bcregistry.gov.bc.ca/"
-VUE_APP_BUSINESS_REGISTRY_URL="https://business-registry-dev.web.app/"
+VUE_APP_BUSINESS_REGISTRY_URL="https://dev.business-registry-dashboard.bcregistry.gov.bc.ca/"
 
 #vaults API
 VUE_APP_AUTH_API_URL="https://auth-api-dev.apps.silver.devops.gov.bc.ca"


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/25281

*Description of changes:*
Sev @severinbeauvais, can you change the following please:
VUE_APP_BUSINESS_REGISTRY_URL="op://web-url/$APP_ENV/business-registry-ui/BUSINESS_REGISTRY_URL"

The values are now:
https://dev.business-registry-dashboard.bcregistry.gov.bc.ca/
https://test.business-registry-dashboard.bcregistry.gov.bc.ca/
https://www.business-registry-dashboard.bcregistry.gov.bc.ca/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
