### PR TITLE
24648 - contact_centre_staff role fixes

### DIFF
--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/common/ProductTOS.vue
+++ b/auth-web/src/components/auth/common/ProductTOS.vue
@@ -69,7 +69,7 @@ export default defineComponent({
     const state = reactive({
       termsAccepted: false,
       istosTouched: false,
-      canAcceptTos: computed(() => !userStore.currentUser.roles.includes(Role.ContactCentreStaff))
+      canAcceptTos: computed(() => !userStore?.currentUser?.roles.includes(Role.ContactCentreStaff))
     })
 
     watch(() => props.isTOSAlreadyAccepted, (newTos, oldTos) => {

--- a/auth-web/src/components/auth/staff/review-task/AccountInformation.vue
+++ b/auth-web/src/components/auth/staff/review-task/AccountInformation.vue
@@ -104,8 +104,8 @@
             {{ accessTypeDesc }}
           </v-col>
           <v-col
-            v-can:EDIT_USER.hide
             v-if="accountUnderReview.accessType === AccessType.GOVN"
+            v-can:EDIT_USER.hide
             cols="auto"
           >
             <v-btn

--- a/auth-web/src/components/auth/staff/review-task/AccountInformation.vue
+++ b/auth-web/src/components/auth/staff/review-task/AccountInformation.vue
@@ -104,6 +104,7 @@
             {{ accessTypeDesc }}
           </v-col>
           <v-col
+            v-can:EDIT_USER.hide
             v-if="accountUnderReview.accessType === AccessType.GOVN"
             cols="auto"
           >

--- a/auth-web/src/views/auth/staff/StaffDashboardView.vue
+++ b/auth-web/src/views/auth/staff/StaffDashboardView.vue
@@ -380,9 +380,7 @@ export default defineComponent({
       searchIdentifier: '',
       canSearchFAS: computed((): boolean => currentUser.value?.roles?.includes(Role.FasSearch)),
       canViewAccounts: computed((): boolean => currentUser.value?.roles?.includes(Role.StaffViewAccounts)),
-      canViewAllTransactions: computed((): boolean => currentUser.value?.roles?.some(
-        role => role === Role.ViewAllTransactions || role === Role.ContactCentreStaff
-      )),
+      canViewAllTransactions: computed((): boolean => currentUser.value?.roles?.includes(Role.ViewAllTransactions)),
       canViewEFTPayments: computed((): boolean => currentUser.value?.roles?.includes(Role.ManageEft)),
       canViewGLCodes: computed((): boolean => currentUser.value?.roles?.includes(Role.ManageGlCodes)),
       isContactCentreStaff: computed(() => currentUser.value?.roles?.includes(Role.ContactCentreStaff)),

--- a/auth-web/src/views/auth/staff/StaffDashboardView.vue
+++ b/auth-web/src/views/auth/staff/StaffDashboardView.vue
@@ -14,6 +14,7 @@
       no-gutters
     >
       <v-col
+        v-can:VIEW_LAUNCH_TITLES.hide
         class="pr-2"
         cols="6"
       >
@@ -125,7 +126,9 @@
           />
         </v-card>
       </v-col>
+
       <v-col
+        v-can:VIEW_LAUNCH_TITLES.hide
         class="pl-2"
         cols="6"
       >
@@ -250,6 +253,7 @@
 
     <!-- Email Safe List -->
     <BaseVExpansionPanel
+      v-can:VIEW_LAUNCH_TITLES.hide
       v-if="isDevOrTest"
       info="Please contact #registries-ops to add or remove email addresses from the safe list."
       title="Safe Email List (DEV/TEST)"
@@ -376,7 +380,7 @@ export default defineComponent({
       searchIdentifier: '',
       canSearchFAS: computed((): boolean => currentUser.value?.roles?.includes(Role.FasSearch)),
       canViewAccounts: computed((): boolean => currentUser.value?.roles?.includes(Role.StaffViewAccounts)),
-      canViewAllTransactions: computed((): boolean => currentUser.value?.roles?.includes(Role.ViewAllTransactions)),
+      canViewAllTransactions: computed((): boolean => currentUser.value?.roles?.some(role => role === Role.ViewAllTransactions || role === Role.ContactCentreStaff)),
       canViewEFTPayments: computed((): boolean => currentUser.value?.roles?.includes(Role.ManageEft)),
       canViewGLCodes: computed((): boolean => currentUser.value?.roles?.includes(Role.ManageGlCodes)),
       isContactCentreStaff: computed(() => currentUser.value?.roles?.includes(Role.ContactCentreStaff)),

--- a/auth-web/src/views/auth/staff/StaffDashboardView.vue
+++ b/auth-web/src/views/auth/staff/StaffDashboardView.vue
@@ -253,8 +253,8 @@
 
     <!-- Email Safe List -->
     <BaseVExpansionPanel
-      v-can:VIEW_LAUNCH_TITLES.hide
       v-if="isDevOrTest"
+      v-can:VIEW_LAUNCH_TITLES.hide
       info="Please contact #registries-ops to add or remove email addresses from the safe list."
       title="Safe Email List (DEV/TEST)"
     >
@@ -380,7 +380,9 @@ export default defineComponent({
       searchIdentifier: '',
       canSearchFAS: computed((): boolean => currentUser.value?.roles?.includes(Role.FasSearch)),
       canViewAccounts: computed((): boolean => currentUser.value?.roles?.includes(Role.StaffViewAccounts)),
-      canViewAllTransactions: computed((): boolean => currentUser.value?.roles?.some(role => role === Role.ViewAllTransactions || role === Role.ContactCentreStaff)),
+      canViewAllTransactions: computed((): boolean => currentUser.value?.roles?.some(
+        role => role === Role.ViewAllTransactions || role === Role.ContactCentreStaff
+      )),
       canViewEFTPayments: computed((): boolean => currentUser.value?.roles?.includes(Role.ManageEft)),
       canViewGLCodes: computed((): boolean => currentUser.value?.roles?.includes(Role.ManageGlCodes)),
       isContactCentreStaff: computed(() => currentUser.value?.roles?.includes(Role.ContactCentreStaff)),


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/24648

*Description of changes:*
Fixes for contact_centre_staff role:
Hiding business registry tile
Hiding staff personal property registry tile
Hiding Safe Email List Tile
Displaying Transaction records
Access type now can't be edited


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
