### PR TITLE
Add in migration for edit user

### DIFF
--- a/auth-api/migrations/README
+++ b/auth-api/migrations/README
@@ -1,3 +1,3 @@
 Generic single-database configuration.
 
-1. Add a new migration: /migrations  poetry run alembic revision --autogenerate -m "migration message"
+1. Add new migration: poetry run flask db revision, make sure DEPLOYMENT_ENV is set to 'migration' in your .env

--- a/auth-api/migrations/versions/2025_02_11_1893ddb6d071_.py
+++ b/auth-api/migrations/versions/2025_02_11_1893ddb6d071_.py
@@ -1,0 +1,29 @@
+"""Migration to add in new permission EDIT_USER for admin
+
+Revision ID: 1893ddb6d071
+Revises: 7425171449c9
+Create Date: 2025-02-11 05:56:03.631513
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1893ddb6d071'
+down_revision = '7425171449c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+  op.execute("""INSERT INTO permissions (membership_type_code, actions)
+    SELECT 'ADMIN', 'edit_user'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM permissions 
+        WHERE membership_type_code = 'ADMIN' 
+        AND actions = 'edit_user'
+    );""")
+
+def downgrade():
+  op.execute("delete from permissions where membership_type_code = 'ADMIN' and actions = 'edit_user'")


### PR DESCRIPTION
So it's consistent with DEV/TEST/PROD.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
