### PR TITLE
25229 - Remove Learn More button in Business Registry Marketing page

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.8.14",
+      "version": "2.8.15",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.8.14",
+  "version": "2.8.15",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/views/auth/home/DecideBusinessView.vue
+++ b/auth-web/src/views/auth/home/DecideBusinessView.vue
@@ -36,12 +36,6 @@
             </v-list-item-subtitle>
           </v-list-item-content>
         </v-list-item>
-
-        <!-- Panel Btns -->
-        <learn-more-button
-          class="mt-3"
-          :redirectUrl="learnMoreUrl"
-        />
       </v-col>
       <!-- Image Column -->
       <v-col
@@ -66,16 +60,9 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import ConfigHelper from '@/util/config-helper'
-import LearnMoreButton from '@/components/auth/common/LearnMoreButton.vue'
 
-@Component({
-  components: {
-    LearnMoreButton
-  }
-})
+@Component({})
 export default class DecideBusinessView extends Vue {
-  readonly learnMoreUrl = 'https://smallbusinessbc.ca/article/how-to-choose-the-right-business-structure-for-your-' +
-    'small-business/'
   readonly selectorWizardUrl = ConfigHelper.getEntitySelectorUrl()
   readonly bulletPoints: Array<any> = [
     {

--- a/auth-web/tests/unit/views/DecideBusinessView.spec.ts
+++ b/auth-web/tests/unit/views/DecideBusinessView.spec.ts
@@ -1,6 +1,5 @@
 import { createLocalVue, mount } from '@vue/test-utils'
 import DecideBusinessView from '@/views/auth/home/DecideBusinessView.vue'
-import LearnMoreButton from '@/components/auth/common/LearnMoreButton.vue'
 import VueRouter from 'vue-router'
 import Vuetify from 'vuetify'
 import flushPromises from 'flush-promises'
@@ -42,7 +41,6 @@ describe('DecideBusinessView.vue', () => {
 
   it('renders the components properly', () => {
     expect(wrapper.findComponent(DecideBusinessView).exists()).toBe(true)
-    expect(wrapper.findComponent(LearnMoreButton).exists()).toBe(true)
   })
 
   it('renders the correct text and number of bullet points', async () => {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/25229

*Description of changes:*
- Remove Learn More button in Business Registry Marketing page

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
