### PR TITLE
26272 use businessid from query string

### DIFF
--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.8.16",
+  "version": "2.8.17",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/stores/business.ts
+++ b/auth-web/src/stores/business.ts
@@ -254,7 +254,16 @@ export const useBusinessStore = defineStore('business', () => {
   }
 
   async function loadBusiness () {
-    const businessIdentifier = ConfigHelper.getFromSession(SessionStorageKeys.BusinessIdentifierKey)
+    let businessIdentifier = ConfigHelper.getFromSession(SessionStorageKeys.BusinessIdentifierKey)
+    // If we don't find anything in SessionStorage, try to grab it from the URL
+    if (businessIdentifier === null) {
+      const queryString = window.location.search
+      const urlParams = new URLSearchParams(queryString)
+      if (urlParams.get('businessid')) {
+        businessIdentifier = urlParams.get('businessid')
+      }
+    }
+
     // Need to look at LEAR, because it has the up-to-date names.
     const learBusiness = await searchBusiness(businessIdentifier)
     const response = await BusinessService.getBusiness(businessIdentifier)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/26272

If a business id is not found in session storage, we check for a value in the query string


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
