### PR TITLE
26537 - Update button links at the bottom of the marketing page

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/home/BcscPanel.vue
+++ b/auth-web/src/components/auth/home/BcscPanel.vue
@@ -108,8 +108,8 @@ export default defineComponent({
     }
   },
   setup () {
-    const cardSetUpUrl = 'https://www2.gov.bc.ca/gov/content/governments/government-id/bcservicescardapp/setup'
-    const learnMoreUrl = 'https://www2.gov.bc.ca/gov/content/governments/government-id/bcservicescardapp/setup'
+    const cardSetUpUrl = 'https://www.id.gov.bc.ca'
+    const learnMoreUrl = 'https://www.id.gov.bc.ca'
     const secureBulletPoints = [
       { text: `A mobile card is a representation of your BC Services Card on your mobile device. ` +
         `It's used to prove who you are when you log in to access government services online.` },

--- a/auth-web/src/components/auth/home/BcscPanel.vue
+++ b/auth-web/src/components/auth/home/BcscPanel.vue
@@ -48,7 +48,7 @@
             <v-list-item-subtitle class="list-item-text">
               It normally takes about 5 minutes to
               <a
-                :href="cardSetUpUrl"
+                :href="learnMoreUrl"
                 class="link"
                 target="_blank"
               >set up a mobile card</a>
@@ -108,7 +108,6 @@ export default defineComponent({
     }
   },
   setup () {
-    const cardSetUpUrl = 'https://www.id.gov.bc.ca'
     const learnMoreUrl = 'https://www.id.gov.bc.ca'
     const secureBulletPoints = [
       { text: `A mobile card is a representation of your BC Services Card on your mobile device. ` +
@@ -122,7 +121,6 @@ export default defineComponent({
     ]
 
     return {
-      cardSetUpUrl,
       learnMoreUrl,
       secureBulletPoints,
       easeBulletPoints


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/26537

*Description of changes:*
- update the link of Learn More button
- update the link of set up a mobile card

![image](https://github.com/user-attachments/assets/1799e78c-5dff-4f06-8c39-fc7dd4ac2e43)
currently go to an 'Information moved' page.
We should update these links to go to [www.id.gov.bc.ca](http://www.id.gov.bc.ca/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
