### PR TITLE
Wrapping test objects in dict() because they cross polute when modifi…

### DIFF
--- a/auth-api/tests/unit/api/test_activity_log.py
+++ b/auth-api/tests/unit/api/test_activity_log.py
@@ -83,7 +83,7 @@ def test_fetch_activity_log_masking(client, jwt, session):  # pylint:disable=unu
 
     factory_activity_log_model(actor=user.id, action=ActivityAction.CREATE_AFFILIATION.value, org_id=org.id)
 
-    user_with_token = TestUserInfo.user_staff_admin
+    user_with_token = dict(TestUserInfo.user_staff_admin)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     staff_user = factory_user_model(TestUserInfo.user_staff_admin)
     factory_activity_log_model(actor=staff_user.id, action=ActivityAction.REMOVE_AFFILIATION.value, org_id=org.id)

--- a/auth-api/tests/unit/api/test_task.py
+++ b/auth-api/tests/unit/api/test_task.py
@@ -161,7 +161,7 @@ def test_put_task_org(client, jwt, session, keycloak_mock, monkeypatch):  # pyli
     # 4. Create Org
     # 5. Update the created task and the relationship
     monkeypatch.setattr("auth_api.utils.user_context._get_token_info", lambda: TestJwtClaims.public_bceid_user)
-    user_with_token = TestUserInfo.user_staff_admin
+    user_with_token = dict(TestUserInfo.user_staff_admin)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -217,7 +217,7 @@ def test_put_task_org_on_hold(client, jwt, session, keycloak_mock, monkeypatch):
     # 4. Create Org
     # 5. Update the created task and the relationship
     monkeypatch.setattr("auth_api.utils.user_context._get_token_info", lambda: TestJwtClaims.public_bceid_user)
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -275,7 +275,7 @@ def test_put_task_product(client, jwt, session, keycloak_mock, monkeypatch):  # 
 
     # Post user, org and product subscription
     headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
-    user_with_token = TestUserInfo.user_staff_admin
+    user_with_token = dict(TestUserInfo.user_staff_admin)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)

--- a/auth-api/tests/unit/api/test_user.py
+++ b/auth-api/tests/unit/api/test_user.py
@@ -110,7 +110,7 @@ def test_add_user_staff_org(client, jwt, session, keycloak_mock, monkeypatch):
 
 def test_delete_bcros_valdiations(client, jwt, session, keycloak_mock, monkeypatch):
     """Assert different conditions of user deletion."""
-    admin_user = TestUserInfo.user_bcros_active
+    admin_user = dict(TestUserInfo.user_bcros_active)
     org = factory_org_model(org_info=TestOrgInfo.org_anonymous)
     user = factory_user_model(user_info=TestUserInfo.user_bcros_active)
     factory_membership_model(user.id, org.id)

--- a/auth-api/tests/unit/api/test_user_settings.py
+++ b/auth-api/tests/unit/api/test_user_settings.py
@@ -62,7 +62,7 @@ def test_get_user_settings(client, jwt, session, keycloak_mock, monkeypatch):  #
     assert schema_utils.validate(item_list, "user_settings_response")[0]
     assert account["productSettings"] == f'/account/{account["id"]}/restricted-product'
 
-    kc_id_no_user = TestUserInfo.user1.get("keycloak_guid")
+    kc_id_no_user = dict(TestUserInfo.user1).get("keycloak_guid")
     claims = copy.deepcopy(TestJwtClaims.updated_test.value)
     claims["sub"] = str(kc_id_no_user)
     patch_token_info(claims, monkeypatch)

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -350,7 +350,7 @@ def test_accept_affiliation_invitation(
     """Accept the affiliation invitation and add the affiliation from the invitation."""
     with patch.object(AffiliationInvitationService, "send_affiliation_invitation", return_value=None):
         with patch.object(auth, "check_auth", return_value=True):
-            user_with_token = TestUserInfo.user_test
+            user_with_token = dict(TestUserInfo.user_test)
             user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
             user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
             user = factory_user_model(user_with_token)
@@ -364,7 +364,7 @@ def test_accept_affiliation_invitation(
                 business_identifier=entity_dictionary["business_identifier"],
             )
 
-            user_with_token_invitee = TestUserInfo.user1
+            user_with_token_invitee = dict(TestUserInfo.user1)
             user_with_token_invitee["keycloak_guid"] = TestJwtClaims.edit_role_2["sub"]
             user_invitee = factory_user_model(user_with_token_invitee)
 
@@ -447,7 +447,7 @@ def test_get_invitations_by_from_org_id(
     """Find an existing invitation with the provided from org id."""
     with patch.object(AffiliationInvitationService, "send_affiliation_invitation", return_value=None):
         patch_token_info(TestJwtClaims.public_user_role, monkeypatch)
-        user_with_token = TestUserInfo.user_test
+        user_with_token = dict(TestUserInfo.user_test)
         user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
         user = factory_user_model(user_with_token)
         patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)
@@ -478,7 +478,7 @@ def test_get_invitations_by_to_org_id(
     """Find an existing invitation with the provided to org id."""
     with patch.object(AffiliationInvitationService, "send_affiliation_invitation", return_value=None):
         patch_token_info(TestJwtClaims.public_user_role, monkeypatch)
-        user_with_token = TestUserInfo.user_test
+        user_with_token = dict(TestUserInfo.user_test)
         user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
         user = factory_user_model(user_with_token)
         patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)

--- a/auth-api/tests/unit/services/test_entity.py
+++ b/auth-api/tests/unit/services/test_entity.py
@@ -106,7 +106,7 @@ def test_update_entity_existing_success(session, monkeypatch):  # pylint:disable
         "name": TestEntityInfo.bc_entity_passcode4["name"],
         "corpTypeCode": TestEntityInfo.bc_entity_passcode4["corpTypeCode"],
     }
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
 
     patch_token_info({"loginSource": "", "realm_access": {"roles": ["system"]}, "corp_type": "BC"}, monkeypatch)
@@ -138,7 +138,7 @@ def test_update_entity_existing_failures(session, monkeypatch):  # pylint:disabl
         "name": TestEntityInfo.bc_entity_passcode4["name"],
         "corpTypeCode": TestEntityInfo.bc_entity_passcode4["corpTypeCode"],
     }
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
 
     with pytest.raises(BusinessException) as exception:

--- a/auth-api/tests/unit/services/test_invitation.py
+++ b/auth-api/tests/unit/services/test_invitation.py
@@ -216,7 +216,7 @@ def test_accept_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # p
     with patch.object(InvitationService, "send_invitation", return_value=None):
         with patch.object(auth, "check_auth", return_value=True):
             with patch.object(InvitationService, "notify_admin", return_value=None):
-                user_with_token = TestUserInfo.user_test
+                user_with_token = dict(TestUserInfo.user_test)
                 user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
                 user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
                 user = factory_user_model(user_with_token)
@@ -225,7 +225,7 @@ def test_accept_invitation(session, auth_mock, keycloak_mock, monkeypatch):  # p
                 org = OrgService.create_org(TestOrgInfo.org1, user_id=user.id)
                 org_dictionary = org.as_dict()
                 invitation_info = factory_invitation(org_dictionary["id"])
-                user_with_token_invitee = TestUserInfo.user1
+                user_with_token_invitee = dict(TestUserInfo.user1)
                 user_with_token_invitee["keycloak_guid"] = TestJwtClaims.edit_role_2["sub"]
                 user_invitee = factory_user_model(user_with_token_invitee)
                 new_invitation = InvitationService.create_invitation(invitation_info, User(user_invitee), "")
@@ -243,7 +243,7 @@ def test_accept_invitation_for_govm(session, auth_mock, keycloak_mock, monkeypat
     with patch.object(InvitationService, "send_invitation", return_value=None):
         with patch.object(auth, "check_auth", return_value=True):
             with patch.object(InvitationService, "notify_admin", return_value=None):
-                user_with_token = TestUserInfo.user_staff_admin
+                user_with_token = dict(TestUserInfo.user_staff_admin)
                 user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
                 user = factory_user_model(user_with_token)
 
@@ -252,7 +252,7 @@ def test_accept_invitation_for_govm(session, auth_mock, keycloak_mock, monkeypat
                 org = OrgService.create_org(TestOrgInfo.org_govm, user_id=user.id)
                 org_dictionary = org.as_dict()
                 invitation_info = factory_invitation(org_dictionary["id"])
-                user_with_token_invitee = TestUserInfo.user1
+                user_with_token_invitee = dict(TestUserInfo.user1)
                 user_with_token_invitee["keycloak_guid"] = TestJwtClaims.edit_role_2["sub"]
                 user_invitee = factory_user_model(user_with_token_invitee)
                 new_invitation = InvitationService.create_invitation(invitation_info, User(user_invitee), "")
@@ -314,7 +314,7 @@ def test_get_invitations_by_org_id(session, auth_mock, keycloak_mock, monkeypatc
     """Find an existing invitation with the provided org id."""
     with patch.object(InvitationService, "send_invitation", return_value=None):
         patch_token_info(TestJwtClaims.public_user_role, monkeypatch)
-        user_with_token = TestUserInfo.user_test
+        user_with_token = dict(TestUserInfo.user_test)
         user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
         user = factory_user_model(user_with_token)
         patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)

--- a/auth-api/tests/unit/services/test_invitation_auth.py
+++ b/auth-api/tests/unit/services/test_invitation_auth.py
@@ -90,7 +90,7 @@ def test_token_user_context(session, auth_mock, monkeypatch):
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_change_authentication_subsequent_invites(session, auth_mock, keycloak_mock, monkeypatch):
     """Assert that changing org authentication method changes new invitation required login source."""
-    user_with_token = TestUserInfo.user_tester
+    user_with_token = dict(TestUserInfo.user_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.tester_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.tester_role["idp_userid"]
     inviter_user = factory_user_model(user_info=user_with_token)
@@ -176,7 +176,7 @@ def test_change_authentication_non_govm(session, auth_mock, keycloak_mock, monke
     invitee_bcsc_user = factory_user_model(TestUserInfo.user1)
     invitee_bceid_user = factory_user_model(TestUserInfo.user2)
 
-    patch_token_info(TestJwtClaims.tester_role, monkeypatch)
+    patch_token_info(TestJwtClaims.user_test, monkeypatch)
     org = OrgService.create_org(TestOrgInfo.org1, user_id=inviter_user.id)
     org_dictionary = org.as_dict()
 
@@ -219,14 +219,14 @@ def test_change_authentication_non_govm(session, auth_mock, keycloak_mock, monke
             assert invitation_model.login_source == LoginSource.BCSC.value
             assert invitation_model.invitation_status_code == InvitationStatus.ACCEPTED.value
 
-            patch_token_info(TestJwtClaims.tester_role, monkeypatch)
+            patch_token_info(TestJwtClaims.user_test, monkeypatch)
             members = MembershipService.get_members_for_org(org_dictionary["id"], "PENDING_APPROVAL")
             assert members
             assert len(members) == 1
 
     # Confirm that an invitation with BCSC login source can be accepted as another user login source and
     # updates the invitation login source based on the accepting user login source
-    patch_token_info(TestJwtClaims.tester_role, monkeypatch)
+    patch_token_info(TestJwtClaims.user_test, monkeypatch)
     with patch.object(InvitationService, "send_invitation", return_value=None):
         # Create invitation with BCSC login source
         with patch.object(ActivityLogPublisher, "publish_activity", return_value=None) as mock_alp:
@@ -265,7 +265,7 @@ def test_change_authentication_non_govm(session, auth_mock, keycloak_mock, monke
             assert invitation_model.login_source == LoginSource.BCEID.value
             assert invitation_model.invitation_status_code == InvitationStatus.ACCEPTED.value
 
-            patch_token_info(TestJwtClaims.tester_role, monkeypatch)
+            patch_token_info(TestJwtClaims.user_test, monkeypatch)
             members = MembershipService.get_members_for_org(org_dictionary["id"], "PENDING_APPROVAL")
             assert members
             assert len(members) == 2
@@ -362,7 +362,7 @@ def test_invitation_anonymous(session, auth_mock, keycloak_mock, monkeypatch):
     inviter_user = factory_user_model(TestUserInfo.user_tester)
     invitee_bcsc_user = factory_user_model(TestUserInfo.user1)
 
-    patch_token_info(TestJwtClaims.tester_role, monkeypatch)
+    patch_token_info(TestJwtClaims.user_test, monkeypatch)
     org = OrgService.create_org(TestOrgInfo.org1, user_id=inviter_user.id)
     org_dictionary = org.as_dict()
 
@@ -400,7 +400,7 @@ def test_invitation_anonymous(session, auth_mock, keycloak_mock, monkeypatch):
             assert invitation_model.login_source is None
             assert invitation_model.invitation_status_code == InvitationStatus.ACCEPTED.value
 
-            patch_token_info(TestJwtClaims.tester_role, monkeypatch)
+            patch_token_info(TestJwtClaims.user_test, monkeypatch)
             members = MembershipService.get_members_for_org(org_dictionary["id"], "PENDING_APPROVAL")
             assert members
             assert len(members) == 1

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -189,7 +189,7 @@ def test_pay_request_is_correct_with_branch_name(session, keycloak_mock, monkeyp
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_update_basic_org_assert_pay_request_activity(session, keycloak_mock, monkeypatch):
     """Assert that while org payment update touches activity log."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user = factory_user_model(user_info=user_with_token)
     patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)
@@ -220,7 +220,7 @@ def test_update_basic_org_assert_pay_request_is_correct(
     session, keycloak_mock, monkeypatch
 ):  # pylint:disable=unused-argument
     """Assert that while org updation , pay-api gets called with proper data for basic accounts."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user = factory_user_model(user_info=user_with_token)
     patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)
@@ -402,7 +402,7 @@ def test_create_org_assert_payment_types(session, keycloak_mock, monkeypatch):  
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_create_product_single_subscription(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user = factory_user_model(user_with_token)
     patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)
@@ -426,7 +426,7 @@ def test_create_product_single_subscription_duplicate_error(
     session, keycloak_mock, monkeypatch
 ):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user = factory_user_model(user_with_token)
     patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)
@@ -455,7 +455,7 @@ def test_create_product_single_subscription_duplicate_error(
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_create_product_multiple_subscription(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an Org can be created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model(user_with_token)
@@ -776,7 +776,7 @@ def test_update_contact_no_contact(session):  # pylint:disable=unused-argument
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_get_members(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that members for an org can be retrieved."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
     user = factory_user_model(user_info=user_with_token)
@@ -795,7 +795,7 @@ def test_get_members(session, keycloak_mock, monkeypatch):  # pylint:disable=unu
 def test_get_invitations(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that invitations for an org can be retrieved."""
     with patch.object(InvitationService, "send_invitation", return_value=None):
-        user_with_token = TestUserInfo.user_test
+        user_with_token = dict(TestUserInfo.user_test)
         user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
         user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
         user = factory_user_model(user_info=user_with_token)
@@ -818,7 +818,7 @@ def test_get_invitations(session, auth_mock, keycloak_mock, monkeypatch):  # pyl
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_get_owner_count_one_owner(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that count of owners is correct."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user = factory_user_model(user_info=user_with_token)
     patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)
@@ -829,7 +829,7 @@ def test_get_owner_count_one_owner(session, keycloak_mock, monkeypatch):  # pyli
 @pytest.mark.parametrize("staff_org", [(TestOrgInfo.staff_org), (TestOrgInfo.sbc_staff_org)])
 def test_create_staff_org_failure(session, keycloak_mock, staff_org, monkeypatch):  # pylint:disable=unused-argument
     """Assert that staff org cannot be created."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user = factory_user_model(user_info=user_with_token)
     patch_token_info({"sub": user.keycloak_guid, "idp_userid": user.idp_userid}, monkeypatch)
@@ -841,7 +841,7 @@ def test_create_staff_org_failure(session, keycloak_mock, staff_org, monkeypatch
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_get_owner_count_two_owner_with_admins(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert wrong org cannot be created."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user = factory_user_model(user_info=user_with_token)
 
@@ -858,7 +858,7 @@ def test_get_owner_count_two_owner_with_admins(session, keycloak_mock, monkeypat
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_delete_org_with_members(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an org can be deleted."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
     user = factory_user_model(user_info=user_with_token)
@@ -881,7 +881,7 @@ def test_delete_org_with_members(session, auth_mock, keycloak_mock, monkeypatch)
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_delete_org_with_affiliation(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that an org cannot be deleted."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user = factory_user_model(user_info=user_with_token)
 
@@ -908,7 +908,7 @@ def test_delete_org_with_members_success(
     session, auth_mock, keycloak_mock, monkeypatch
 ):  # pylint:disable=unused-argument
     """Assert that an org can be deleted."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
     user = factory_user_model(user_info=user_with_token)

--- a/auth-api/tests/unit/services/test_product_notifications.py
+++ b/auth-api/tests/unit/services/test_product_notifications.py
@@ -47,7 +47,7 @@ from tests.utilities.factory_utils import factory_user_model_with_contact, patch
 @patch.object(auth_api.services.products, "publish_to_mailer")
 def test_default_approved_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product approved notification default is created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -108,7 +108,7 @@ def test_default_approved_notification(mock_mailer, session, auth_mock, keycloak
 @patch.object(auth_api.services.products, "publish_to_mailer")
 def test_default_rejected_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product rejected notification default is created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -176,7 +176,7 @@ def test_default_rejected_notification(mock_mailer, session, auth_mock, keycloak
 @patch.object(auth_api.services.products, "publish_to_mailer")
 def test_detailed_approved_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product approved notification with details is created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -264,7 +264,7 @@ def test_detailed_rejected_notification(
     mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info, contact_type
 ):
     """Assert product rejected notification with details is created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -353,7 +353,7 @@ def test_detailed_rejected_notification(
 @patch.object(auth_api.services.products, "publish_to_mailer")
 def test_hold_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product notification is not created for on hold state."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -431,7 +431,7 @@ def test_confirmation_notification(
     mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info, contact_type
 ):
     """Assert product confirmation notification is properly created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -479,7 +479,7 @@ def test_confirmation_notification(
 @patch.object(auth_api.services.products, "publish_to_mailer")
 def test_no_confirmation_notification(mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info):
     """Assert product confirmation notification not created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -524,7 +524,7 @@ def test_resubmission_notification(
     mock_mailer, session, auth_mock, keycloak_mock, monkeypatch, org_product_info, contact_type
 ):
     """Assert product resubmission notifications are created."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)

--- a/auth-api/tests/unit/services/test_task.py
+++ b/auth-api/tests/unit/services/test_task.py
@@ -132,7 +132,7 @@ def test_create_task_product(session, keycloak_mock):  # pylint:disable=unused-a
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_update_task(session, keycloak_mock, monkeypatch, test_name, rmv_contact):  # pylint:disable=unused-argument
     """Assert that a task can be updated."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)
@@ -174,7 +174,7 @@ def test_update_task(session, keycloak_mock, monkeypatch, test_name, rmv_contact
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_hold_task(session, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a task can be updated."""
-    user_with_token = TestUserInfo.user_bceid_tester
+    user_with_token = dict(TestUserInfo.user_bceid_tester)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_bceid_user["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_bceid_user["idp_userid"]
     user = factory_user_model_with_contact(user_with_token)

--- a/auth-api/tests/unit/services/test_user.py
+++ b/auth-api/tests/unit/services/test_user.py
@@ -63,7 +63,7 @@ def test_as_dict(session):  # pylint: disable=unused-argument
     user = UserService(user_model)
 
     dictionary = user.as_dict()
-    assert dictionary["username"] == TestUserInfo.user1["username"]
+    assert dictionary["username"] == dict(TestUserInfo.user1)["username"]
 
 
 def test_user_save_by_token(session, monkeypatch):  # pylint: disable=unused-argument
@@ -444,7 +444,7 @@ def test_user_save_by_token_fail(session, monkeypatch):  # pylint: disable=unuse
 
 def test_add_contact_to_user(session, monkeypatch):  # pylint: disable=unused-argument
     """Assert that a contact can be added to a user."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.user_test["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.user_test["idp_userid"]
     factory_user_model(user_info=user_with_token)
@@ -467,7 +467,7 @@ def test_add_contact_user_no_user(session, monkeypatch):  # pylint: disable=unus
 
 def test_add_contact_to_user_already_exists(session, monkeypatch):  # pylint: disable=unused-argument
     """Assert that a contact cannot be added to a user that already has a contact."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.user_test["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.user_test["idp_userid"]
     factory_user_model(user_info=user_with_token)
@@ -482,7 +482,7 @@ def test_add_contact_to_user_already_exists(session, monkeypatch):  # pylint: di
 
 def test_update_contact_for_user(session, monkeypatch):  # pylint: disable=unused-argument
     """Assert that a contact can be updated for a user."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.user_test["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.user_test["idp_userid"]
     factory_user_model(user_info=user_with_token)
@@ -555,7 +555,7 @@ def test_update_contact_for_user_no_contact(session, monkeypatch):  # pylint: di
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_delete_contact_for_user(session, monkeypatch):  # pylint: disable=unused-argument
     """Assert that a contact can be deleted for a user."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.user_test["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.user_test["idp_userid"]
     factory_user_model(user_info=user_with_token)
@@ -604,7 +604,7 @@ def test_find_users(session):  # pylint: disable=unused-argument
 
 def test_user_find_by_token(session, monkeypatch):  # pylint: disable=unused-argument
     """Assert that a user can be found by token."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.user_test["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.user_test["idp_userid"]
     factory_user_model(user_info=user_with_token)
@@ -640,12 +640,12 @@ def test_user_find_by_username(session):  # pylint: disable=unused-argument
     user = UserService.find_by_username(TestUserInfo.user1["username"])
     assert user is not None
     dictionary = user.as_dict()
-    assert dictionary["username"] == TestUserInfo.user1["username"]
+    assert dictionary["username"] == dict(TestUserInfo.user1)["username"]
 
 
 def test_user_find_by_username_no_model_object(session):  # pylint: disable=unused-argument
     """Assert that the business can't be found with no model."""
-    username = TestUserInfo.user_test["username"]
+    username = dict(TestUserInfo.user_test)["username"]
 
     user = UserService.find_by_username(username)
 
@@ -665,7 +665,7 @@ def test_user_find_by_username_missing_username(session):  # pylint: disable=unu
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_delete_contact_user_link(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a contact can not be deleted if contact link exists."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
     user_model = factory_user_model(user_info=user_with_token)
@@ -700,7 +700,7 @@ def test_delete_contact_user_link(session, auth_mock, keycloak_mock, monkeypatch
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_delete_user(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a user can be deleted."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.user_test["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.user_test["idp_userid"]
     user_model = factory_user_model(user_info=user_with_token)

--- a/auth-api/tests/unit/services/test_user_settings.py
+++ b/auth-api/tests/unit/services/test_user_settings.py
@@ -30,7 +30,7 @@ from tests.utilities.factory_utils import factory_user_model, patch_token_info
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_user_settings(session, auth_mock, keycloak_mock, monkeypatch):  # pylint:disable=unused-argument
     """Assert that a contact can not be deleted if contact link exists."""
-    user_with_token = TestUserInfo.user_test
+    user_with_token = dict(TestUserInfo.user_test)
     user_with_token["keycloak_guid"] = TestJwtClaims.public_user_role["sub"]
     user_with_token["idp_userid"] = TestJwtClaims.public_user_role["idp_userid"]
     user_model = factory_user_model(user_info=user_with_token)

--- a/auth-api/tests/utilities/factory_utils.py
+++ b/auth-api/tests/utilities/factory_utils.py
@@ -85,7 +85,7 @@ def factory_entity_service(entity_info: dict = TestEntityInfo.entity1):
     return entity_service
 
 
-def factory_user_model(user_info: dict = TestUserInfo.user1):
+def factory_user_model(user_info: dict = dict(TestUserInfo.user1)):
     """Produce a user model."""
     roles = user_info.get("roles", None)
     if user_info.get("access_type", None) == AccessType.ANONYMOUS.value:
@@ -110,7 +110,7 @@ def factory_user_model(user_info: dict = TestUserInfo.user1):
     return user
 
 
-def factory_user_model_with_contact(user_info: dict = TestUserInfo.user1, keycloak_guid=None):
+def factory_user_model_with_contact(user_info: dict = dict(TestUserInfo.user1), keycloak_guid=None):
     """Produce a user model."""
     user_type = Role.ANONYMOUS_USER.name if user_info.get("access_type", None) == AccessType.ANONYMOUS.value else None
     user = UserModel(


### PR DESCRIPTION
…ed across test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
