### PR TITLE
26910 use business id from URL first

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.9.2",
+      "version": "2.9.3",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/stores/business.ts
+++ b/auth-web/src/stores/business.ts
@@ -254,8 +254,10 @@ export const useBusinessStore = defineStore('business', () => {
   }
 
   async function loadBusiness (businessQueryIdentifier = '') {
-    // Check session first or use query string if available.
-    const businessIdentifier = ConfigHelper.getFromSession(SessionStorageKeys.BusinessIdentifierKey) || businessQueryIdentifier
+    // Check query string first, if provided, otherwise fall back to business id in session storage.
+    // Note: session storage might contain business id from last time.
+    const businessIdentifier = businessQueryIdentifier || ConfigHelper.getFromSession(SessionStorageKeys.BusinessIdentifierKey)
+
     // Need to look at LEAR, because it has the up-to-date names.
     const learBusiness = await searchBusiness(businessIdentifier)
     const response = await BusinessService.getBusiness(businessIdentifier)

--- a/auth-web/src/views/auth/BusinessProfileView.vue
+++ b/auth-web/src/views/auth/BusinessProfileView.vue
@@ -98,7 +98,7 @@ export default class BusinessProfileView extends Mixins(AccountChangeMixin, Next
   private editing = false
   private isLoading = true
   private readonly currentBusiness!: Business
-  private readonly loadBusiness!: (businessId) => Business
+  private readonly loadBusiness!: (businessId: string) => Promise<Business>
   private navigateBack (): void {
     if (this.$route.query.redirect) {
       if (this.currentOrganization) {
@@ -113,7 +113,8 @@ export default class BusinessProfileView extends Mixins(AccountChangeMixin, Next
 
   async mounted () {
     this.isLoading = true
-    // Include businessid from query string in case session is empty.
+    // Pass in business id from URL query string.
+    // Note: action will set session storage.
     await this.loadBusiness(this.$attrs.businessid)
     // Check if there is already contact info so that we display the appropriate copy
     if ((this.currentBusiness?.contacts?.length || 0) > 0) {


### PR DESCRIPTION
*Issue #:* bcgov/entity#26910

*Description of changes:*
- app version = 2.9.3
- use business id from URL first, else fall back to session storage value
- fixed a typing issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).