### PR TITLE
22113 - Removed logic that stops conditionally-approved NRs from being affiliated

### DIFF
--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -279,10 +279,6 @@ class Affiliation:
             if not (invoices and invoices["invoices"] and invoices["invoices"][0].get("statusCode") == "COMPLETED"):
                 raise BusinessException(Error.NR_NOT_PAID, None)
 
-        # If consentFlag is not R, N or Null for a CONDITIONAL NR throw error
-        if status == NRStatus.CONDITIONAL.value and nr_json.get("consentFlag", None) not in (None, "R", "N"):
-            raise BusinessException(Error.NR_NOT_APPROVED, None)
-
         if not user_is_staff and (
             (phone and re.sub(r"\D", "", phone) != re.sub(r"\D", "", nr_phone))
             or (email and email.casefold() != nr_email.casefold())


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/

*Description of changes:*
Removed the logic that prevents conditionally-approved NRs from being affiliated

BEFORE:
<img width="766" alt="before conditional nr" src="https://github.com/user-attachments/assets/db3cae76-e725-40eb-8a23-decfd3ecdadf" />

AFTER:
<img width="773" alt="after conditional nr" src="https://github.com/user-attachments/assets/d5f3c739-5454-44e9-85f5-312c31734bbb" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
