### PR TITLE
27336 - Allow bcol admin invite other admins to a customer's account

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.9.8",
+      "version": "2.9.9",
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",
         "@bcrs-shared-components/bread-crumb": "1.0.8",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/account-settings/team-management/InviteUsersForm.vue
+++ b/auth-web/src/components/auth/account-settings/team-management/InviteUsersForm.vue
@@ -130,8 +130,8 @@ export default class InviteUsersForm extends TeamManagementMixin {
   }
 
   private get availableRoles () {
-    const isBcolAdmin = this.currentUser?.roles?.includes(Role.BcolStaffAdmin)
-    if ((this.currentMembership.membershipTypeCode !== MembershipType.Admin) && !isBcolAdmin) {
+    const isStaffManageAccounts = this.currentUser?.roles?.includes(Role.StaffManageAccounts)
+    if ((this.currentMembership.membershipTypeCode !== MembershipType.Admin) && !isStaffManageAccounts) {
       return this.roles.filter(role => role.name !== MembershipType.Admin)
     }
     return this.roles

--- a/auth-web/src/components/auth/account-settings/team-management/InviteUsersForm.vue
+++ b/auth-web/src/components/auth/account-settings/team-management/InviteUsersForm.vue
@@ -105,6 +105,7 @@ import { Component, Emit } from 'vue-property-decorator'
 import { MembershipType, RoleInfo } from '@/models/Organization'
 import CommonUtils from '@/util/common-util'
 import { Invitation } from '@/models/Invitation'
+import { Role } from '@/util/constants'
 import TeamManagementMixin from '../../mixins/TeamManagementMixin.vue'
 import { useOrgStore } from '@/stores/org'
 import { useUserStore } from '@/stores/user'
@@ -129,7 +130,8 @@ export default class InviteUsersForm extends TeamManagementMixin {
   }
 
   private get availableRoles () {
-    if ((this.currentMembership.membershipTypeCode !== MembershipType.Admin)) {
+    const isBcolAdmin = this.currentUser?.roles?.includes(Role.BcolStaffAdmin)
+    if ((this.currentMembership.membershipTypeCode !== MembershipType.Admin) && !isBcolAdmin) {
       return this.roles.filter(role => role.name !== MembershipType.Admin)
     }
     return this.roles


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/27336

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
