### PR TITLE
26898 - Update to how business name is obtained for firms

### DIFF
--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -314,10 +314,7 @@ class AffiliationInvitation:
             alternative_names = business["business"].get("alternateNames")
             if alternative_names is not None:
                 for alt_name in alternative_names:
-                    if (
-                        alt_name.get("identifier") == business_identifier
-                        and alt_name.get("name")
-                    ):
+                    if alt_name.get("identifier") == business_identifier and alt_name.get("name"):
                         business_name = alt_name.get("name")
                         break
         AffiliationInvitation.send_affiliation_invitation(
@@ -388,9 +385,8 @@ class AffiliationInvitation:
                 alternative_names = business["business"].get("alternateNames")
                 if alternative_names is not None:
                     for alt_name in alternative_names:
-                        if (
-                            alt_name.get("identifier") == self._model.entity.business_identifier
-                            and alt_name.get("name")
+                        if alt_name.get("identifier") == self._model.entity.business_identifier and alt_name.get(
+                            "name"
                         ):
                             business_name = alt_name.get("name")
                             break
@@ -603,10 +599,7 @@ class AffiliationInvitation:
             alternative_names = business["business"].get("alternateNames")
             if alternative_names is not None:
                 for alt_name in alternative_names:
-                    if (
-                        alt_name.get("identifier") == business["business"]["identifier"]
-                        and alt_name.get("name")
-                    ):
+                    if alt_name.get("identifier") == business["business"]["identifier"] and alt_name.get("name"):
                         business_name = alt_name.get("name")
                         break
         email_address = AffiliationInvitation.get_invitation_email(

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -306,10 +306,13 @@ class AffiliationInvitation:
         affiliation_invitation.token = confirmation_token
         affiliation_invitation.login_source = mandatory_login_source
         affiliation_invitation.save()
-
+        if business["business"]["legalType"] not in ["SP", "GP"]:
+            business_name = business["business"]["legalName"]
+        else:
+            business_name = business["business"]["alternateNames"]["name"]
         AffiliationInvitation.send_affiliation_invitation(
             affiliation_invitation=affiliation_invitation,
-            business_name=business["business"]["legalName"],
+            business_name=business_name,
             app_url=invitation_origin + "/",
             email_addresses=affiliation_invitation.recipient_email,
         )
@@ -368,10 +371,13 @@ class AffiliationInvitation:
                 config_id="ENTITY_SVC_CLIENT_ID", config_secret="ENTITY_SVC_CLIENT_SECRET"
             )
             business = AffiliationInvitation._get_business_details(entity.business_identifier, token)
-
+            if business["business"]["legalType"] not in ["SP", "GP"]:
+                business_name = business["business"]["legalName"]
+            else:
+                business_name = business["business"]["alternateNames"]["name"]
             AffiliationInvitation.send_affiliation_invitation(
                 affiliation_invitation=invitation,
-                business_name=business["business"]["legalName"],
+                business_name=business_name,
                 app_url=invitation_origin + "/",
                 email_addresses=invitation.recipient_email,
             )
@@ -571,7 +577,10 @@ class AffiliationInvitation:
         business = AffiliationInvitation._get_business_details(
             business_identifier=affiliation_invitation.entity.business_identifier, token=token
         )
-        business_name = business["business"]["legalName"]
+        if business["business"]["legalType"] not in ["SP", "GP"]:
+            business_name = business["business"]["legalName"]
+        else:
+            business_name = business["business"]["alternateNames"]["name"]
 
         email_address = AffiliationInvitation.get_invitation_email(
             affiliation_invitation_type=AffiliationInvitationType.REQUEST, org_id=affiliation_invitation.from_org_id

--- a/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_email.html
@@ -1,4 +1,6 @@
-### Authorization Confirmation
+
+Authorization Confirmation
+--------------------------
 
 To confirm that {{ account_name_with_branch }} can manage {{ business_name }} ({{ business_identifier }}), follow the steps below:  
 

--- a/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_email.html
@@ -1,6 +1,5 @@
 
-Authorization Confirmation
---------------------------
+# Authorization Confirmation
 
 To confirm that {{ account_name_with_branch }} can manage {{ business_name }} ({{ business_identifier }}), follow the steps below:  
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/26898 

For Firms we now populate business_name from alternateNames, as legalName is often populated with org name for firms.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
