### PR TITLE
27075 - add auth even for PATCH that doesn't use deactivate member

### DIFF
--- a/auth-api/src/auth_api/services/membership.py
+++ b/auth-api/src/auth_api/services/membership.py
@@ -275,6 +275,10 @@ class Membership:  # pylint: disable=too-many-instance-attributes,too-few-public
                     self._model.org_id, action, name=json.dumps(name), id=self._model.user.id, value=membership_type
                 )
             )
+            
+            if action == ActivityAction.REMOVE_TEAM_MEMBER.value:
+                publish_team_member_event(QueueMessageTypes.TEAM_MEMBER_REMOVED.value, self._model.org_id, self._model.user_id)
+                
         # Add to account_holders group in keycloak
         Membership._add_or_remove_group(self._model)
         is_bcros_user = self._model.user.login_source == LoginSource.BCROS.value

--- a/auth-api/src/auth_api/services/membership.py
+++ b/auth-api/src/auth_api/services/membership.py
@@ -275,10 +275,12 @@ class Membership:  # pylint: disable=too-many-instance-attributes,too-few-public
                     self._model.org_id, action, name=json.dumps(name), id=self._model.user.id, value=membership_type
                 )
             )
-            
+
             if action == ActivityAction.REMOVE_TEAM_MEMBER.value:
-                publish_team_member_event(QueueMessageTypes.TEAM_MEMBER_REMOVED.value, self._model.org_id, self._model.user_id)
-                
+                publish_team_member_event(
+                    QueueMessageTypes.TEAM_MEMBER_REMOVED.value, self._model.org_id, self._model.user_id
+                )
+
         # Add to account_holders group in keycloak
         Membership._add_or_remove_group(self._model)
         is_bcros_user = self._model.user.login_source == LoginSource.BCROS.value

--- a/auth-api/tests/unit/services/test_membership.py
+++ b/auth-api/tests/unit/services/test_membership.py
@@ -141,6 +141,7 @@ def test_remove_member_removes_group_to_the_user(publish_mock, session, monkeypa
         )
 
         publish_mock.assert_called_once_with(QueueMessageTypes.TEAM_MEMBER_REMOVED.value, org_id, membership.user_id)
+        publish_mock.reset_mock()
 
     # ACTIVE
     active_membership_status = MembershipStatusCodeModel.get_membership_status_by_code(Status.ACTIVE.name)
@@ -155,6 +156,7 @@ def test_remove_member_removes_group_to_the_user(publish_mock, session, monkeypa
         mock_alp.assert_called_with(
             Activity(action=ActivityAction.REMOVE_TEAM_MEMBER.value, org_id=ANY, name=ANY, id=ANY, value=ANY)
         )
+        publish_mock.assert_called_once_with(QueueMessageTypes.TEAM_MEMBER_REMOVED.value, org_id, membership.user_id)
 
     user_groups = keycloak_service.get_user_groups(user_id=kc_user2.id)
     groups = []


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/27075

*Description of changes:*
- update PATCH to deactivate member to send auth event message


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
