### PR TITLE
28438 - Update Affiliation to display proper title

### DIFF
--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -115,40 +115,51 @@ class AffiliationInvitation:
                     AffiliationInvitationData.OrgDetails, affiliation_invitation_dict["from_org"]
                 )
             )
-            if to_org := affiliation_invitation_dict.get("to_org"):
+            if to_org_dict := affiliation_invitation_dict.get("to_org"):
                 to_org = AffiliationInvitationData.OrgDetails(
                     **_init_dict_for_dataclass_from_dict(
-                        AffiliationInvitationData.OrgDetails, affiliation_invitation_dict["to_org"]
+                        AffiliationInvitationData.OrgDetails, to_org_dict
                     )
                 )
+            else:
+                to_org = None
 
             business_entity = next(
                 (
-                    business_entity
-                    for business_entity in business_entities
-                    if affiliation_invitation_dict["business_identifier"] == business_entity["identifier"]
+                    be
+                    for be in business_entities
+                    if affiliation_invitation_dict["business_identifier"] == be["identifier"]
                 ),
                 None,
             )
 
-            entity = (
-                AffiliationInvitationData.EntityDetails(
-                    business_identifier=business_entity["identifier"],
-                    name=business_entity["legalName"],
-                    state=business_entity["state"],
-                    corp_type=business_entity["legalType"],
+            entity_details = None
+            if business_entity:
+                entity_name_to_display = business_entity.get("legalName")
+                entity_legal_type = business_entity.get("legalType")
+                business_identifier = business_entity.get("identifier")
+
+                if entity_legal_type in ["SP", "GP"]:
+                    entity_name_to_display = AffiliationInvitation.get_business_name_from_alternative_name(
+                        business_entity,
+                        entity_name_to_display,
+                        business_identifier
+                    )
+
+                entity_details = AffiliationInvitationData.EntityDetails(
+                    business_identifier=business_identifier,
+                    name=entity_name_to_display,
+                    state=business_entity.get("state"),
+                    corp_type=entity_legal_type,
                     corp_sub_type=business_entity.get("legalSubType", None),
                 )
-                if business_entity
-                else None
-            )
 
             aid = AffiliationInvitationData(
                 **{
                     **_init_dict_for_dataclass_from_dict(AffiliationInvitationData, affiliation_invitation_dict),
                     "from_org": from_org,
                     "to_org": to_org,
-                    "entity": entity,
+                    "entity": entity_details,
                 }
             )
             result.append(aid)
@@ -352,16 +363,15 @@ class AffiliationInvitation:
         return get_business_response.json()["businessEntities"]
 
     @staticmethod
-    def get_business_name_from_alternative_name(business, business_name, business_identifier):
-        """Firms use alternative names rather than legalName. Reassign business_name if we find an alternative name."""
-        alternative_names = business["business"].get("alternateNames")
-        if alternative_names is not None:
-            for alt_name in alternative_names:
-                if alt_name.get("identifier") == business_identifier and alt_name.get("name"):
-                    business_name = alt_name.get("name")
-                    break
+    def get_business_name_from_alternative_name(business_data, default_name, business_identifier):
+        """Get the business name from the alternative name list, if it exists."""
+        business_info_dict = business_data.get('business') if 'business' in business_data else business_data
 
-        return business_name
+        if alternative_names := business_info_dict.get('alternateNames'):
+            for alt_name in alternative_names:
+                if alt_name.get('identifier') == business_identifier:
+                    return alt_name.get('name')
+        return default_name
 
     def update_affiliation_invitation(self, user, invitation_origin, affiliation_invitation_info: Dict):
         """Update the specified affiliation invitation with new data."""

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -115,51 +115,40 @@ class AffiliationInvitation:
                     AffiliationInvitationData.OrgDetails, affiliation_invitation_dict["from_org"]
                 )
             )
-            if to_org_dict := affiliation_invitation_dict.get("to_org"):
+            if to_org := affiliation_invitation_dict.get("to_org"):
                 to_org = AffiliationInvitationData.OrgDetails(
                     **_init_dict_for_dataclass_from_dict(
-                        AffiliationInvitationData.OrgDetails, to_org_dict
+                        AffiliationInvitationData.OrgDetails, affiliation_invitation_dict["to_org"]
                     )
                 )
-            else:
-                to_org = None
 
             business_entity = next(
                 (
-                    be
-                    for be in business_entities
-                    if affiliation_invitation_dict["business_identifier"] == be["identifier"]
+                    business_entity
+                    for business_entity in business_entities
+                    if affiliation_invitation_dict["business_identifier"] == business_entity["identifier"]
                 ),
                 None,
             )
 
-            entity_details = None
-            if business_entity:
-                entity_name_to_display = business_entity.get("legalName")
-                entity_legal_type = business_entity.get("legalType")
-                business_identifier = business_entity.get("identifier")
-
-                if entity_legal_type in ["SP", "GP"]:
-                    entity_name_to_display = AffiliationInvitation.get_business_name_from_alternative_name(
-                        business_entity,
-                        entity_name_to_display,
-                        business_identifier
-                    )
-
-                entity_details = AffiliationInvitationData.EntityDetails(
-                    business_identifier=business_identifier,
-                    name=entity_name_to_display,
-                    state=business_entity.get("state"),
-                    corp_type=entity_legal_type,
+            entity = (
+                AffiliationInvitationData.EntityDetails(
+                    business_identifier=business_entity["identifier"],
+                    name=business_entity["legalName"],
+                    state=business_entity["state"],
+                    corp_type=business_entity["legalType"],
                     corp_sub_type=business_entity.get("legalSubType", None),
                 )
+                if business_entity
+                else None
+            )
 
             aid = AffiliationInvitationData(
                 **{
                     **_init_dict_for_dataclass_from_dict(AffiliationInvitationData, affiliation_invitation_dict),
                     "from_org": from_org,
                     "to_org": to_org,
-                    "entity": entity_details,
+                    "entity": entity,
                 }
             )
             result.append(aid)
@@ -363,15 +352,16 @@ class AffiliationInvitation:
         return get_business_response.json()["businessEntities"]
 
     @staticmethod
-    def get_business_name_from_alternative_name(business_data, default_name, business_identifier):
-        """Get the business name from the alternative name list, if it exists."""
-        business_info_dict = business_data.get('business') if 'business' in business_data else business_data
-
-        if alternative_names := business_info_dict.get('alternateNames'):
+    def get_business_name_from_alternative_name(business, business_name, business_identifier):
+        """Firms use alternative names rather than legalName. Reassign business_name if we find an alternative name."""
+        alternative_names = business["business"].get("alternateNames")
+        if alternative_names is not None:
             for alt_name in alternative_names:
-                if alt_name.get('identifier') == business_identifier:
-                    return alt_name.get('name')
-        return default_name
+                if alt_name.get("identifier") == business_identifier and alt_name.get("name"):
+                    business_name = alt_name.get("name")
+                    break
+
+        return business_name
 
     def update_affiliation_invitation(self, user, invitation_origin, affiliation_invitation_info: Dict):
         """Update the specified affiliation invitation with new data."""

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -117,9 +117,7 @@ class AffiliationInvitation:
             )
             if to_org_dict := affiliation_invitation_dict.get("to_org"):
                 to_org = AffiliationInvitationData.OrgDetails(
-                    **_init_dict_for_dataclass_from_dict(
-                        AffiliationInvitationData.OrgDetails, to_org_dict
-                    )
+                    **_init_dict_for_dataclass_from_dict(AffiliationInvitationData.OrgDetails, to_org_dict)
                 )
             else:
                 to_org = None
@@ -141,9 +139,7 @@ class AffiliationInvitation:
 
                 if entity_legal_type in ["SP", "GP"]:
                     entity_name_to_display = AffiliationInvitation.get_business_name_from_alternative_name(
-                        business_entity,
-                        entity_name_to_display,
-                        business_identifier
+                        business_entity, entity_name_to_display, business_identifier
                     )
 
                 entity_details = AffiliationInvitationData.EntityDetails(
@@ -365,12 +361,12 @@ class AffiliationInvitation:
     @staticmethod
     def get_business_name_from_alternative_name(business_data, default_name, business_identifier):
         """Get the business name from the alternative name list, if it exists."""
-        business_info_dict = business_data.get('business') if 'business' in business_data else business_data
+        business_info_dict = business_data.get("business") if "business" in business_data else business_data
 
-        if alternative_names := business_info_dict.get('alternateNames'):
+        if alternative_names := business_info_dict.get("alternateNames"):
             for alt_name in alternative_names:
-                if alt_name.get('identifier') == business_identifier:
-                    return alt_name.get('name')
+                if alt_name.get("identifier") == business_identifier:
+                    return alt_name.get("name")
         return default_name
 
     def update_affiliation_invitation(self, user, invitation_origin, affiliation_invitation_info: Dict):

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -88,14 +88,12 @@ def setup_org_and_entity(user):
                     "identifier": "FM0000123",
                     "legalName": "John Smith",
                     "legalType": "SP",
-                    "alternateNames": [
-                        {"identifier": "FM0000123", "name": "Smith's Construction"}
-                    ]
+                    "alternateNames": [{"identifier": "FM0000123", "name": "Smith's Construction"}],
                 }
             },
             "John Smith",
             "FM0000123",
-            "Smith's Construction"
+            "Smith's Construction",
         ),
         # Test case 2: Direct business object structure with matching alternate name
         (
@@ -103,13 +101,11 @@ def setup_org_and_entity(user):
                 "identifier": "FM0000123",
                 "legalName": "John Smith",
                 "legalType": "SP",
-                "alternateNames": [
-                    {"identifier": "FM0000123", "name": "Smith's Construction"}
-                ]
+                "alternateNames": [{"identifier": "FM0000123", "name": "Smith's Construction"}],
             },
             "John Smith",
             "FM0000123",
-            "Smith's Construction"
+            "Smith's Construction",
         ),
         # Test case 3: No matching alternate name (different identifier)
         (
@@ -118,14 +114,12 @@ def setup_org_and_entity(user):
                     "identifier": "FM0000123",
                     "legalName": "John Smith",
                     "legalType": "SP",
-                    "alternateNames": [
-                        {"identifier": "FM0000999", "name": "Other Business"}
-                    ]
+                    "alternateNames": [{"identifier": "FM0000999", "name": "Other Business"}],
                 }
             },
             "John Smith",
             "FM0000123",
-            "John Smith"  # Should return default name
+            "John Smith",  # Should return default name
         ),
         # Test case 4: No alternate names at all
         (
@@ -134,25 +128,19 @@ def setup_org_and_entity(user):
                     "identifier": "FM0000123",
                     "legalName": "John Smith",
                     "legalType": "SP",
-                    "alternateNames": []
+                    "alternateNames": [],
                 }
             },
             "John Smith",
             "FM0000123",
-            "John Smith"  # Should return default name
+            "John Smith",  # Should return default name
         ),
         # Test case 5: alternateNames field missing
         (
-            {
-                "business": {
-                    "identifier": "FM0000123",
-                    "legalName": "John Smith",
-                    "legalType": "SP"
-                }
-            },
+            {"business": {"identifier": "FM0000123", "legalName": "John Smith", "legalType": "SP"}},
             "John Smith",
             "FM0000123",
-            "John Smith"  # Should return default name
+            "John Smith",  # Should return default name
         ),
         # Test case 6: Multiple alternate names, only first matching one is used
         (
@@ -163,15 +151,15 @@ def setup_org_and_entity(user):
                     "legalType": "SP",
                     "alternateNames": [
                         {"identifier": "FM0000123", "name": "Smith's Construction"},
-                        {"identifier": "FM0000123", "name": "John's Business"}
-                    ]
+                        {"identifier": "FM0000123", "name": "John's Business"},
+                    ],
                 }
             },
             "John Smith",
             "FM0000123",
-            "Smith's Construction"  # Should return first matching alternate name
+            "Smith's Construction",  # Should return first matching alternate name
         ),
-    ]
+    ],
 )
 def test_get_business_name_from_alternative_name(business_data, default_name, business_identifier, expected_name):
     """Test get_business_name_from_alternative_name method with various scenarios."""
@@ -193,12 +181,10 @@ def test_get_business_name_from_alternative_name(business_data, default_name, bu
                     "legalName": "John Smith",
                     "legalType": "SP",
                     "state": "ACTIVE",
-                    "alternateNames": [
-                        {"identifier": "FM0000123", "name": "Smith's Construction"}
-                    ]
+                    "alternateNames": [{"identifier": "FM0000123", "name": "Smith's Construction"}],
                 }
             ],
-            ["Smith's Construction"]  # Should use alternate name
+            ["Smith's Construction"],  # Should use alternate name
         ),
         # Test case 2: GP firm with alternate name
         (
@@ -208,24 +194,15 @@ def test_get_business_name_from_alternative_name(business_data, default_name, bu
                     "legalName": "Smith & Jones",
                     "legalType": "GP",
                     "state": "ACTIVE",
-                    "alternateNames": [
-                        {"identifier": "FM0000124", "name": "Smith Jones Construction Partnership"}
-                    ]
+                    "alternateNames": [{"identifier": "FM0000124", "name": "Smith Jones Construction Partnership"}],
                 }
             ],
-            ["Smith Jones Construction Partnership"]  # Should use alternate name
+            ["Smith Jones Construction Partnership"],  # Should use alternate name
         ),
         # Test case 3: SP firm without alternate name
         (
-            [
-                {
-                    "identifier": "FM0000125",
-                    "legalName": "Jane Doe",
-                    "legalType": "SP",
-                    "state": "ACTIVE"
-                }
-            ],
-            ["Jane Doe"]  # Should use legal name
+            [{"identifier": "FM0000125", "legalName": "Jane Doe", "legalType": "SP", "state": "ACTIVE"}],
+            ["Jane Doe"],  # Should use legal name
         ),
         # Test case 4: Non-SP/GP firm (should always use legal name)
         (
@@ -235,12 +212,10 @@ def test_get_business_name_from_alternative_name(business_data, default_name, bu
                     "legalName": "ABC Corp",
                     "legalType": "BC",
                     "state": "ACTIVE",
-                    "alternateNames": [
-                        {"identifier": "BC0000126", "name": "ABC Corporation"}
-                    ]
+                    "alternateNames": [{"identifier": "BC0000126", "name": "ABC Corporation"}],
                 }
             ],
-            ["ABC Corp"]  # Should use legal name even with alternate name
+            ["ABC Corp"],  # Should use legal name even with alternate name
         ),
         # Test case 5: Mixed firms
         (
@@ -250,50 +225,45 @@ def test_get_business_name_from_alternative_name(business_data, default_name, bu
                     "legalName": "Alice Smith",
                     "legalType": "SP",
                     "state": "ACTIVE",
-                    "alternateNames": [
-                        {"identifier": "FM0000127", "name": "Alice's Bakery"}
-                    ]
+                    "alternateNames": [{"identifier": "FM0000127", "name": "Alice's Bakery"}],
                 },
                 {
                     "identifier": "BC0000128",
                     "legalName": "XYZ Inc",
                     "legalType": "BC",
                     "state": "ACTIVE",
-                    "alternateNames": [
-                        {"identifier": "BC0000128", "name": "XYZ Corporation"}
-                    ]
-                }
+                    "alternateNames": [{"identifier": "BC0000128", "name": "XYZ Corporation"}],
+                },
             ],
-            ["Alice's Bakery", "XYZ Inc"]  # SP uses alternate, BC uses legal
+            ["Alice's Bakery", "XYZ Inc"],  # SP uses alternate, BC uses legal
         ),
-    ]
+    ],
 )
 def test_enrich_affiliation_invitations_with_business_name_logic(monkeypatch, business_entities, expected_names):
     """Test that enrich_affiliation_invitations_dict_list_with_business_data uses correct names for SP/GP firms."""
+
     # Mock the _get_multiple_business_details method to return our test data
     def mock_get_multiple_business_details(business_identifiers, token):
         return business_entities
 
     monkeypatch.setattr(
         "auth_api.services.affiliation_invitation.AffiliationInvitation._get_multiple_business_details",
-        mock_get_multiple_business_details
+        mock_get_multiple_business_details,
     )
 
     # Create test affiliation invitation dictionaries
     affiliation_invitation_dicts = []
     for i, business_entity in enumerate(business_entities):
-        affiliation_invitation_dicts.append({
-            "id": i + 1,
-            "business_identifier": business_entity["identifier"],
-            "from_org": {
-                "id": 100,
-                "name": "Test Org",
-                "org_type": "PREMIUM"
-            },
-            "to_org": None,
-            "status": "PENDING",
-            "type": "EMAIL"
-        })
+        affiliation_invitation_dicts.append(
+            {
+                "id": i + 1,
+                "business_identifier": business_entity["identifier"],
+                "from_org": {"id": 100, "name": "Test Org", "org_type": "PREMIUM"},
+                "to_org": None,
+                "status": "PENDING",
+                "type": "EMAIL",
+            }
+        )
 
     # Call the method under test
     result = AffiliationInvitationService.enrich_affiliation_invitations_dict_list_with_business_data(
@@ -318,27 +288,26 @@ def test_enrich_affiliation_invitations_empty_list():
 @mock.patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token", mock_token)
 def test_enrich_affiliation_invitations_missing_business_entity(monkeypatch):
     """Test handling when business entity is not found in the response."""
+
     # Mock to return empty list (no matching business entities)
     def mock_get_multiple_business_details(business_identifiers, token):
         return []
 
     monkeypatch.setattr(
         "auth_api.services.affiliation_invitation.AffiliationInvitation._get_multiple_business_details",
-        mock_get_multiple_business_details
+        mock_get_multiple_business_details,
     )
 
-    affiliation_invitation_dicts = [{
-        "id": 1,
-        "business_identifier": "FM0000999",
-        "from_org": {
-            "id": 100,
-            "name": "Test Org",
-            "org_type": "PREMIUM"
-        },
-        "to_org": None,
-        "status": "PENDING",
-        "type": "EMAIL"
-    }]
+    affiliation_invitation_dicts = [
+        {
+            "id": 1,
+            "business_identifier": "FM0000999",
+            "from_org": {"id": 100, "name": "Test Org", "org_type": "PREMIUM"},
+            "to_org": None,
+            "status": "PENDING",
+            "type": "EMAIL",
+        }
+    ]
 
     result = AffiliationInvitationService.enrich_affiliation_invitations_dict_list_with_business_data(
         affiliation_invitation_dicts


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/28438

### Description of Changes

Modified the `enrich_affiliation_invitations_dict_list_with_business_data` method in `auth-api/src/auth_api/services/affiliation_invitation.py`.

When processing business details for an affiliation invitation, if the entity's `legalType` is "SP" or "GP", the code now calls `get_business_name_from_alternative_name`. This ensures that an `alternateName` (operating name), if available, is prioritized over the `legalName` for display.

**Updated the `get_business_name_from_alternative_name` method:**
- It now correctly handles different structures of the input `business_data`
- It can accept either the full business details object from the Legal API (which has a nested `business` key) or just the nested business information directly
- This makes it reusable in contexts where the data structure might vary (e.g., during invitation creation vs. enrichment of existing invitation data)
- The core logic of checking `alternateNames` using the `business_identifier` remains the same



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
