### PR TITLE
28585 - SBC Staff mapping update - test for org type security group

### DIFF
--- a/auth-api/src/auth_api/models/org.py
+++ b/auth-api/src/auth_api/models/org.py
@@ -15,7 +15,7 @@
 
 Basic users will have an internal Org that is not created explicitly, but implicitly upon User account creation.
 """
-from typing import List
+from typing import List, Self
 
 from sql_versioning import Versioned
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, and_, cast, desc, event, func, text
@@ -120,7 +120,7 @@ class Org(Versioned, BaseModel):  # pylint: disable=too-few-public-methods,too-m
         return cls.query.filter_by(uuid=org_uuid).first()
 
     @classmethod
-    def find_by_org_id(cls, org_id: int):
+    def find_by_org_id(cls, org_id: int) -> Self:
         """Find an Org instance that matches the provided id."""
         return cls.query.filter_by(id=int(org_id or -1)).first()
 

--- a/auth-api/src/auth_api/services/membership.py
+++ b/auth-api/src/auth_api/services/membership.py
@@ -34,7 +34,7 @@ from auth_api.models import MembershipType as MembershipTypeModel
 from auth_api.models import Org as OrgModel
 from auth_api.models.dataclass import Activity
 from auth_api.schemas import MembershipSchema
-from auth_api.utils.constants import GROUP_CONTACT_CENTRE_STAFF, GROUP_MAXIMUS_STAFF
+from auth_api.utils.constants import GROUP_CONTACT_CENTRE_STAFF, GROUP_MAXIMUS_STAFF, GROUP_SBC_STAFF
 from auth_api.utils.enums import ActivityAction, LoginSource, NotificationType, OrgStatus, OrgType, Status
 from auth_api.utils.roles import ADMIN, ALLOWED_READ_ROLES, COORDINATOR, STAFF
 from auth_api.utils.user_context import UserContext, user_context
@@ -54,6 +54,7 @@ logger = StructuredLogging.get_logger()
 org_type_to_group_mapping = {
     OrgType.MAXIMUS_STAFF.value: GROUP_MAXIMUS_STAFF,
     OrgType.CC_STAFF.value: GROUP_CONTACT_CENTRE_STAFF,
+    OrgType.SBC_STAFF.value: GROUP_SBC_STAFF,
 }
 
 

--- a/auth-api/src/auth_api/utils/constants.py
+++ b/auth-api/src/auth_api/utils/constants.py
@@ -22,6 +22,7 @@ GROUP_API_GW_USERS = "api_gateway_users"
 GROUP_API_GW_SANDBOX_USERS = "api_gateway_sandbox_users"
 GROUP_MAXIMUS_STAFF = "maximus_staff"
 GROUP_CONTACT_CENTRE_STAFF = "contact_centre_staff"
+GROUP_SBC_STAFF = "sbc_staff"
 
 # Affidavit folder
 AFFIDAVIT_FOLDER_NAME = "Affidavits"

--- a/auth-api/tests/conftest.py
+++ b/auth-api/tests/conftest.py
@@ -25,6 +25,8 @@ from sqlalchemy_utils import create_database, database_exists, drop_database
 from auth_api import create_app, setup_jwt_manager
 from auth_api.exceptions import BusinessException, Error
 from auth_api.models import db as _db
+from auth_api.models import Org
+from auth_api.models.org import receive_before_update
 from auth_api.utils.auth import jwt as _jwt
 
 
@@ -338,3 +340,10 @@ def mock_pub_sub_call(mocker):
             raise CancelledError("This is a mock")
 
     mocker.patch("google.cloud.pubsub_v1.PublisherClient", PublisherMock)
+
+@pytest.fixture
+def disable_org_update_listener():
+    """Temporarily remove before update listener on Org then re-add after test."""
+    event.remove(Org, "before_update", receive_before_update)
+    yield
+    event.listen(Org, "before_update", receive_before_update)

--- a/auth-api/tests/docker/setup/demo-realm.json
+++ b/auth-api/tests/docker/setup/demo-realm.json
@@ -438,6 +438,30 @@
       ],
       "clientRoles": {},
       "subGroups": []
+    },
+    {
+      "name": "maximus_staff",
+      "path": "/maximus_staff",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "name": "contact_centre_staff",
+      "path": "/contact_centre_staff",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "name": "sbc_staff",
+      "path": "/sbc_staff",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
     }
   ],
   "defaultRoles": [

--- a/auth-api/tests/unit/api/test_orgs_by_type.py
+++ b/auth-api/tests/unit/api/test_orgs_by_type.py
@@ -1,0 +1,150 @@
+# Copyright © 2025 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests to verify the org creation process and security group grants by org type.
+
+Test-Suite to ensure that the proper security groups are granted based on org type.
+"""
+import json
+from http import HTTPStatus
+
+import pytest
+from faker import Faker
+
+from auth_api.services.keycloak import KeycloakService
+from auth_api.utils.constants import GROUP_MAXIMUS_STAFF, GROUP_CONTACT_CENTRE_STAFF, GROUP_SBC_STAFF
+from auth_api.utils.enums import (
+    OrgType, LoginSource,
+)
+from auth_api.models import Org as OrgModel
+from auth_api.models import OrgType as OrgTypeModel
+from auth_api.utils.roles import ADMIN, USER
+from tests.utilities.factory_scenarios import (
+    TestJwtClaims,
+    TestOrgInfo, KeycloakScenario, CONFIG,
+)
+from tests.utilities.factory_utils import (
+    factory_auth_header,
+    factory_invitation,
+)
+
+fake = Faker()
+
+
+def generate_claims_gov_user_payload():
+    """Generate unique claims payload with different names."""
+    return  {
+        "iss": CONFIG.JWT_OIDC_TEST_ISSUER,
+        "firstname": fake.first_name(),
+        "lastname": fake.last_name(),
+        "preferred_username": fake.user_name(),
+        "realm_access": {"roles": ["public_user", "account_holder", "gov_account_user"]},
+        "loginSource": LoginSource.IDIR.value,
+    }
+
+def generate_gov_user_headers(jwt):
+    """Create KC User and generate JWT for headers."""
+    claims = generate_claims_gov_user_payload()
+    request = KeycloakScenario.create_user_by_user_info(claims)
+    KeycloakService.add_user(request, return_if_exists=True)
+    kc_user = KeycloakService.get_user_by_username(request.user_name)
+    claims['id'] = kc_user.id
+    claims['sub'] = kc_user.id
+    return kc_user, factory_auth_header(jwt=jwt, claims=claims)
+
+def assert_invite(client, org_id, headers_inviter, headers_invitee, kc_invitee, security_group):
+    """Assert invitation send and accept flow."""
+    rv = client.post(
+        "/api/v1/invitations",
+        data=json.dumps(factory_invitation(org_id, "test@email.com", membership_type=ADMIN)),
+        headers=headers_inviter,
+        content_type="application/json",
+    )
+    invitation_dict = json.loads(rv.data)
+    invitation_token = invitation_dict['token']
+
+    rv = client.put(
+        "/api/v1/invitations/tokens/{}".format(invitation_token),
+        headers=headers_invitee,
+        content_type="application/json",
+    )
+
+    assert rv.status_code == HTTPStatus.OK
+    dictionary = json.loads(rv.data)
+    assert dictionary["status"] == "ACCEPTED"
+
+    kc_user_groups = KeycloakService.get_user_groups(kc_invitee.id)
+    assert kc_user_groups
+    assert any(group["name"] == security_group for group in kc_user_groups)
+
+@pytest.mark.parametrize(
+    "security_group, org_type",
+    [
+        (GROUP_MAXIMUS_STAFF, OrgType.MAXIMUS_STAFF.value),
+        (GROUP_CONTACT_CENTRE_STAFF, OrgType.CC_STAFF.value),
+        (GROUP_SBC_STAFF, OrgType.SBC_STAFF.value)
+    ],
+)
+def test_keycloak_groups_by_org_type(security_group, org_type, client, jwt, session, disable_org_update_listener):
+    """Assert that proper security groups granted by org type."""
+    headers_staff_admin = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    kc_gov_admin, headers_gov_account_admin = generate_gov_user_headers(jwt)
+    kc_gov_user, headers_gov_account_user = generate_gov_user_headers(jwt)
+
+    client.post("/api/v1/users", headers=headers_gov_account_admin, content_type="application/json")
+    client.post("/api/v1/users", headers=headers_gov_account_user, content_type="application/json")
+    client.post("/api/v1/users", headers=headers_staff_admin, content_type="application/json")
+
+    rv = client.post(
+        "/api/v1/orgs", data=json.dumps(TestOrgInfo.org_govm), headers=headers_staff_admin, content_type="application/json"
+    )
+    dictionary = json.loads(rv.data)
+    assert dictionary.get("branchName") == TestOrgInfo.org_govm.get("branchName")
+    org_id = dictionary["id"]
+    org_type_model = OrgTypeModel.get_type_for_code(org_type)
+    org = OrgModel.find_by_org_id(org_id)
+    org.org_type = org_type_model # Requires the disable_org_update_listener fixture to bypass type_code change check
+    org.save()
+
+    # Confirm account create admin invitation flow and added security group - staff user inviting
+    assert_invite(client, org_id, headers_staff_admin, headers_gov_account_admin, kc_gov_admin, security_group)
+
+    # Confirm admin inviting member flow and added security group - admin user inviting
+    assert_invite(client, org_id, headers_gov_account_admin, headers_gov_account_user, kc_gov_user, security_group)
+
+    rv = client.get("/api/v1/orgs/{}/members?status=ACTIVE".format(org_id), headers=headers_staff_admin)
+    assert rv.status_code == HTTPStatus.OK
+    dictionary = json.loads(rv.data)
+    members = dictionary["members"]
+    assert dictionary["members"]
+    assert len(members) == 2
+
+    # Confirm deactivating membership also removed security group
+    rv = client.patch(
+        "/api/v1/orgs/{}/members/{}".format(org_id, members[1]['id']),
+        headers=headers_gov_account_admin,
+        data=json.dumps({"status": "INACTIVE"}),
+        content_type="application/json",
+    )
+
+    rv = client.get("/api/v1/orgs/{}/members?status=ACTIVE".format(org_id), headers=headers_staff_admin)
+    assert rv.status_code == HTTPStatus.OK
+    dictionary = json.loads(rv.data)
+    members = dictionary["members"]
+    assert dictionary["members"]
+    assert len(members) == 1
+
+    gov_user_groups = KeycloakService.get_user_groups(kc_gov_user.id)
+    assert gov_user_groups
+    assert not any(group["name"] == security_group for group in gov_user_groups)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/28585

*Description of changes:*
- add mapping for org type security group grant for membership
- add test without keycloak mock to validate security group granting code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
