### PR TITLE
Revert "30049 - updated expiry in email template"

### DIFF
--- a/auth-api/pyproject.toml
+++ b/auth-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auth-api"
-version = "3.0.7"
+version = "3.0.6"
 description = ""
 authors = ["\"BC Registries and Online Services\""]
 readme = "README.md"

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -533,21 +533,12 @@ class AffiliationInvitation:
         to_org_name = affiliation_invitation.to_org.name if affiliation_invitation.to_org else None
         business_identifier = affiliation_invitation.entity.business_identifier
 
-        token_expiry_period = int(current_app.config.get("AFFILIATION_TOKEN_EXPIRY_PERIOD_MINS"))
-        expiry_text = (
-            # token_expiry_period should be < 60 or a multiple of 60
-            f"{token_expiry_period} minutes"
-            if (token_expiry_period < 60)
-            else f"{token_expiry_period // 60} hours"
-        )
-
         data = {
             "accountId": from_org_id,
             "businessName": business_name,
             "emailAddresses": email_addresses,
             "orgName": from_org_name,
             "businessIdentifier": business_identifier,
-            "expiryText": expiry_text,
         }
         notification_type = QueueMessageTypes.AFFILIATION_INVITATION.value
 

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -772,7 +772,6 @@ def test_send_affiliation_invitation_magic_link(
         "businessIdentifier": affiliation_invitation.entity.business_identifier,
         "contextUrl": "https://localhost.com//affiliationInvitation/acceptToken"
         "?token=ABCD&orgName=RnJvbSB0aGUgbW9vbiBpbmMu",
-        "expiryText": "12 hours",
     }
 
     publish_to_mailer_mock.assert_called_with(
@@ -807,7 +806,6 @@ def test_send_affiliation_invitation_request_sent(
         "toOrgName": affiliation_invitation.to_org.name,
         "toOrgBranchName": affiliation_invitation.to_org.branch_name,
         "additionalMessage": additional_message,
-        "expiryText": "12 hours",
     }
     notification_type = QueueMessageTypes.AFFILIATION_INVITATION_REQUEST.value
     publish_to_mailer_mock.assert_called_with(notification_type=notification_type, data=expected_data)
@@ -855,7 +853,6 @@ def test_send_affiliation_invitation_request_authorized(
         "toOrgName": affiliation_invitation.to_org.name,
         "toOrgBranchName": affiliation_invitation.to_org.branch_name,
         "isAuthorized": True,
-        "expiryText": "12 hours",
     }
 
     notification_type = QueueMessageTypes.AFFILIATION_INVITATION_REQUEST_AUTHORIZATION.value
@@ -906,7 +903,6 @@ def test_send_affiliation_invitation_request_refused(
         "toOrgName": affiliation_invitation.to_org.name,
         "toOrgBranchName": affiliation_invitation.to_org.branch_name,
         "isAuthorized": False,
-        "expiryText": "12 hours",
     }
 
     notification_type = QueueMessageTypes.AFFILIATION_INVITATION_REQUEST_AUTHORIZATION.value

--- a/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_email.html
@@ -7,7 +7,7 @@ To confirm that {{ account_name_with_branch }} can manage {{ business_name }} ({
 
 2. [Add {{ business_name }} ({{ business_identifier }})]({{ context_url }}) to your list of businesses.
 
-For security reasons, this link will expire in {{ expiry_text }}. If the link expires, you will need to request a new one on your [My Business Registry](https://business-registry-dashboard.bcregistry.gov.bc.ca).
+For security reasons, this link will expire in 15 minutes. If the link expires, you will need to request a new one on your [My Business Registry](https://business-registry-dashboard.bcregistry.gov.bc.ca).
 
 If you did not initiate this request, please disregard this email.
 

--- a/queue_services/account-mailer/src/account_mailer/resources/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/resources/worker.py
@@ -355,10 +355,10 @@ def handle_affiliation_invitation(message_type, email_msg):
     requesting_account = email_msg.get("fromOrgName")
     if from_branch_name := email_msg.get("fromOrgBranchName"):
         requesting_account += " - " + from_branch_name
+
     account = email_msg.get("toOrgName")
     if to_branch_name := email_msg.get("toOrgBranchName"):
         account += " - " + to_branch_name
-    expiry_text = email_msg.get("expiryText")
 
     email_dict = common_mailer.process(
         **{
@@ -373,7 +373,6 @@ def handle_affiliation_invitation(message_type, email_msg):
             "account": account,
             "is_authorized": email_msg.get("isAuthorized", None),
             "additional_message": email_msg.get("additionalMessage", None),
-            "expiry_text": expiry_text,
         }
     )
     process_email(email_dict)


### PR DESCRIPTION
Reverts bcgov/sbc-auth#3486.

Unfortunately, the expiry text isn't being displayed in the email. I figure it's better to revert the change so that the codebase is functional in case we need to quickly deploy a hotfix today, and I'll work on this change separately.

<img width="489" height="603" alt="image" src="https://github.com/user-attachments/assets/32cadefe-4801-49e8-9200-07fa0f94f8a2" />
