### PR TITLE
30406 Update affiliation_invitation.py to allow users to initialize affiliation invitations

### DIFF
--- a/auth-api/pyproject.toml
+++ b/auth-api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auth-api"
-version = "3.0.8"
+version = "3.0.9"
 description = ""
 authors = ["\"BC Registries and Online Services\""]
 readme = "README.md"

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -767,9 +767,7 @@ class AffiliationInvitation:
         invitation_type = invitation_type or AffiliationInvitationType.from_value(invitation.type)
         from_org_id = from_org_id or invitation.from_org_id
         match invitation_type:
-            case AffiliationInvitationType.REQUEST:
-                check_auth(org_id=from_org_id, one_of_roles=(ADMIN, COORDINATOR, STAFF))
-            case AffiliationInvitationType.EMAIL:
+            case AffiliationInvitationType.REQUEST | AffiliationInvitationType.EMAIL:
                 check_auth(org_id=from_org_id, one_of_roles=(ADMIN, COORDINATOR, USER, STAFF))
             case _:
                 raise BusinessException(Error.INVALID_AFFILIATION_INVITATION_TYPE, None)


### PR DESCRIPTION
*Issue #:* bcgov/entity#30406

*Description of changes:*
- updated API version
- enable USER to request affiliation invitation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).