### PR TITLE
27014 - emails fix for inherited roles from group

### DIFF
--- a/auth-api/src/auth_api/services/keycloak.py
+++ b/auth-api/src/auth_api/services/keycloak.py
@@ -37,14 +37,15 @@ from auth_api.utils.user_context import UserContext, user_context
 
 from .keycloak_user import KeycloakUser
 
+
 @dataclass
 class KCRequestConfig:
     """Used for keycloak request configuration."""
-    
+
     base_url: str
     realm: str
     timeout: int
-    
+
 class KeycloakService:
     """For Keycloak services."""
 
@@ -306,24 +307,24 @@ class KeycloakService:
                     current_app.logger.error(f"Exception: {task}")
                 elif task.status != 204:
                     current_app.logger.error(f"Returned non 204: {task.method} - {task.url} - {task.status}")
-    
+
     @staticmethod
     def kc_user_to_dict(user: dict) -> dict:
         """Return a dict representation of the KC user."""
         return {"firstName": user["firstName"], "lastName": user["lastName"], "email": user["email"]}
-    
-    
+
+
     @staticmethod
     def get_default_kc_request_config():
         """Return default request configuration for Keycloak API calls."""
         config = current_app.config
-        
+
         return KCRequestConfig(
             base_url=config.get("KEYCLOAK_BASE_URL"),
             realm=config.get("KEYCLOAK_REALMNAME"),
             timeout=config.get("CONNECT_TIMEOUT", 60)
         )
-    
+
     @staticmethod
     def get_keycloak_groups_for_role(role: str):
         """Get keycloak group representations for role name."""
@@ -365,22 +366,22 @@ class KeycloakService:
             raise BusinessException(Error.DATA_NOT_FOUND, None)
         response.raise_for_status()
         return response.json()
-        
+
     @staticmethod
     def get_user_emails_with_role(role: str):
-        """Get user emails with the role name."""        
+        """Get user emails with the role name."""
         # This does not retrieve users that inherit the role through a group, keycloak currently does
         # not support any query parameters or ways to retrieve this in a single call, we need to
         # get all the groups that contain the desired role and fetch the members.
         kc_users = KeycloakService.get_keycloak_users_for_role(role) or []
-        users = [KeycloakService.kc_user_to_dict(kc_user) for kc_user in kc_users]        
+        users = [KeycloakService.kc_user_to_dict(kc_user) for kc_user in kc_users]
         kc_groups = KeycloakService.get_keycloak_groups_for_role(role)
         group_members = []
         for kc_group in kc_groups:
             group_members.extend(
                 [
-                    KeycloakService.kc_user_to_dict(member) for member in 
-                    KeycloakService.get_keycloak_members_for_group(kc_group["id"])    
+                    KeycloakService.kc_user_to_dict(member) for member in
+                    KeycloakService.get_keycloak_members_for_group(kc_group["id"])
                 ]
             )
         users.extend(group_members)

--- a/auth-api/tests/unit/services/test_keycloak.py
+++ b/auth-api/tests/unit/services/test_keycloak.py
@@ -295,7 +295,7 @@ def test_get_user_emails_with_role(
 ):
     """Test get_user_emails_with_role returns users from both direct role assignment and group membership."""
     mock_get_admin_token.return_value = "mock_token"
-    
+
     # Set up for direct role assignment to a user and test handling logic when users are returned
     kc_users = [
         {
@@ -311,7 +311,7 @@ def test_get_user_emails_with_role(
             "email": "jane.smith@example.com"
         }
     ]
-    
+
     # Groups and group members to test logic when inherited group roles exist
     kc_groups = [
         {"id": "group1", "name": "test_group_1"},


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/27014

*Description of changes:*
- fix route that returns emails by role where inherited roles from groups are not returned


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
