### PR TITLE
32405 - SAF email template update, create affiliation confirmation email

### DIFF
--- a/auth-api/devops/vaults.gcp.env
+++ b/auth-api/devops/vaults.gcp.env
@@ -70,5 +70,6 @@ VPC_CONNECTOR="op://CD/$APP_ENV/auth-api/VPC_CONNECTOR"
 ENVIRONMENT_NAME="op://CD/$APP_ENV/base/DEPLOYMENT_ENV"
 
 # web-url
-BUSINESS_REGISTRY_URL="op://web-url/$APP_ENV/business-registry-ui/BUSINESS_REGISTRY_URL"
-REGISTRY_HOME_URL="op://web-url/$APP_ENV/business/REGISTRY_HOME_URL"
+BUSINESS_REGISTRY_URL="op://web-url/$APP_ENV/business-registry-ui/BUSINESS_REGISTRY_URL" # business-registry-dashboard.gov.bc.ca
+REGISTRY_HOME_URL="op://web-url/$APP_ENV/business/REGISTRY_HOME_URL" # home.business.bcregistry.gov.bc.ca
+BC_REGISTRY_HOME_URL="op://web-url/$APP_ENV/registry/REGISTRY_HOME_URL" # bcregistry.gov.bc.ca

--- a/auth-api/src/auth_api/models/affiliation_invitation.py
+++ b/auth-api/src/auth_api/models/affiliation_invitation.py
@@ -70,20 +70,25 @@ class AffiliationInvitation(BaseModel):  # pylint: disable=too-many-instance-att
     def expires_on(self):
         """Calculate the expiry date based on the config value."""
         if self.invitation_status_code == InvitationStatuses.PENDING.value:
-            return self.sent_date + timedelta(minutes=self._get_expiry_minutes())
+            expiry_minutes = self._get_expiry_minutes()
+            expiry_datetime = self.sent_date + timedelta(minutes=expiry_minutes)
+
+            # set expiry to end of day if type is UNAFFILIATED_EMAIL
+            if self.type == AffiliationInvitationTypeEnum.UNAFFILIATED_EMAIL.value:
+                return expiry_datetime.replace(hour=23, minute=59, second=59)
+
+            return expiry_datetime
         return None
 
     @hybrid_property
     def status(self):
         """Calculate the status based on the config value."""
-        current_time = datetime.now()
         # if type is REQUEST do not expire (only cancel through todo)
         if self.type == AffiliationInvitationTypeEnum.REQUEST.value:
             return self.invitation_status_code
 
         if self.invitation_status_code == InvitationStatuses.PENDING.value:
-            expiry_time = self.sent_date + timedelta(minutes=self._get_expiry_minutes())
-            if current_time >= expiry_time:
+            if self.expires_on and datetime.now() >= self.expires_on:
                 return InvitationStatuses.EXPIRED.value
         return self.invitation_status_code
 

--- a/auth-api/src/auth_api/models/dataclass.py
+++ b/auth-api/src/auth_api/models/dataclass.py
@@ -219,6 +219,17 @@ class UnaffiliatedEmailInvitationData(Serializable):
     business_identifier: str
     token: str
     context_url: str
+    expiry_date: str
+
+@dataclass
+class ConfirmationEmailData(Serializable):
+    """Data for sending an affiliation confirmation email to the mailer queue."""
+
+    business_name: str
+    email_addresses: str
+    business_identifier: str
+    context_url: str
+    completion_date: str
 
 
 @dataclass

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -202,8 +202,8 @@ class Affiliation:
             email_address = contact_link.contact.email
 
         if email_address:
-            registry_home_url = current_app.config.get("REGISTRY_HOME_URL")
-            context_url = f"{registry_home_url}login"
+            bc_registry_home_url = current_app.config.get("BC_REGISTRY_HOME_URL")
+            context_url = f"{bc_registry_home_url}login"
 
             mailer_data = ConfirmationEmailData(
                 business_name=entity.name,

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -28,7 +28,7 @@ from auth_api.models import db
 from auth_api.models.affiliation import Affiliation as AffiliationModel
 from auth_api.models.affiliation_invitation import AffiliationInvitation as AffiliationInvitationModel
 from auth_api.models.contact_link import ContactLink
-from auth_api.models.dataclass import Activity, AffiliationBase, AffiliationSearchDetails, DeleteAffiliationRequest
+from auth_api.models.dataclass import Activity, AffiliationBase, AffiliationSearchDetails, DeleteAffiliationRequest, ConfirmationEmailData
 from auth_api.models.dataclass import Affiliation as AffiliationData
 from auth_api.models.entity import Entity
 from auth_api.models.membership import Membership as MembershipModel
@@ -41,6 +41,8 @@ from auth_api.utils.enums import ActivityAction, CorpType, NRActionCodes, NRName
 from auth_api.utils.passcode import validate_passcode
 from auth_api.utils.roles import AFFILIATION_ALLOWED_ROLES, ALL_ALLOWED_ROLES, CLIENT_AUTH_ROLES, STAFF, Role
 from auth_api.utils.user_context import UserContext, user_context
+from auth_api.utils.account_mailer import publish_to_mailer
+from auth_api.utils.enums import QueueMessageType
 
 from .activity_log_publisher import ActivityLogPublisher
 from .rest_service import RestService
@@ -192,6 +194,27 @@ class Affiliation:
             name = entity.name if len(entity.name) > 0 else entity.business_identifier
             ActivityLogPublisher.publish_activity(
                 Activity(org_id, ActivityAction.CREATE_AFFILIATION.value, name=name, id=entity.business_identifier)
+            )
+
+        email_address = None
+        contact_link = ContactLink.find_by_org_id(org_id)
+        if contact_link and contact_link.contact:
+            email_address = contact_link.contact.email
+
+        if email_address:
+            registry_home_url = current_app.config.get("REGISTRY_HOME_URL")
+            context_url = f"{registry_home_url}login"
+
+            mailer_data = ConfirmationEmailData(
+                business_name=entity.name,
+                email_addresses=email_address,
+                business_identifier=entity.business_identifier,
+                context_url=context_url,
+                completion_date=affiliation.created
+            )
+            publish_to_mailer(
+                notification_type=QueueMessageType.AFFILIATION_INVITATION_CONFIRMATION_EMAIL.value,
+                data=mailer_data.to_dict(),
             )
 
         return Affiliation(affiliation)

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -28,7 +28,13 @@ from auth_api.models import db
 from auth_api.models.affiliation import Affiliation as AffiliationModel
 from auth_api.models.affiliation_invitation import AffiliationInvitation as AffiliationInvitationModel
 from auth_api.models.contact_link import ContactLink
-from auth_api.models.dataclass import Activity, AffiliationBase, AffiliationSearchDetails, DeleteAffiliationRequest, ConfirmationEmailData
+from auth_api.models.dataclass import (
+    Activity,
+    AffiliationBase,
+    AffiliationSearchDetails,
+    ConfirmationEmailData,
+    DeleteAffiliationRequest,
+)
 from auth_api.models.dataclass import Affiliation as AffiliationData
 from auth_api.models.entity import Entity
 from auth_api.models.membership import Membership as MembershipModel
@@ -36,13 +42,12 @@ from auth_api.schemas import AffiliationSchema
 from auth_api.services.entity import Entity as EntityService
 from auth_api.services.org import Org as OrgService
 from auth_api.services.user import User as UserService
+from auth_api.utils.account_mailer import publish_to_mailer
 from auth_api.utils.auth_event_publisher import publish_affiliation_event
-from auth_api.utils.enums import ActivityAction, CorpType, NRActionCodes, NRNameStatus, NRStatus
+from auth_api.utils.enums import ActivityAction, CorpType, NRActionCodes, NRNameStatus, NRStatus, QueueMessageType
 from auth_api.utils.passcode import validate_passcode
 from auth_api.utils.roles import AFFILIATION_ALLOWED_ROLES, ALL_ALLOWED_ROLES, CLIENT_AUTH_ROLES, STAFF, Role
 from auth_api.utils.user_context import UserContext, user_context
-from auth_api.utils.account_mailer import publish_to_mailer
-from auth_api.utils.enums import QueueMessageType
 
 from .activity_log_publisher import ActivityLogPublisher
 from .rest_service import RestService

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -218,7 +218,7 @@ class Affiliation:
                 completion_date=affiliation.created
             )
             publish_to_mailer(
-                notification_type=QueueMessageType.AFFILIATION_INVITATION_CONFIRMATION_EMAIL.value,
+                notification_type=QueueMessageType.AFFILIATION_CONFIRMATION_EMAIL.value,
                 data=mailer_data.to_dict(),
             )
 

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -695,8 +695,12 @@ class AffiliationInvitation:
         if affiliation_invitation is None:
             raise BusinessException(Error.DATA_NOT_FOUND, None)
 
-        if affiliation_invitation.type == AffiliationInvitationType.UNAFFILIATED_EMAIL.value:
-            token_valid_for = int(CONFIG.UNAFFILIATED_EMAIL_TOKEN_EXPIRY_PERIOD_MINS) * 60
+        expiry_date = affiliation_invitation.expires_on
+        sent_date = affiliation_invitation.sent_date
+    
+        if expiry_date:
+            duration = expiry_date - sent_date
+            token_valid_for = int(duration.total_seconds())
         else:
             token_valid_for = (
                 int(CONFIG.AFFILIATION_TOKEN_EXPIRY_PERIOD_MINS) * 60
@@ -888,10 +892,7 @@ class AffiliationInvitation:
         registry_home_url = current_app.config.get("REGISTRY_HOME_URL")
         business_registry_url = current_app.config.get("BUSINESS_REGISTRY_URL")
         context_url = f"{registry_home_url}?preset=bcscUser&token={confirmation_token}&return={business_registry_url}affiliationInvitation/acceptToken"
-
-        token_valid_for = int(CONFIG.UNAFFILIATED_EMAIL_TOKEN_EXPIRY_PERIOD_MINS) * 60
-        expiry_datetime = affiliation_invitation.sent_date + timedelta(seconds=token_valid_for)
-        display_datetime = expiry_datetime - timedelta(days=1)
+        expiry_date = affiliation_invitation.expires_on
 
         mailer_data = UnaffiliatedEmailInvitationData(
             business_name=business_name,
@@ -899,7 +900,7 @@ class AffiliationInvitation:
             business_identifier=entity.business_identifier,
             token=confirmation_token,
             context_url=context_url,
-            expiry_date=display_datetime
+            expiry_date=expiry_date
         )
         publish_to_mailer(
             notification_type=QueueMessageType.AFFILIATION_INVITATION_UNAFFILIATED_EMAIL.value,

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -697,7 +697,7 @@ class AffiliationInvitation:
 
         expiry_date = affiliation_invitation.expires_on
         sent_date = affiliation_invitation.sent_date
-    
+
         if expiry_date:
             duration = expiry_date - sent_date
             token_valid_for = int(duration.total_seconds())

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -886,7 +886,8 @@ class AffiliationInvitation:
             )
 
         registry_home_url = current_app.config.get("REGISTRY_HOME_URL")
-        context_url = f"{registry_home_url}?preset=bcscUser&token={confirmation_token}"
+        business_registry_url = current_app.config.get("BUSINESS_REGISTRY_URL")
+        context_url = f"{registry_home_url}?preset=bcscUser&token={confirmation_token}&return={business_registry_url}affiliationInvitation/acceptToken"
 
         mailer_data = UnaffiliatedEmailInvitationData(
             business_name=business_name,

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -14,7 +14,7 @@
 """Service for managing Affiliation Invitation data."""
 
 from dataclasses import fields
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from urllib.parse import urlencode
 
 from flask import current_app
@@ -889,12 +889,17 @@ class AffiliationInvitation:
         business_registry_url = current_app.config.get("BUSINESS_REGISTRY_URL")
         context_url = f"{registry_home_url}?preset=bcscUser&token={confirmation_token}&return={business_registry_url}affiliationInvitation/acceptToken"
 
+        token_valid_for = int(CONFIG.UNAFFILIATED_EMAIL_TOKEN_EXPIRY_PERIOD_MINS) * 60
+        expiry_datetime = affiliation_invitation.sent_date + timedelta(seconds=token_valid_for)
+        display_datetime = expiry_datetime - timedelta(days=1)
+
         mailer_data = UnaffiliatedEmailInvitationData(
             business_name=business_name,
             email_addresses=contact.email,
             business_identifier=entity.business_identifier,
             token=confirmation_token,
             context_url=context_url,
+            expiry_date=display_datetime
         )
         publish_to_mailer(
             notification_type=QueueMessageType.AFFILIATION_INVITATION_UNAFFILIATED_EMAIL.value,

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -14,7 +14,7 @@
 """Service for managing Affiliation Invitation data."""
 
 from dataclasses import fields
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from urllib.parse import urlencode
 
 from flask import current_app

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -392,6 +392,8 @@ class QueueMessageType(Enum):
     """Local queue message types not yet in sbc_common_components."""
 
     AFFILIATION_INVITATION_UNAFFILIATED_EMAIL = "bc.registry.auth.affiliationInvitationUnaffiliatedEmail"
+    AFFILIATION_INVITATION_CONFIRMATION_EMAIL = "bc.registry.auth.affiliationInvitationConfirmationEmail"
+
 
 
 class QueueSources(Enum):

--- a/auth-api/src/auth_api/utils/enums.py
+++ b/auth-api/src/auth_api/utils/enums.py
@@ -392,7 +392,7 @@ class QueueMessageType(Enum):
     """Local queue message types not yet in sbc_common_components."""
 
     AFFILIATION_INVITATION_UNAFFILIATED_EMAIL = "bc.registry.auth.affiliationInvitationUnaffiliatedEmail"
-    AFFILIATION_INVITATION_CONFIRMATION_EMAIL = "bc.registry.auth.affiliationInvitationConfirmationEmail"
+    AFFILIATION_CONFIRMATION_EMAIL = "bc.registry.auth.affiliationConfirmationEmail"
 
 
 

--- a/auth-api/tests/unit/models/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/models/test_affiliation_invitation.py
@@ -18,6 +18,7 @@ Test suite to ensure that the  model routines are working as expected.
 
 from _datetime import datetime, timedelta
 from uuid import uuid4
+
 from freezegun import freeze_time
 
 from auth_api.config import get_named_config

--- a/auth-api/tests/unit/models/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/models/test_affiliation_invitation.py
@@ -18,6 +18,7 @@ Test suite to ensure that the  model routines are working as expected.
 
 from _datetime import datetime, timedelta
 from uuid import uuid4
+from freezegun import freeze_time
 
 from auth_api.config import get_named_config
 from auth_api.models import AffiliationInvitation as AffiliationInvitationModel
@@ -464,3 +465,50 @@ def test_find_all_sent_to_org_affiliated_with_entity(session):
         AffiliationInvitationSearch(to_org_id="1", entity_id="1")
     )
     assert len(affiliation_invitations) == affiliation_invitation_count - 1
+
+
+@freeze_time("2026-04-21 14:30:00")
+def test_expires_on_property_standard_invitation(session):
+    """Assert expires_on for standard invitations matches exact minutes."""
+    invitation = factory_affiliation_invitation_model(
+        session=session,
+        status=InvitationStatus.PENDING.value
+    )
+    invitation.sent_date = datetime.now()
+
+    expiry_mins = int(get_named_config().AFFILIATION_TOKEN_EXPIRY_PERIOD_MINS)
+    expected_expiry = datetime.now() + timedelta(minutes=expiry_mins)
+
+    assert invitation.expires_on == expected_expiry
+    assert invitation.expires_on.hour == expected_expiry.hour
+    assert invitation.expires_on.minute == expected_expiry.minute
+
+
+@freeze_time("2026-04-21 14:30:00")
+def test_expires_on_property_unaffiliated_type_invitation(session):
+    """Assert expires_on for UNAFFILIATED_EMAIL ends at 23:59:59 on the expiry date."""
+    invitation = factory_affiliation_invitation_model(
+        session=session,
+        status=InvitationStatus.PENDING.value,
+        invitation_type=AffiliationInvitationType.UNAFFILIATED_EMAIL.value
+    )
+    invitation.sent_date = datetime.now()
+
+    expiry_mins = int(get_named_config().UNAFFILIATED_EMAIL_TOKEN_EXPIRY_PERIOD_MINS)
+    expiry_date = datetime.now() + timedelta(minutes=expiry_mins)
+    expiry_date_eod = expiry_date.replace(hour=23, minute=59, second=59)
+
+    assert invitation.expires_on == expiry_date_eod
+    assert invitation.expires_on.hour == 23
+    assert invitation.expires_on.minute == 59
+    assert invitation.expires_on.second == 59
+
+
+def test_expires_on_property_returns_none_when_not_pending(session):
+    """Assert expires_on returns None if the invitation is already accepted/failed."""
+    invitation = factory_affiliation_invitation_model(
+        session=session,
+        status=InvitationStatus.ACCEPTED.value
+    )
+
+    assert invitation.expires_on is None

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -337,8 +337,6 @@ def test_create_affiliation_sends_confirmation_email(mock_publish, session, auth
         org_id, business_identifier, TestEntityInfo.entity_lear_mock["passCode"]
     )
 
-    print(affiliation.as_dict())
-
     assert affiliation
     mock_publish.assert_called_once()
 

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -18,12 +18,15 @@ Test suite to ensure that the Affiliation service routines are working as expect
 
 from unittest import mock
 from unittest.mock import ANY, patch
+from freezegun import freeze_time
+from datetime import datetime
 
 import pytest
 
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
 from auth_api.models.affiliation import Affiliation as AffiliationModel
+from auth_api.models import ContactLink as ContactLinkModel
 from auth_api.models.dataclass import Activity, DeleteAffiliationRequest
 from auth_api.models.dataclass import Affiliation as AffiliationData
 from auth_api.models.org import Org as OrgModel
@@ -314,6 +317,38 @@ def test_create_affiliation_firms_party_not_valid(session, auth_mock, monkeypatc
         AffiliationService.create_affiliation(org_id, business_identifier, "test user")
 
     assert exception.value.code == Error.INVALID_USER_CREDENTIALS.name
+
+@mock.patch('auth_api.services.affiliation.publish_to_mailer')
+@freeze_time("2026-04-17 11:12:13+00:00")
+def test_create_affiliation_sends_confirmation_email(mock_publish, session, auth_mock, monkeypatch):
+    """Assert that creating an affiliation sends a confirmation email."""
+    entity_service = factory_entity_service(entity_info=TestEntityInfo.entity_lear_mock)
+    business_identifier = entity_service.business_identifier
+
+    user = factory_user_model_with_contact()
+    contact = user.contacts[0].contact
+    org_service = factory_org_service()
+    org_id = org_service.as_dict()['id']
+
+    contact_link = ContactLinkModel(org_id=org_id, contact_id=contact.id)
+    contact_link.save()
+
+    affiliation = AffiliationService.create_affiliation(
+        org_id, business_identifier, TestEntityInfo.entity_lear_mock["passCode"]
+    )
+
+    print(affiliation.as_dict())
+
+    assert affiliation
+    mock_publish.assert_called_once()
+
+    call_args = mock_publish.call_args
+    data = call_args[1]['data']
+    assert call_args[1]['notification_type'] == 'bc.registry.auth.affiliationInvitationConfirmationEmail'
+    assert data['businessName'] == entity_service.name
+    assert data['emailAddresses'] == contact.email
+    assert data['businessIdentifier'] == business_identifier
+    assert data['completionDate'].replace(microsecond=0) == datetime.fromisoformat(affiliation.as_dict()['created']).replace(tzinfo=None)
 
 
 def test_find_affiliated_entities_by_org_id(session, auth_mock):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -16,17 +16,17 @@
 Test suite to ensure that the Affiliation service routines are working as expected.
 """
 
+from datetime import datetime
 from unittest import mock
 from unittest.mock import ANY, patch
-from freezegun import freeze_time
-from datetime import datetime
 
 import pytest
+from freezegun import freeze_time
 
 from auth_api.exceptions import BusinessException
 from auth_api.exceptions.errors import Error
-from auth_api.models.affiliation import Affiliation as AffiliationModel
 from auth_api.models import ContactLink as ContactLinkModel
+from auth_api.models.affiliation import Affiliation as AffiliationModel
 from auth_api.models.dataclass import Activity, DeleteAffiliationRequest
 from auth_api.models.dataclass import Affiliation as AffiliationData
 from auth_api.models.org import Org as OrgModel
@@ -318,7 +318,7 @@ def test_create_affiliation_firms_party_not_valid(session, auth_mock, monkeypatc
 
     assert exception.value.code == Error.INVALID_USER_CREDENTIALS.name
 
-@mock.patch('auth_api.services.affiliation.publish_to_mailer')
+@mock.patch("auth_api.services.affiliation.publish_to_mailer")
 @freeze_time("2026-04-17 11:12:13+00:00")
 def test_create_affiliation_sends_confirmation_email(mock_publish, session, auth_mock, monkeypatch):
     """Assert that creating an affiliation sends a confirmation email."""
@@ -328,7 +328,7 @@ def test_create_affiliation_sends_confirmation_email(mock_publish, session, auth
     user = factory_user_model_with_contact()
     contact = user.contacts[0].contact
     org_service = factory_org_service()
-    org_id = org_service.as_dict()['id']
+    org_id = org_service.as_dict()["id"]
 
     contact_link = ContactLinkModel(org_id=org_id, contact_id=contact.id)
     contact_link.save()
@@ -341,12 +341,12 @@ def test_create_affiliation_sends_confirmation_email(mock_publish, session, auth
     mock_publish.assert_called_once()
 
     call_args = mock_publish.call_args
-    data = call_args[1]['data']
-    assert call_args[1]['notification_type'] == 'bc.registry.auth.affiliationInvitationConfirmationEmail'
-    assert data['businessName'] == entity_service.name
-    assert data['emailAddresses'] == contact.email
-    assert data['businessIdentifier'] == business_identifier
-    assert data['completionDate'].replace(microsecond=0) == datetime.fromisoformat(affiliation.as_dict()['created']).replace(tzinfo=None)
+    data = call_args[1]["data"]
+    assert call_args[1]["notification_type"] == "bc.registry.auth.affiliationInvitationConfirmationEmail"
+    assert data["businessName"] == entity_service.name
+    assert data["emailAddresses"] == contact.email
+    assert data["businessIdentifier"] == business_identifier
+    assert data["completionDate"].replace(microsecond=0) == datetime.fromisoformat(affiliation.as_dict()["created"]).replace(tzinfo=None)
 
 
 def test_find_affiliated_entities_by_org_id(session, auth_mock):  # pylint:disable=unused-argument

--- a/auth-api/tests/unit/services/test_affiliation.py
+++ b/auth-api/tests/unit/services/test_affiliation.py
@@ -342,7 +342,7 @@ def test_create_affiliation_sends_confirmation_email(mock_publish, session, auth
 
     call_args = mock_publish.call_args
     data = call_args[1]["data"]
-    assert call_args[1]["notification_type"] == "bc.registry.auth.affiliationInvitationConfirmationEmail"
+    assert call_args[1]["notification_type"] == "bc.registry.auth.affiliationConfirmationEmail"
     assert data["businessName"] == entity_service.name
     assert data["emailAddresses"] == contact.email
     assert data["businessIdentifier"] == business_identifier

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -1110,7 +1110,7 @@ def test_send_unaffiliated_email_invitation_mailer_data(
     assert data["contextUrl"].startswith("https://localhost.com?preset=bcscUser&token=")
     # NOTE: 'https://localhost.com' is the brd url and will contain a slash at the end in dev/test/prod
     assert data["contextUrl"].endswith("&return=https://localhost.comaffiliationInvitation/acceptToken")
-    assert data["token"] == data["contextUrl"].split("token=")[1]
+    assert data["token"] == data["contextUrl"].split("token=")[1].split("&return=")[0]
 
 
 def test_validate_and_get_org_id():

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -1098,7 +1098,7 @@ def test_send_unaffiliated_email_invitation_mailer_data(
     """Verify UNAFFILIATED_EMAIL - data for email is correctly generated with context_url."""
     entity = create_test_entity()
 
-    invitation = AffiliationInvitationService.send_unaffiliated_email_invitation(entity)
+    AffiliationInvitationService.send_unaffiliated_email_invitation(entity)
 
     publish_to_mailer_mock.assert_called_once()
     call_kwargs = publish_to_mailer_mock.call_args
@@ -1112,13 +1112,8 @@ def test_send_unaffiliated_email_invitation_mailer_data(
     # NOTE: 'https://localhost.com' is the brd url and will contain a slash at the end in dev/test/prod
     assert data["contextUrl"].endswith("&return=https://localhost.comaffiliationInvitation/acceptToken")
     assert data["token"] == data["contextUrl"].split("token=")[1].split("&return=")[0]
-
     # sent date == 21/04/2026 12:00:00 with @freeze_time
-    token_valid_for = int(get_named_config().UNAFFILIATED_EMAIL_TOKEN_EXPIRY_PERIOD_MINS) * 60
-    expected_expiry = invitation.sent_date + timedelta(seconds=token_valid_for)
-    # should show the first full day before the sent date + the expiry period
-    expected_display = expected_expiry - timedelta(days=1)
-    assert data["expiryDate"] == expected_display
+    assert data["expiryDate"] == datetime(2026, 4, 28, 23, 59, 59) # April 28, 2026 11:59:59pm
 
 
 def test_validate_and_get_org_id():

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -1090,6 +1090,7 @@ def test_unaffiliated_email_invitation_auth(
             assert result.as_dict()["status"] == InvitationStatus.ACCEPTED.value
 
 
+@freeze_time("2026-04-21 12:00:00")
 @patch.object(auth_api.services.affiliation_invitation, "publish_to_mailer")
 def test_send_unaffiliated_email_invitation_mailer_data(
     publish_to_mailer_mock, session, auth_mock, keycloak_mock, business_mock, monkeypatch, mock_service_account_token
@@ -1097,7 +1098,7 @@ def test_send_unaffiliated_email_invitation_mailer_data(
     """Verify UNAFFILIATED_EMAIL - data for email is correctly generated with context_url."""
     entity = create_test_entity()
 
-    AffiliationInvitationService.send_unaffiliated_email_invitation(entity)
+    invitation = AffiliationInvitationService.send_unaffiliated_email_invitation(entity)
 
     publish_to_mailer_mock.assert_called_once()
     call_kwargs = publish_to_mailer_mock.call_args
@@ -1111,6 +1112,13 @@ def test_send_unaffiliated_email_invitation_mailer_data(
     # NOTE: 'https://localhost.com' is the brd url and will contain a slash at the end in dev/test/prod
     assert data["contextUrl"].endswith("&return=https://localhost.comaffiliationInvitation/acceptToken")
     assert data["token"] == data["contextUrl"].split("token=")[1].split("&return=")[0]
+
+    # sent date == 21/04/2026 12:00:00 with @freeze_time
+    token_valid_for = int(get_named_config().UNAFFILIATED_EMAIL_TOKEN_EXPIRY_PERIOD_MINS) * 60
+    expected_expiry = invitation.sent_date + timedelta(seconds=token_valid_for)
+    # should show the first full day before the sent date + the expiry period
+    expected_display = expected_expiry - timedelta(days=1)
+    assert data["expiryDate"] == expected_display
 
 
 def test_validate_and_get_org_id():

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -1109,7 +1109,7 @@ def test_send_unaffiliated_email_invitation_mailer_data(
     assert data["businessIdentifier"] == entity.as_dict()["business_identifier"]
     assert data["contextUrl"].startswith("https://localhost.com?preset=bcscUser&token=")
     # NOTE: 'https://localhost.com' is the brd url and will contain a slash at the end in dev/test/prod
-    assert data["contextUrl"].endswith("&return=https://localhost.comaffiliationInvitation/token")
+    assert data["contextUrl"].endswith("&return=https://localhost.comaffiliationInvitation/acceptToken")
     assert data["token"] == data["contextUrl"].split("token=")[1]
 
 

--- a/auth-api/tests/unit/services/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/services/test_affiliation_invitation.py
@@ -1108,6 +1108,8 @@ def test_send_unaffiliated_email_invitation_mailer_data(
     assert data["emailAddresses"] == "foo@bar.com"
     assert data["businessIdentifier"] == entity.as_dict()["business_identifier"]
     assert data["contextUrl"].startswith("https://localhost.com?preset=bcscUser&token=")
+    # NOTE: 'https://localhost.com' is the brd url and will contain a slash at the end in dev/test/prod
+    assert data["contextUrl"].endswith("&return=https://localhost.comaffiliationInvitation/token")
     assert data["token"] == data["contextUrl"].split("token=")[1]
 
 

--- a/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_confirmation_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_confirmation_email.html
@@ -1,0 +1,24 @@
+# Your business is fully set up and ready to be managed in the BC Business Registry using your BC Registries account.
+
+Business Name: **{{ business_name }}**
+Incorporation / Registration Number: **{{ business_identifier }}**
+Completion Date: **{{ completion_date }}**
+
+**What you can do now:**
+
+Using your BC Registries account, you can:
+- File Annual Reports
+- Update addresses and director information
+- View and manage business details in one place
+- Manage multiple businesses from a single dashboard
+- Use secure online services available through the BC Business Registry
+
+[Access my business: Log in to the BC Business Registry]({{ context_url }})
+
+Thank you for using the BC Business Registry. We’re pleased to offer a secure, modern, and streamlined service for managing your business online.
+
+***
+
+**BC Registry Services**
+
+Email: [bcrossupport@gov.bc.ca](mailto:bcrossupport@gov.bc.ca)

--- a/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_unaffiliated_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_unaffiliated_email.html
@@ -1,40 +1,34 @@
+# Managing your company and access to the BC Business Registry
 
-# Your business is being moved to the new BC Registries system
+Company Name: **{{ business_name }}**
+Incorporation Number: **{{ business_identifier }}**
 
-**Business Name:** {{ business_name }}
-**Incorporation Number:** {{ business_identifier }}
+Complete your account registration by: **{{ expiry_date }}**
 
-The Government of B.C. is moving your business management services from Corporate Online to BC Registries. You will no longer be able to make changes to your business in Corporate Online moving forward.
+BC Registry Services has moved your company from Corporate Online to the new BC Business Registry.
 
-**To continue managing your business online, you will need to add your business to a BC Registries account.**
+**What this change means for you:**
 
-[Add my business to a BC Registries Account now]({{ context_url }})
+- You can no longer make changes to your company in Corporate Online.
+- You must create a BC Services Card Account to prove your identity online.
+- Next, you must create a BC Registries account to access and manage your business.
 
-This link is valid for 7 days.
-
-***
+[Access my company: Log in or create my BC Registries account]({{ context_url }})
 
 **Here is what you need to do:**
 
-**Step 1:**
-Log in using your existing BC Services Card Account (or set up your BC Services Card Account if you do not have one). 
+**STEP 1:**    [Log in]({{ context_url }}) with your BC Services Card account. If you do not have one, [set one up first](https://id.gov.bc.ca/static/help/setup_app.html).
 
-**Step 2:**
-Once logged in, create a BC Registries Account or use an existing one to manage your business.
+**STEP 2:**    After signing in, create your BC Registries account or use an existing one.
 
-**Step 3:**
-Your business will automatically be connected to your account.
+**STEP 3:**    Your company will automatically be connected to your account.
 
-**Step 4:**
-You will now be using your BC Registries Account to manage your business going forward.
+**STEP 4:**    Use your BC Registries account to manage your company going forward.
 
-_If you manage multiple businesses, you'll receive a separate email for each one and will need to complete the process for each business._
-
-[Add my business to a BC Registries Account now]({{ context_url }})
+_If you manage multiple companies, you’ll receive a separate email for each one and must repeat the steps for each company._
 
 ***
 
-**Business Registry**
-BC Registries and Online Services
+**BC Registry Services**
 
-Email: [BCOLhelp@gov.bc.ca](mailto:BCOLhelp@gov.bc.ca)
+Email: [bcrossupport@gov.bc.ca](mailto:bcrossupport@gov.bc.ca)

--- a/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_unaffiliated_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/affiliation_invitation_unaffiliated_email.html
@@ -1,23 +1,40 @@
 
-# Manage Your Business on BC Registries
+# Your business is being moved to the new BC Registries system
 
-You are receiving this email because **{{ business_name }}** ({{ business_identifier }}) has been registered with BC Registries.
+**Business Name:** {{ business_name }}
+**Incorporation Number:** {{ business_identifier }}
 
-To manage your business through BC Registries and Online Services, follow the steps below:
+The Government of B.C. is moving your business management services from Corporate Online to BC Registries. You will no longer be able to make changes to your business in Corporate Online moving forward.
 
-1. Log in using your BC Services Card.
+**To continue managing your business online, you will need to add your business to a BC Registries account.**
 
-2. [Manage {{ business_name }} ({{ business_identifier }})]({{ context_url }})
+[Add my business to a BC Registries Account now]({{ context_url }})
 
-For security reasons, this link can only be used once.
+This link is valid for 7 days.
 
-If you did not expect this email, please disregard it.
+***
+
+**Here is what you need to do:**
+
+**Step 1:**
+Log in using your existing BC Services Card Account (or set up your BC Services Card Account if you do not have one). 
+
+**Step 2:**
+Once logged in, create a BC Registries Account or use an existing one to manage your business.
+
+**Step 3:**
+Your business will automatically be connected to your account.
+
+**Step 4:**
+You will now be using your BC Registries Account to manage your business going forward.
+
+_If you manage multiple businesses, you'll receive a separate email for each one and will need to complete the process for each business._
+
+[Add my business to a BC Registries Account now]({{ context_url }})
 
 ***
 
 **Business Registry**
 BC Registries and Online Services
 
-Toll Free: [1-877-526-1526](1-877-526-1526)
-Victoria Office: [250-387-7848](250-387-7848)
-Email: [BCRegistries@gov.bc.ca](BCRegistries@gov.bc.ca)
+Email: [BCOLhelp@gov.bc.ca](mailto:BCOLhelp@gov.bc.ca)

--- a/queue_services/account-mailer/src/account_mailer/enums.py
+++ b/queue_services/account-mailer/src/account_mailer/enums.py
@@ -95,6 +95,7 @@ class SubjectType(Enum):
     AFFILIATION_INVITATION_UNAFFILIATED_EMAIL = (
         "[BC Registries and Online Services] Manage Your Business on BC Registries"
     )
+    AFFILIATION_CONFIRMATION_EMAIL = "[BC Registries and Online Services] You’re Ready to Manage Your Business in the BC Business Registry"
 
 
 class TitleType(Enum):
@@ -174,6 +175,7 @@ class TemplateType(Enum):
     PAYMENT_DUE_NOTIFICATION_TEMPLATE_NAME = "payment_due_notification"
     EFT_AVAILABLE_NOTIFICATION_TEMPLATE_NAME = "eft_available_notification"
     AFFILIATION_INVITATION_UNAFFILIATED_EMAIL_TEMPLATE_NAME = "affiliation_invitation_unaffiliated_email"
+    AFFILIATION_CONFIRMATION_EMAIL_TEMPLATE_NAME = "affiliation_confirmation_email"
 
 
 class Constants(Enum):

--- a/queue_services/account-mailer/src/account_mailer/resources/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/resources/worker.py
@@ -397,7 +397,8 @@ def handle_unaffiliated_email_invitation(message_type, email_msg):
     business_identifier = email_msg.get("businessIdentifier")
     logo_url = email_msg.get("logo_url")
     context_url = email_msg.get("contextUrl")
-    expiry_date = get_local_formatted_date(email_msg.get("expiryDate"), "%B %d, %Y")
+    expiry_date = datetime.fromisoformat(email_msg.get("expiryDate"))
+    display_date = get_local_formatted_date(expiry_date, "%B %d, %Y")
 
     template_name = TemplateType.AFFILIATION_INVITATION_UNAFFILIATED_EMAIL_TEMPLATE_NAME.value
     subject = SubjectType.AFFILIATION_INVITATION_UNAFFILIATED_EMAIL.value
@@ -411,7 +412,7 @@ def handle_unaffiliated_email_invitation(message_type, email_msg):
         business_name=business_name,
         business_identifier=business_identifier,
         context_url=context_url,
-        expiry_date=expiry_date,
+        expiry_date=display_date,
     )
     process_email(email_dict)
 
@@ -423,7 +424,8 @@ def handle_affiliation_confirmation_email(message_type, email_msg):
     business_identifier = email_msg.get("businessIdentifier")
     logo_url = email_msg.get("logo_url")
     context_url = email_msg.get("contextUrl")
-    completion_date = get_local_formatted_date(email_msg.get("completionDate"), "%B %d, %Y")
+    completion_date = datetime.fromisoformat(email_msg.get("completionDate"))
+    display_date = get_local_formatted_date(completion_date, "%B %d, %Y")
 
     template_name = TemplateType.AFFILIATION_CONFIRMATION_EMAIL_TEMPLATE_NAME.value
     subject = SubjectType.AFFILIATION_CONFIRMATION_EMAIL.value
@@ -437,7 +439,7 @@ def handle_affiliation_confirmation_email(message_type, email_msg):
         business_name=business_name,
         business_identifier=business_identifier,
         context_url=context_url,
-        completion_date=completion_date,
+        completion_date=display_date,
     )
     process_email(email_dict)
 

--- a/queue_services/account-mailer/src/account_mailer/resources/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/resources/worker.py
@@ -395,6 +395,7 @@ def handle_unaffiliated_email_invitation(message_type, email_msg):
     business_identifier = email_msg.get("businessIdentifier")
     logo_url = email_msg.get("logo_url")
     context_url = email_msg.get("contextUrl")
+    expiry_date = get_local_formatted_date(email_msg.get("expiryDate"), "%B %d, %Y")
 
     template_name = TemplateType.AFFILIATION_INVITATION_UNAFFILIATED_EMAIL_TEMPLATE_NAME.value
     subject = SubjectType.AFFILIATION_INVITATION_UNAFFILIATED_EMAIL.value
@@ -408,6 +409,7 @@ def handle_unaffiliated_email_invitation(message_type, email_msg):
         business_name=business_name,
         business_identifier=business_identifier,
         context_url=context_url,
+        expiry_date=expiry_date,
     )
     process_email(email_dict)
 

--- a/queue_services/account-mailer/src/account_mailer/resources/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/resources/worker.py
@@ -40,7 +40,7 @@ from account_mailer.services import google_store, notification_service
 from account_mailer.utils import format_currency, format_day_with_suffix, get_local_formatted_date
 
 AFFILIATION_INVITATION_UNAFFILIATED_EMAIL = "bc.registry.auth.affiliationInvitationUnaffiliatedEmail"
-AFFILIATION_CONFIRMATION_EMAIL = "bc.registry.auth.affiliationInvitationConfirmationEmail"
+AFFILIATION_CONFIRMATION_EMAIL = "bc.registry.auth.affiliationConfirmationEmail"
 
 bp = Blueprint("worker", __name__)
 

--- a/queue_services/account-mailer/src/account_mailer/resources/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/resources/worker.py
@@ -40,6 +40,7 @@ from account_mailer.services import google_store, notification_service
 from account_mailer.utils import format_currency, format_day_with_suffix, get_local_formatted_date
 
 AFFILIATION_INVITATION_UNAFFILIATED_EMAIL = "bc.registry.auth.affiliationInvitationUnaffiliatedEmail"
+AFFILIATION_CONFIRMATION_EMAIL = "bc.registry.auth.affiliationInvitationConfirmationEmail"
 
 bp = Blueprint("worker", __name__)
 
@@ -72,6 +73,7 @@ def worker():
         handle_reset_passcode(message_type, email_msg)
         handle_affiliation_invitation(message_type, email_msg)
         handle_unaffiliated_email_invitation(message_type, email_msg)
+        handle_affiliation_confirmation_email(message_type, email_msg)
         handle_product_actions(message_type, email_msg)
         handle_statement_notification(message_type, email_msg)
         handle_payment_reminder_or_due(message_type, email_msg)
@@ -413,6 +415,32 @@ def handle_unaffiliated_email_invitation(message_type, email_msg):
     )
     process_email(email_dict)
 
+def handle_affiliation_confirmation_email(message_type, email_msg):
+    """Handle the affiliation confirmation email message."""
+    if message_type != AFFILIATION_CONFIRMATION_EMAIL:
+        return
+    business_name = email_msg.get("businessName")
+    business_identifier = email_msg.get("businessIdentifier")
+    logo_url = email_msg.get("logo_url")
+    context_url = email_msg.get("contextUrl")
+    completion_date = get_local_formatted_date(email_msg.get("completionDate"), "%B %d, %Y")
+
+    template_name = TemplateType.AFFILIATION_CONFIRMATION_EMAIL_TEMPLATE_NAME.value
+    subject = SubjectType.AFFILIATION_CONFIRMATION_EMAIL.value
+
+    email_dict = common_mailer.process(
+        org_id=None,
+        recipients=email_msg.get("emailAddresses"),
+        template_name=template_name,
+        subject=subject,
+        logo_url=logo_url,
+        business_name=business_name,
+        business_identifier=business_identifier,
+        context_url=context_url,
+        completion_date=completion_date,
+    )
+    process_email(email_dict)
+
 
 def handle_product_actions(message_type, email_msg):
     """Handle the product actions messages."""
@@ -528,6 +556,7 @@ def handle_other_messages(message_type, email_msg):
         QueueMessageTypes.PAYMENT_REMINDER_NOTIFICATION.value,
         QueueMessageTypes.PAYMENT_DUE_NOTIFICATION.value,
         AFFILIATION_INVITATION_UNAFFILIATED_EMAIL,
+        AFFILIATION_CONFIRMATION_EMAIL
     ]:
         return
 

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -611,7 +611,7 @@ def test_unaffiliated_email_invitation(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
-            "expiryDate": datetime(2026, 4, 16).isoformat()
+            "expiryDate": "2026-04-16 00:00:00"
         }
         helper_add_event_to_queue(
             client,
@@ -640,7 +640,7 @@ def test_affiliation_confirmation_email(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
-            "completionDate": datetime(2026, 4, 16).isoformat()
+            "completionDate": "2026-04-16 00:00:00"
         }
         helper_add_event_to_queue(
             client,

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -23,7 +23,7 @@ from google.cloud import storage
 from sbc_common_components.utils.enums import QueueMessageTypes
 
 from account_mailer.enums import SubjectType
-from account_mailer.resources.worker import AFFILIATION_INVITATION_UNAFFILIATED_EMAIL
+from account_mailer.resources.worker import AFFILIATION_INVITATION_UNAFFILIATED_EMAIL, AFFILIATION_CONFIRMATION_EMAIL
 from account_mailer.services import notification_service
 
 from . import factory_membership_model, factory_org_model, factory_user_model_with_contact
@@ -602,7 +602,7 @@ def test_payment_due_notification_email(app, session, client):
 
 
 def test_unaffiliated_email_invitation(app, session, client):
-    """Assert that unaffiliated email invitation uses context_url from message data."""
+    """Assert that unaffiliated email invitation uses context_url and expiry_date from message data."""
     context_url = "https://localhost.com?preset=bcscUser&token=ABC123"
     with patch.object(notification_service, "send_email", return_value=None) as mock_send:
         mail_details = {
@@ -611,6 +611,7 @@ def test_unaffiliated_email_invitation(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
+            "expiryDate": datetime(2026, 4, 16)
         }
         helper_add_event_to_queue(
             client,
@@ -627,3 +628,33 @@ def test_unaffiliated_email_invitation(app, session, client):
         email_body = mock_send.call_args.args[0].get("content").get("body")
         assert email_body is not None
         assert "https://localhost.com?preset=bcscUser&amp;token=ABC123" in email_body
+        assert "April 16, 2026" in email_body
+
+def test_affiliation_confirmation_email(app, session, client):
+    """Assert that unaffiliated email invitation uses context_url and completion_date from message data."""
+    context_url = "https://localhost.com/login"
+    with patch.object(notification_service, "send_email", return_value=None) as mock_send:
+        mail_details = {
+            "businessName": "Test Corp.",
+            "emailAddresses": "test@test.com",
+            "businessIdentifier": "CP1234567",
+            "token": "ABC123",
+            "contextUrl": context_url,
+            "completionDate": datetime(2026, 4, 16)
+        }
+        helper_add_event_to_queue(
+            client,
+            message_type=AFFILIATION_CONFIRMATION_EMAIL,
+            mail_details=mail_details,
+        )
+
+        mock_send.assert_called()
+        assert mock_send.call_args.args[0].get("recipients") == "test@test.com"
+        assert (
+            mock_send.call_args.args[0].get("content").get("subject")
+            == SubjectType.AFFILIATION_CONFIRMATION_EMAIL.value
+        )
+        email_body = mock_send.call_args.args[0].get("content").get("body")
+        assert email_body is not None
+        assert "https://localhost.com/login" in email_body
+        assert "April 16, 2026" in email_body

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -611,7 +611,7 @@ def test_unaffiliated_email_invitation(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
-            "expiryDate": "2026-04-16 00:00:00"
+            "expiryDate": f"{datetime(2026, 4, 16)}"
         }
         helper_add_event_to_queue(
             client,
@@ -640,7 +640,7 @@ def test_affiliation_confirmation_email(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
-            "completionDate": "2026-04-16 00:00:00"
+            "completionDate": f"{datetime(2026, 4, 16)}"
         }
         helper_add_event_to_queue(
             client,

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -611,7 +611,7 @@ def test_unaffiliated_email_invitation(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
-            "expiryDate": f"{datetime(2026, 4, 16)}"
+            "expiryDate": f"{datetime(2026, 4, 16, 12, 0, 0)}"
         }
         helper_add_event_to_queue(
             client,
@@ -640,7 +640,7 @@ def test_affiliation_confirmation_email(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
-            "completionDate": f"{datetime(2026, 4, 16)}"
+            "completionDate": f"{datetime(2026, 4, 16, 12, 0, 0)}"
         }
         helper_add_event_to_queue(
             client,

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -611,7 +611,7 @@ def test_unaffiliated_email_invitation(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
-            "expiryDate": datetime(2026, 4, 16)
+            "expiryDate": datetime(2026, 4, 16).isoformat()
         }
         helper_add_event_to_queue(
             client,
@@ -640,7 +640,7 @@ def test_affiliation_confirmation_email(app, session, client):
             "businessIdentifier": "CP1234567",
             "token": "ABC123",
             "contextUrl": context_url,
-            "completionDate": datetime(2026, 4, 16)
+            "completionDate": datetime(2026, 4, 16).isoformat()
         }
         helper_add_event_to_queue(
             client,

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -23,7 +23,7 @@ from google.cloud import storage
 from sbc_common_components.utils.enums import QueueMessageTypes
 
 from account_mailer.enums import SubjectType
-from account_mailer.resources.worker import AFFILIATION_INVITATION_UNAFFILIATED_EMAIL, AFFILIATION_CONFIRMATION_EMAIL
+from account_mailer.resources.worker import AFFILIATION_CONFIRMATION_EMAIL, AFFILIATION_INVITATION_UNAFFILIATED_EMAIL
 from account_mailer.services import notification_service
 
 from . import factory_membership_model, factory_org_model, factory_user_model_with_contact


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/32405

*Description of changes:*
- update unaffiliated email template to final design
- send confirmation email on successful affiliation creation
- update affiliation invitation model to return expires_on at the end of the day if type == unaffiliated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
