### PR TITLE
Reset pdf summary view when searching a new business

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.10.51",
+  "version": "2.10.52",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.10.51",
+      "version": "2.10.52",
       "hasInstallScript": true,
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",
@@ -55,7 +55,7 @@
         "@types/vuelidate": "^0.7.13",
         "@typescript-eslint/eslint-plugin": "^6.4.0",
         "@typescript-eslint/parser": "^6.4.0",
-        "@volar-plugins/vetur": "*",
+        "@volar-plugins/vetur": "latest",
         "@vue/eslint-config-standard": "^4.0.0",
         "@vue/eslint-config-typescript": "^4.0.0",
         "@vue/test-utils": "1.3.6",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.10.51",
+  "version": "2.10.52",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/staff/admin/AdministrativeBN.vue
+++ b/auth-web/src/components/auth/staff/admin/AdministrativeBN.vue
@@ -317,6 +317,7 @@ export default class AdministrativeBN extends Vue {
   }]
 
   private async mounted () {
+    this.closePdfDialog() // prevent displaying information for the previously loaded business
     const identifier = ConfigHelper.getFromSession(SessionStorageKeys.BusinessIdentifierKey)
     if (identifier) {
       this.businessIdentifier = identifier
@@ -345,6 +346,7 @@ export default class AdministrativeBN extends Vue {
   }
 
   resetSearch () {
+    this.closePdfDialog() // prevent displaying information for the previously loaded business
     this.businessDetails = null
     this.searchedBusinessIdentifier = null
     this.businessIdentifier = null

--- a/auth-web/tests/unit/components/AdministrativeBN.spec.ts
+++ b/auth-web/tests/unit/components/AdministrativeBN.spec.ts
@@ -85,4 +85,26 @@ describe('Search Business Form: Result', () => {
     await promise
     expect(wrapper.vm.downloadActive).toBe(false)
   })
+
+  it('clears business summary pdf data when searching a new business', async () => {
+    // mock the window.URL.revokeObjectURL function
+    delete window.URL.revokeObjectURL
+    window.location = { pathname: vi.fn() } as any
+    window.URL.revokeObjectURL = vi.fn().mockImplementation(() => new Promise(resolve => setTimeout(resolve, 50)))
+
+    wrapper.setData({
+      businessDetails: {
+        legalName: 'Business Name',
+        identifier: 'FM1234567',
+        taxId: '123456789BC0001'
+      },
+      pdfDialog: true,
+      pdfUrl: 'fake'
+    })
+    await flushPromises()
+
+    await wrapper.vm.resetSearch()
+    expect(wrapper.vm.pdfDialog).toBe(false)
+    expect(wrapper.vm.pdfUrl).toBe('')
+  })
 })


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33210

*Description of changes:*
small bug fix to admin dashboard to reset the business summary pdf data when switching businesses

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
