### PR TITLE
fix(auth-api): user history duplicate key violation

### DIFF
--- a/auth-api/src/auth_api/models/user.py
+++ b/auth-api/src/auth_api/models/user.py
@@ -86,9 +86,12 @@ class User(Versioned, BaseModel):
     user_status = relationship("UserStatusCode", foreign_keys=[status], lazy="subquery")
 
     @classmethod
-    def find_by_username(cls, username):
+    def find_by_username(cls, username, for_update=False):
         """Return the first user with the provided username."""
-        return cls.query.filter_by(username=username).first()
+        query = cls.query.filter_by(username=username)
+        if for_update:
+            query = query.with_for_update()
+        return query.first()
 
     @classmethod
     @user_context
@@ -114,8 +117,12 @@ class User(Versioned, BaseModel):
     def find_by_jwt_idp_userid(cls, **kwargs):
         """Find an existing user by idp_userid."""
         user_from_context: UserContext = kwargs["user_context"]
+        for_update = kwargs.get("for_update", False)
         if idp_userid := user_from_context.token_info.get("idp_userid", None):
-            return db.session.query(User).filter(User.idp_userid == idp_userid).one_or_none()
+            query = db.session.query(User).filter(User.idp_userid == idp_userid)
+            if for_update:
+                query = query.with_for_update()
+            return query.one_or_none()
         if not idp_userid:
             current_app.logger.error("No idp_userid provided from token_info.")
         return None

--- a/auth-api/src/auth_api/services/user.py
+++ b/auth-api/src/auth_api/services/user.py
@@ -366,9 +366,9 @@ class User:  # pylint: disable=too-many-instance-attributes disable=too-many-pub
 
         is_anonymous_user = user_from_context.token_info.get("accessType", None) == AccessType.ANONYMOUS.value
         if is_anonymous_user:
-            existing_user = UserModel.find_by_username(user_from_context.user_name)
+            existing_user = UserModel.find_by_username(user_from_context.user_name, for_update=True)
         else:
-            existing_user = UserModel.find_by_jwt_idp_userid()
+            existing_user = UserModel.find_by_jwt_idp_userid(for_update=True)
 
         first_name, last_name = User._get_names(existing_user, request_json)
 


### PR DESCRIPTION
Resolves SEV4 issue outlined in 2026-05-12 postmortem by serializing concurrent JWT token logins using SELECT FOR UPDATE row locking.