### PR TITLE
Update to use gcp_trace instead of default otlp_proto_grpc

### DIFF
--- a/auth-api/Dockerfile
+++ b/auth-api/Dockerfile
@@ -84,6 +84,7 @@ COPY --chown=web:web . /code
 
 ENV OTEL_SDK_DISABLED=true \
     OTEL_SERVICE_NAME=auth-api \
+    OTEL_TRACES_EXPORTER=gcp_trace \
     OTEL_TRACES_SAMPLER=always_on \
     OTEL_TRACES_SAMPLER_ARG=1.0
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33243

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
