### PR TITLE
auth-api: suppress pg8000 InterfaceError on connection close during Cloud SQL maintenance

### DIFF
--- a/auth-api/poetry.lock
+++ b/auth-api/poetry.lock
@@ -623,7 +623,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cloud-sql-connector"
-version = "0.2.0"
+version = "0.2.3"
 description = "Cloud SQL connection utilities for database connectivity with authentication and schema management"
 optional = false
 python-versions = "^3.12"
@@ -640,7 +640,7 @@ sqlalchemy = "^2.0.0"
 type = "git"
 url = "https://github.com/bcgov/sbc-connect-common.git"
 reference = "main"
-resolved_reference = "9240434e42a3c21187abe59f4c1b0318680f7c84"
+resolved_reference = "9a760cf5ea31d3f95806c2dcac15ca9d9800df51"
 subdirectory = "python/cloud-sql-connector"
 
 [[package]]

--- a/auth-api/src/auth_api/__init__.py
+++ b/auth-api/src/auth_api/__init__.py
@@ -19,7 +19,7 @@ This module is the API for the Authroization system.
 import os
 import traceback
 
-from cloud_sql_connector import DBConfig, setup_search_path_event_listener
+from cloud_sql_connector import DBConfig, setup_pg8000_close_event_listener, setup_search_path_event_listener
 from flask import Flask, request  # noqa: TC002
 from flask_cors import CORS
 from flask_migrate import Migrate, upgrade
@@ -71,6 +71,8 @@ def create_app(run_mode=None):
         with app.app_context():
             engine = db.engine
             setup_search_path_event_listener(engine, schema)
+            # Suppress pg8000 InterfaceError on connection close during teardown
+            setup_pg8000_close_event_listener(engine)
 
     if run_mode == "migration":
         Migrate(app, db)


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33379
*Description of changes:*
my reference: 
https://github.com/bcgov/bcros-common/commit/e70bcd8ee80597deb8bfb9dbd82b75dc152bb991#diff-51bd4cd231f9d9f13e96b42a712fd15629d89f8eec0ee11be973ffeaef087226R4

https://github.com/bcgov/bcros-common/commit/e70bcd8ee80597deb8bfb9dbd82b75dc152bb991

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
