### PR TITLE
33528 auth-web: hotfix for regular users

### DIFF
--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.10.53",
+  "version": "2.10.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.10.53",
+      "version": "2.10.54",
       "hasInstallScript": true,
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.10.53",
+  "version": "2.10.54",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/util/http-util.ts
+++ b/auth-web/src/util/http-util.ts
@@ -20,6 +20,11 @@ axios.interceptors.request.use(
     if (token) {
       request.headers.Authorization = `Bearer ${token}`
     }
+    const account = JSON.parse(ConfigHelper.getFromSession(SessionStorageKeys.CurrentAccount || '{}'))
+    const accountId = account?.id
+    if (accountId) {
+      request.headers['Account-Id'] = accountId
+    }
     const authApiUrl = ConfigHelper.getAuthAPIUrl()
     const authApiKey = import.meta.env.VUE_APP_AUTH_API_KEY
     if (authApiKey && request.url.includes(authApiUrl)) {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33528

*Description of changes:*
- regular users need the account id set in the header of the request when going through the gateway

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
