### PR TITLE
33376 - Fix account mailer 400 error

### DIFF
--- a/auth-web/src/stores/user.ts
+++ b/auth-web/src/stores/user.ts
@@ -1,11 +1,10 @@
 import { DocumentUpload, User, UserProfileData, UserSettings } from '@/models/user'
 import { NotaryContact, NotaryInformation } from '@/models/notary'
 import { computed, reactive, toRefs } from '@vue/composition-api'
+import { ApiErrorCode } from '@/util/constants'
 import CommonUtils from '@/util/common-util'
 import { Contact } from '@/models/contact'
-import DocumentService from '@/services/document.services'
 import { KCUserProfile } from 'sbc-common-components/src/models/KCUserProfile'
-import KeyCloakService from 'sbc-common-components/src/services/keycloak.services'
 import { RoleInfo } from '@/models/Organization'
 import { TermsOfUseDocument } from '@/models/TermsOfUseDocument'
 import UserService from '@/services/user.services'
@@ -15,9 +14,6 @@ export interface UserTerms {
   isTermsOfUseAccepted: boolean
   termsOfUseAcceptedVersion: string
 }
-
-const CONTACT_EXISTS_CODE = 'DATA_ALREADY_EXISTS'
-const CONTACT_NOT_FOUND_CODE = 'DATA_NOT_FOUND'
 
 export const useUserStore = defineStore('user', () => {
   const state = reactive({
@@ -175,7 +171,7 @@ export const useUserStore = defineStore('user', () => {
       return saveContactFromResponse(await UserService.createContact(userContact), 201)
     } catch (error: any) {
       // Idempotency guard: if contact already exists, convert create -> update.
-      if (error?.response?.data?.code === CONTACT_EXISTS_CODE) {
+      if (error?.response?.data?.code === ApiErrorCode.DATA_ALREADY_EXISTS) {
         return saveContactFromResponse(await UserService.updateContact(userContact), 200)
       }
       throw error
@@ -193,7 +189,7 @@ export const useUserStore = defineStore('user', () => {
       return saveContactFromResponse(await UserService.updateContact(userContact), 200)
     } catch (error: any) {
       // Idempotency guard: if contact does not exist yet, convert update -> create.
-      if (error?.response?.data?.code === CONTACT_NOT_FOUND_CODE) {
+      if (error?.response?.data?.code === ApiErrorCode.DATA_NOT_FOUND) {
         return saveContactFromResponse(await UserService.createContact(userContact), 201)
       }
       throw error

--- a/auth-web/src/stores/user.ts
+++ b/auth-web/src/stores/user.ts
@@ -16,6 +16,9 @@ export interface UserTerms {
   termsOfUseAcceptedVersion: string
 }
 
+const CONTACT_EXISTS_CODE = 'DATA_ALREADY_EXISTS'
+const CONTACT_NOT_FOUND_CODE = 'DATA_NOT_FOUND'
+
 export const useUserStore = defineStore('user', () => {
   const state = reactive({
     currentUser: undefined as KCUserProfile,
@@ -150,17 +153,32 @@ export const useUserStore = defineStore('user', () => {
     }
   }
 
-  async function createUserContact (contact?: Contact) {
+  function buildUserContact (contact?: Contact): Contact {
     const userProfile = state.userProfileData
-    const userContact: Contact = contact || {
+    return contact || {
       phone: userProfile?.phone,
       email: userProfile?.email,
       phoneExtension: userProfile?.phoneExtension
     }
-    const response = await UserService.createContact(userContact)
-    if (response?.data && response.status === 201) {
+  }
+
+  function saveContactFromResponse (response: any, successStatus: number) {
+    if (response?.data && response.status === successStatus) {
       state.userContact = response.data
       return response.data
+    }
+  }
+
+  async function createUserContact (contact?: Contact) {
+    const userContact = buildUserContact(contact)
+    try {
+      return saveContactFromResponse(await UserService.createContact(userContact), 201)
+    } catch (error: any) {
+      // Idempotency guard: if contact already exists, convert create -> update.
+      if (error?.response?.data?.code === CONTACT_EXISTS_CODE) {
+        return saveContactFromResponse(await UserService.updateContact(userContact), 200)
+      }
+      throw error
     }
   }
 
@@ -170,16 +188,15 @@ export const useUserStore = defineStore('user', () => {
   }
 
   async function updateUserContact (contact?: Contact) {
-    const userProfile = state.userProfileData
-    const userContact: Contact = contact || {
-      phone: userProfile?.phone,
-      email: userProfile?.email,
-      phoneExtension: userProfile?.phoneExtension
-    }
-    const response = await UserService.updateContact(userContact)
-    if (response?.data && response.status === 200) {
-      state.userContact = response.data
-      return response.data
+    const userContact = buildUserContact(contact)
+    try {
+      return saveContactFromResponse(await UserService.updateContact(userContact), 200)
+    } catch (error: any) {
+      // Idempotency guard: if contact does not exist yet, convert update -> create.
+      if (error?.response?.data?.code === CONTACT_NOT_FOUND_CODE) {
+        return saveContactFromResponse(await UserService.createContact(userContact), 201)
+      }
+      throw error
     }
   }
 

--- a/auth-web/src/util/constants.ts
+++ b/auth-web/src/util/constants.ts
@@ -716,3 +716,8 @@ export enum OrgNameLabel {
     BUSINESS = 'Legal Business Name',
     REGULAR = 'Account Name'
 }
+
+export enum ApiErrorCode {
+    DATA_ALREADY_EXISTS = 'DATA_ALREADY_EXISTS',
+    DATA_NOT_FOUND = 'DATA_NOT_FOUND'
+}

--- a/auth-web/src/views/auth/create-account/AccountSetupView.vue
+++ b/auth-web/src/views/auth/create-account/AccountSetupView.vue
@@ -173,8 +173,9 @@ export default defineComponent({
     async function createAccount () {
       state.isLoading = true
       try {
-        const organization = await orgStore.createOrg()
+        // Save contact before createOrg; otherwise PAD email can fail due to missing recipient data.
         await saveOrUpdateContact()
+        const organization = await orgStore.createOrg()
         await userStore.getUserProfile('@me')
         await orgStore.syncOrganization(organization.id)
         await orgStore.syncMembership(organization.id)

--- a/auth-web/src/views/auth/create-account/NonBcscAccountSetupView.vue
+++ b/auth-web/src/views/auth/create-account/NonBcscAccountSetupView.vue
@@ -204,8 +204,9 @@ export default defineComponent({
             await userStore.createAffidavit()
           }
           await userStore.updateUserFirstAndLastName()
-          const organization = await orgStore.createOrg()
+          // Save contact before createOrg; otherwise PAD email can fail due to missing recipient data.
           await saveOrUpdateContact()
+          const organization = await orgStore.createOrg()
           await userStore.getUserProfile('@me')
           await orgStore.syncOrganization(organization.id)
           await orgStore.syncMembership(organization.id)

--- a/auth-web/tests/unit/stores/user.spec.ts
+++ b/auth-web/tests/unit/stores/user.spec.ts
@@ -1,0 +1,47 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { Contact } from '@/models/contact'
+import UserService from '@/services/user.services'
+import { useUserStore } from '@/stores/user'
+
+describe('User Store - contact idempotency', () => {
+  const contact: Contact = {
+    email: 'test@example.com',
+    phone: '555-555-5555',
+    phoneExtension: '123'
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('createUserContact falls back to update when contact exists', async () => {
+    const userStore = useUserStore()
+    const createSpy = vi.spyOn(UserService, 'createContact').mockRejectedValue({
+      response: { data: { code: 'DATA_ALREADY_EXISTS' } }
+    })
+    const updateSpy = vi.spyOn(UserService, 'updateContact').mockResolvedValue({ status: 200, data: contact } as any)
+
+    const result = await userStore.createUserContact(contact)
+
+    expect(createSpy).toHaveBeenCalledWith(contact)
+    expect(updateSpy).toHaveBeenCalledWith(contact)
+    expect(result).toEqual(contact)
+    expect(userStore.userContact).toEqual(contact)
+  })
+
+  it('updateUserContact falls back to create when contact is missing', async () => {
+    const userStore = useUserStore()
+    const updateSpy = vi.spyOn(UserService, 'updateContact').mockRejectedValue({
+      response: { data: { code: 'DATA_NOT_FOUND' } }
+    })
+    const createSpy = vi.spyOn(UserService, 'createContact').mockResolvedValue({ status: 201, data: contact } as any)
+
+    const result = await userStore.updateUserContact(contact)
+
+    expect(updateSpy).toHaveBeenCalledWith(contact)
+    expect(createSpy).toHaveBeenCalledWith(contact)
+    expect(result).toEqual(contact)
+    expect(userStore.userContact).toEqual(contact)
+  })
+})

--- a/queue_services/account-mailer/src/account_mailer/email_processors/pad_confirmation.py
+++ b/queue_services/account-mailer/src/account_mailer/email_processors/pad_confirmation.py
@@ -61,14 +61,18 @@ def process(email_msg: dict, org_id: str, token: str) -> dict:
 
 def _get_admin_emails(username):
     admin_user = UserModel.find_by_username(username)
-    if admin_user:
-        admin_name = admin_user.firstname + " " + admin_user.lastname
-        if admin_user.contacts:
-            admin_emails = admin_user.contacts[0].contact.email
-        else:
-            admin_emails = admin_user.email
-    else:
+    if not admin_user:
         raise ValueError("Admin user not found, cannot determine email address.")
+
+    firstname = admin_user.firstname or ""
+    lastname = admin_user.lastname or ""
+    admin_name = f"{firstname} {lastname}".strip()
+
+    admin_emails = admin_user.contacts[0].contact.email if admin_user.contacts else None
+    if not admin_emails:
+        admin_emails = admin_user.email
+    if not admin_emails:
+        raise ValueError(f"No email address found for user {username}, cannot send PAD confirmation.")
 
     return admin_emails, admin_name
 

--- a/queue_services/account-mailer/src/account_mailer/email_processors/pad_confirmation.py
+++ b/queue_services/account-mailer/src/account_mailer/email_processors/pad_confirmation.py
@@ -28,6 +28,7 @@ from account_mailer.pdf_utils import get_pdf_from_report_api, get_pdf_from_stora
 
 def process(email_msg: dict, org_id: str, token: str) -> dict:
     """Build the email for PAD Confirmation notification."""
+    current_app.logger.debug("account notification: %s", org_id)
     current_app.logger.debug("email_msg notification: %s", email_msg)
     _, account_name_with_branch = get_account_info(org_id)
     username = email_msg.get("padTosAcceptedBy")
@@ -62,15 +63,13 @@ def process(email_msg: dict, org_id: str, token: str) -> dict:
 def _get_admin_emails(username):
     admin_user = UserModel.find_by_username(username)
     if not admin_user:
-        raise ValueError("Admin user not found, cannot determine email address.")
+        raise ValueError(f"Admin user not found for username {username}, cannot determine email address.")
 
     firstname = admin_user.firstname or ""
     lastname = admin_user.lastname or ""
     admin_name = f"{firstname} {lastname}".strip()
 
-    admin_emails = admin_user.contacts[0].contact.email if admin_user.contacts else None
-    if not admin_emails:
-        admin_emails = admin_user.email
+    admin_emails = (admin_user.contacts[0].contact.email if admin_user.contacts else None) or admin_user.email or None
     if not admin_emails:
         raise ValueError(f"No email address found for user {username}, cannot send PAD confirmation.")
 

--- a/queue_services/account-mailer/tests/unit/__init__.py
+++ b/queue_services/account-mailer/tests/unit/__init__.py
@@ -95,6 +95,35 @@ def factory_contact_model():
     return contact
 
 
+def factory_user_model_for_email_test(
+    username: str,
+    firstname: str | None,
+    lastname: str | None,
+    user_email: str | None = None,
+    with_contact: bool = False,
+    contact_email: str = "foo@bar.com",
+):
+    """Create a user with optional linked contact for email processor tests."""
+    user = UserModel(
+        username=username,
+        firstname=firstname,
+        lastname=lastname,
+        email=user_email,
+        keycloak_guid=uuid.uuid4(),
+    )
+    user.save()
+    if with_contact:
+        contact = factory_contact_model()
+        if contact_email != "foo@bar.com":
+            contact.email = contact_email
+            contact.save()
+        contact_link = ContactLinkModel()
+        contact_link.contact = contact
+        contact_link.user = user
+        contact_link.save()
+    return user
+
+
 class TestUserInfo(dict, Enum):
     """Test scenarios of user."""
 

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -18,15 +18,22 @@ import types
 from datetime import datetime
 from unittest.mock import patch
 
+import pytest
 from auth_api.services.rest_service import RestService
 from google.cloud import storage
 from sbc_common_components.utils.enums import QueueMessageTypes
 
+from account_mailer.email_processors.pad_confirmation import _get_admin_emails
 from account_mailer.enums import SubjectType
 from account_mailer.resources.worker import AFFILIATION_CONFIRMATION_EMAIL, AFFILIATION_INVITATION_UNAFFILIATED_EMAIL
 from account_mailer.services import notification_service
 
-from . import factory_membership_model, factory_org_model, factory_user_model_with_contact
+from . import (
+    factory_membership_model,
+    factory_org_model,
+    factory_user_model_for_email_test,
+    factory_user_model_with_contact,
+)
 from .utils import helper_add_event_to_queue
 
 
@@ -739,3 +746,51 @@ def test_affiliation_confirmation_email(app, session, client):
         assert email_body is not None
         assert "https://localhost.com/login" in email_body
         assert "April 16, 2026" in email_body
+
+
+def test_get_admin_emails_null_firstname(app, session):
+    """Assert that a user with a null firstname does not raise TypeError."""
+    factory_user_model_for_email_test(
+        username="bcsc/nullfirst",
+        firstname=None,
+        lastname="Smith",
+        with_contact=True,
+    )
+
+    emails, name = _get_admin_emails("bcsc/nullfirst")
+    assert emails == "foo@bar.com"
+    assert name == "Smith"
+
+
+def test_get_admin_emails_no_email_raises(app, session):
+    """Assert that a user with no contact and no user email raises ValueError."""
+    factory_user_model_for_email_test(
+        username="bcsc/noemail",
+        firstname="John",
+        lastname="Smith",
+    )
+
+    with pytest.raises(ValueError, match="No email address found for user bcsc/noemail"):
+        _get_admin_emails("bcsc/noemail")
+
+
+def test_get_admin_emails_falls_back_to_user_email_when_contact_email_blank(app, session):
+    """Assert that blank contact email falls back to users.email."""
+    factory_user_model_for_email_test(
+        username="bcsc/fallback",
+        firstname="John",
+        lastname="Smith",
+        user_email="john.smith@example.com",
+        with_contact=True,
+        contact_email="",
+    )
+
+    emails, name = _get_admin_emails("bcsc/fallback")
+    assert emails == "john.smith@example.com"
+    assert name == "John Smith"
+
+
+def test_get_admin_emails_user_not_found_raises(app, session):
+    """Assert that a missing username raises ValueError."""
+    with pytest.raises(ValueError, match="Admin user not found, cannot determine email address."):
+        _get_admin_emails("bcsc/doesnotexist")

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -792,5 +792,5 @@ def test_get_admin_emails_falls_back_to_user_email_when_contact_email_blank(app,
 
 def test_get_admin_emails_user_not_found_raises(app, session):
     """Assert that a missing username raises ValueError."""
-    with pytest.raises(ValueError, match="Admin user not found, cannot determine email address."):
+    with pytest.raises(ValueError, match="Admin user not found for username"):
         _get_admin_emails("bcsc/doesnotexist")


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33376
https://github.com/bcgov/entity/issues/33397

*Description of changes:*
Fixes PAD account-create email failures (#33376) by 
(1) hardening account-mailer recipient resolution (safe admin name, contact→user email fallback, fail fast when no recipient email) 
(2) saving user contact before org creation in account setup flows to avoid a race where PAD email runs before contact data exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
