### PR TITLE
33386: Fix StaleDataError race condition in process_name_events

### DIFF
--- a/queue_services/auth-queue/src/auth_queue/resources/worker.py
+++ b/queue_services/auth-queue/src/auth_queue/resources/worker.py
@@ -205,7 +205,7 @@ def process_name_events(event_message: SimpleCloudEvent):
             org: OrgModel = db.session.query(OrgModel).filter(OrgModel.id == int(auth_account_id or -1)).one_or_none()
             # If account is present and is not a gov account, then affiliate.
             if org and org.access_type != AccessType.GOVM.value:
-                # Load/create entity HERE (after the slow PAY API call) so it stays
+                # Load/create entity HERE (after the PAY API calls) so it stays
                 # in the session for the shortest possible time before being saved.
                 nr_entity = EntityModel.find_by_business_identifier(nr_number)
                 if nr_entity is None:

--- a/queue_services/auth-queue/src/auth_queue/resources/worker.py
+++ b/queue_services/auth-queue/src/auth_queue/resources/worker.py
@@ -175,16 +175,13 @@ def process_name_events(event_message: SimpleCloudEvent):
     request_data = event_message.data.get("request") or event_message.data.get("name")
     nr_number = request_data["nrNum"]
     nr_status = request_data["newState"]
-    nr_entity = EntityModel.find_by_business_identifier(nr_number)
-    if nr_entity is None:
-        current_app.logger.info("Entity doesn't exist, creating a new entity.")
-        nr_entity = EntityModel(business_identifier=nr_number, corp_type_code=CorpType.NR.value)
 
-    nr_entity.status = nr_status
-    nr_entity.name = request_data.get("name", "")  # its not part of event now, this is to handle if they include it.
-    nr_entity.last_modified_by = None  # TODO not present in event message.
-    nr_entity.last_modified = parser.parse(event_message.time)
-    # Future - None needs to be replaced with whatever we decide to fill the data with.
+    # Do the DRAFT affiliation work BEFORE loading the entity for the final save.
+    # The PAY API call can take several seconds; loading the entity earlier would leave
+    # it dirty in the session for that whole window, creating a race condition where a
+    # concurrent auth-api delete causes StaleDataError on the final UPDATE.
+    affiliated_org: OrgModel | None = None
+    nr_entity: EntityModel | None = None
     if nr_status == "DRAFT" and not AffiliationModel.find_affiliations_by_business_identifier(nr_number):
         current_app.logger.info("Status is DRAFT, getting invoices for account")
         token = None
@@ -208,27 +205,49 @@ def process_name_events(event_message: SimpleCloudEvent):
             org: OrgModel = db.session.query(OrgModel).filter(OrgModel.id == int(auth_account_id or -1)).one_or_none()
             # If account is present and is not a gov account, then affiliate.
             if org and org.access_type != AccessType.GOVM.value:
+                # Load/create entity HERE (after the slow PAY API call) so it stays
+                # in the session for the shortest possible time before being saved.
+                nr_entity = EntityModel.find_by_business_identifier(nr_number)
+                if nr_entity is None:
+                    nr_entity = EntityModel(business_identifier=nr_number, corp_type_code=CorpType.NR.value)
                 nr_entity.pass_code_claimed = True
                 current_app.logger.info(
                     "Creating affiliation between Entity : %s and Org : %s",
                     nr_entity,
                     org,
                 )
-                affiliation: AffiliationModel = AffiliationModel(entity=nr_entity, org=org)
-                affiliation.flush()
-                activity: ActivityLogModel = ActivityLogModel(
-                    org_id=org.id,
-                    action=ActivityAction.CREATE_AFFILIATION.value,
-                    item_name=nr_entity.business_identifier,
-                    item_id=nr_entity.business_identifier,
-                    item_type=None,
-                    item_value=None,
-                    actor_id=None,
-                )
-                activity.flush()
+                AffiliationModel(entity=nr_entity, org=org).flush()
+                affiliated_org = org  # remembered for the activity log written at the end
 
+    # Only look up the entity if the DRAFT block above didn't already load or create it.
+    # This avoids a redundant SELECT and guarantees we use the same object that was
+    # flushed with the affiliation (preserving pass_code_claimed and the session state).
+    if nr_entity is None:
+        nr_entity = EntityModel.find_by_business_identifier(nr_number)
+        if nr_entity is None:
+            current_app.logger.info("Entity doesn't exist, creating a new entity.")
+            nr_entity = EntityModel(business_identifier=nr_number, corp_type_code=CorpType.NR.value)
+    nr_entity.status = nr_status
+    nr_entity.name = request_data.get("name", "")  # its not part of event now, this is to handle if they include it.
+    nr_entity.last_modified_by = None  # TODO not present in event message.
+    nr_entity.last_modified = parser.parse(event_message.time)
     nr_entity.save()
+
+    # Activity log is a pure audit event — write it last so it never blocks the core
+    # entity/affiliation work and is easy to see at the bottom of the function.
+    if affiliated_org:
+        ActivityLogModel(
+            org_id=affiliated_org.id,
+            action=ActivityAction.CREATE_AFFILIATION.value,
+            item_name=nr_entity.business_identifier,
+            item_id=nr_entity.business_identifier,
+            item_type=None,
+            item_value=None,
+            actor_id=None,
+        ).save()
+
     if flags.is_on("enable-entity-mapping", default=False) is True:
         entity_details = {"nrNumber": nr_number}
         EntityMappingService.from_entity_details(entity_details, skip_auth=True)
     current_app.logger.debug("<<<<<<<process_name_events<<<<<<<<<<")
+

--- a/queue_services/auth-queue/src/auth_queue/resources/worker.py
+++ b/queue_services/auth-queue/src/auth_queue/resources/worker.py
@@ -250,4 +250,3 @@ def process_name_events(event_message: SimpleCloudEvent):
         entity_details = {"nrNumber": nr_number}
         EntityMappingService.from_entity_details(entity_details, skip_auth=True)
     current_app.logger.debug("<<<<<<<process_name_events<<<<<<<<<<")
-

--- a/queue_services/auth-queue/tests/unit/test_names_worker_queue.py
+++ b/queue_services/auth-queue/tests/unit/test_names_worker_queue.py
@@ -140,3 +140,150 @@ def test_names_events_listener_queue(  # pylint: disable=too-many-arguments
     entity: EntityModel = EntityModel.find_by_business_identifier(nr_number)
     assert entity
     assert not entity.pass_code_claimed
+
+
+def test_names_events_non_draft_status_updates_existing_entity(
+    app,  # pylint: disable=unused-argument
+    session,  # pylint: disable=unused-argument
+    client,
+    monkeypatch,
+):
+    """Assert that a non-DRAFT state change updates an existing entity without creating an affiliation.
+
+    This covers the path that previously caused StaleDataError: entity already in DB,
+    status changes to APPROVED/CONSUMED/etc., no PAY API call, just an UPDATE.
+    """
+    monkeypatch.setattr(
+        "auth_api.services.rest_service.RestService.get_service_account_token",
+        lambda *_args, **_kwargs: None,
+    )
+
+    nr_number = f"NR {get_random_number()}"
+
+    # First event: create the entity via a DRAFT with no matching invoices.
+    monkeypatch.setattr(
+        "auth_api.services.rest_service.RestService.get",
+        lambda *_args, **_kwargs: _empty_invoices_response(),
+    )
+    helper_add_nr_event_to_queue(client, nr_number, "DRAFT", "TEST")
+
+    entity: EntityModel = EntityModel.find_by_business_identifier(nr_number)
+    assert entity
+    assert entity.status == "DRAFT"
+    assert not entity.pass_code_claimed
+
+    # Second event: status moves to APPROVED — this is the UPDATE path that hit StaleDataError.
+    helper_add_nr_event_to_queue(client, nr_number, "APPROVED", "DRAFT")
+
+    entity = EntityModel.find_by_business_identifier(nr_number)
+    assert entity
+    assert entity.status == "APPROVED"
+    assert not entity.pass_code_claimed
+
+    # No affiliation or activity log should exist.
+    affiliations = AffiliationModel.find_affiliations_by_business_identifier(nr_number)
+    assert len(affiliations) == 0
+    activity_logs = db.session.query(ActivityLogModel).all()
+    assert len(activity_logs) == 0
+
+
+def test_names_events_draft_entity_already_exists(
+    app,  # pylint: disable=unused-argument
+    session,  # pylint: disable=unused-argument
+    client,
+    monkeypatch,
+):
+    """Assert that a DRAFT event affiliates correctly when the entity already exists in the DB.
+
+    Exercises the find_by_business_identifier branch inside the DRAFT block (not the new-entity path).
+    """
+    org = OrgModel(
+        name="Test",
+        org_type=OrgTypeModel.get_default_type(),
+        org_status=OrgStatusModel.get_default_status(),
+        access_type=AccessType.REGULAR.value,
+    ).save()
+    org_id = org.id
+
+    nr_number = f"NR {get_random_number()}"
+
+    # Pre-create the entity so the DRAFT block finds an existing row.
+    monkeypatch.setattr(
+        "auth_api.services.rest_service.RestService.get_service_account_token",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "auth_api.services.rest_service.RestService.get",
+        lambda *_args, **_kwargs: _empty_invoices_response(),
+    )
+    helper_add_nr_event_to_queue(client, nr_number, "DRAFT", "TEST")
+
+    entity: EntityModel = EntityModel.find_by_business_identifier(nr_number)
+    assert entity
+    assert not entity.pass_code_claimed
+
+    # Now send a second DRAFT event with a real org in the invoices.
+    def get_invoices_mock(*_args, **_kwargs):
+        import json
+        from requests.models import Response
+
+        response = Response()
+        response.status_code = 200
+        response._content = str.encode(  # pylint: disable=protected-access
+            json.dumps({"invoices": [{"businessIdentifier": nr_number, "paymentAccount": {"accountId": org_id}}]})
+        )
+        return response
+
+    monkeypatch.setattr("auth_api.services.rest_service.RestService.get", get_invoices_mock)
+    helper_add_nr_event_to_queue(client, nr_number, "DRAFT", "TEST")
+
+    entity = EntityModel.find_by_business_identifier(nr_number)
+    assert entity
+    assert entity.pass_code_claimed
+
+    affiliations = AffiliationModel.find_affiliations_by_org_id(org_id)
+    assert len(affiliations) == 1
+    assert affiliations[0].entity_id == entity.id
+
+    activity_logs = db.session.query(ActivityLogModel).filter(ActivityLogModel.org_id == org_id).all()
+    assert len(activity_logs) == 1
+
+
+def test_names_events_draft_empty_invoices_no_affiliation(
+    app,  # pylint: disable=unused-argument
+    session,  # pylint: disable=unused-argument
+    client,
+    monkeypatch,
+):
+    """Assert that a DRAFT event with empty invoices creates the entity but no affiliation."""
+    monkeypatch.setattr(
+        "auth_api.services.rest_service.RestService.get_service_account_token",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "auth_api.services.rest_service.RestService.get",
+        lambda *_args, **_kwargs: _empty_invoices_response(),
+    )
+
+    nr_number = f"NR {get_random_number()}"
+    helper_add_nr_event_to_queue(client, nr_number, "DRAFT", "TEST")
+
+    entity: EntityModel = EntityModel.find_by_business_identifier(nr_number)
+    assert entity
+    assert entity.status == "DRAFT"
+    assert not entity.pass_code_claimed
+
+    affiliations = AffiliationModel.find_affiliations_by_business_identifier(nr_number)
+    assert len(affiliations) == 0
+    assert len(db.session.query(ActivityLogModel).all()) == 0
+
+
+def _empty_invoices_response():
+    """Return a mock PAY API response with no invoices."""
+    import json
+    from requests.models import Response
+
+    response = Response()
+    response.status_code = 200
+    response._content = str.encode(json.dumps({"invoices": []}))  # pylint: disable=protected-access
+    return response

--- a/queue_services/auth-queue/tests/unit/test_names_worker_queue.py
+++ b/queue_services/auth-queue/tests/unit/test_names_worker_queue.py
@@ -180,10 +180,10 @@ def test_names_events_non_draft_status_updates_existing_entity(
     assert entity.status == "APPROVED"
     assert not entity.pass_code_claimed
 
-    # No affiliation or activity log should exist.
+    # No affiliation or activity log should exist for this NR.
     affiliations = AffiliationModel.find_affiliations_by_business_identifier(nr_number)
     assert len(affiliations) == 0
-    activity_logs = db.session.query(ActivityLogModel).all()
+    activity_logs = db.session.query(ActivityLogModel).filter(ActivityLogModel.item_id == nr_number).all()
     assert len(activity_logs) == 0
 
 
@@ -224,9 +224,6 @@ def test_names_events_draft_entity_already_exists(
 
     # Now send a second DRAFT event with a real org in the invoices.
     def get_invoices_mock(*_args, **_kwargs):
-        import json
-        from requests.models import Response
-
         response = Response()
         response.status_code = 200
         response._content = str.encode(  # pylint: disable=protected-access
@@ -275,14 +272,11 @@ def test_names_events_draft_empty_invoices_no_affiliation(
 
     affiliations = AffiliationModel.find_affiliations_by_business_identifier(nr_number)
     assert len(affiliations) == 0
-    assert len(db.session.query(ActivityLogModel).all()) == 0
+    assert len(db.session.query(ActivityLogModel).filter(ActivityLogModel.item_id == nr_number).all()) == 0
 
 
 def _empty_invoices_response():
     """Return a mock PAY API response with no invoices."""
-    import json
-    from requests.models import Response
-
     response = Response()
     response.status_code = 200
     response._content = str.encode(json.dumps({"invoices": []}))  # pylint: disable=protected-access


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33386

## Description of changes: ##
Fixed race condition causing StaleDataError in process_name_events.

The worker was loading the Entity from the database at the top of process_name_events, then immediately setting fields on it, and only calling save() at the very end; after a potentially multi-second PAY API call. 
This left the entity object dirty in the SQLAlchemy session for the entire duration of that call. If a concurrent auth-api request deleted the entity row during that window, the final UPDATE would match zero rows and SQLAlchemy would raise StaleDataError.

### Fix: ###
- Moved the entity load to after the PAY API call, so it stays in the session for the shortest possible time before being written back
- Moved the activity log write to after nr_entity.save() since it is a audit event and has no role on the core entity/affiliation work

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
