### PR TITLE
33382 - Own PAD setup-in-progress user message in auth-api

### DIFF
--- a/auth-api/src/auth_api/exceptions/errors.py
+++ b/auth-api/src/auth_api/exceptions/errors.py
@@ -125,7 +125,10 @@ class Error(Enum):
     )
     BCEID_USERS_CANT_BE_OWNERS = "BCEID Users cant be owners", HTTPStatus.BAD_REQUEST
     PAYMENT_ACCOUNT_UPSERT_FAILED = "Account upsert failed in Pay", HTTPStatus.INTERNAL_SERVER_ERROR
-    CFS_ACCOUNT_SETUP_IN_PROGRESS = "CFS_ACCOUNT_SETUP_IN_PROGRESS", HTTPStatus.BAD_REQUEST
+    CFS_ACCOUNT_SETUP_IN_PROGRESS = (
+        "Payment account setup is still in progress. Please wait a few minutes and try updating your bank details again.",
+        HTTPStatus.BAD_REQUEST,
+    )
     ACCOUNT_FEES_FETCH_FAILED = "Failed to fetch account fees from Pay API", HTTPStatus.INTERNAL_SERVER_ERROR
     GOVM_ACCOUNT_DATA_MISSING = (
         "GOVM account creation needs payment info , gl code and mailing address",

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -1380,7 +1380,7 @@ def test_create_product_single_subscription_qs(session, monkeypatch):
 
 
 def test_handle_pay_http_error_known_pay_api_code(app):
-    """Assert pay-api type-only response maps to auth Error enum and uses auth message as detail."""
+    """Assert pay-api type-only response maps to auth Error enum; user message is on exception.message."""
     response = Response()
     response.status_code = 400
     response._content = b'{"type": "CFS_ACCOUNT_SETUP_IN_PROGRESS"}'
@@ -1393,4 +1393,4 @@ def test_handle_pay_http_error_known_pay_api_code(app):
 
     assert exc_info.value.code == Error.CFS_ACCOUNT_SETUP_IN_PROGRESS.name
     assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
-    assert exc_info.value.detail == Error.CFS_ACCOUNT_SETUP_IN_PROGRESS.message
+    assert exc_info.value.message == Error.CFS_ACCOUNT_SETUP_IN_PROGRESS.message

--- a/auth-api/tests/unit/services/test_org.py
+++ b/auth-api/tests/unit/services/test_org.py
@@ -1380,10 +1380,10 @@ def test_create_product_single_subscription_qs(session, monkeypatch):
 
 
 def test_handle_pay_http_error_known_pay_api_code(app):
-    """Assert that a known pay-api error type maps to the correct auth Error enum and status."""
+    """Assert pay-api type-only response maps to auth Error enum and uses auth message as detail."""
     response = Response()
     response.status_code = 400
-    response._content = b'{"type": "CFS_ACCOUNT_SETUP_IN_PROGRESS", "detail": "Please wait a few minutes."}'
+    response._content = b'{"type": "CFS_ACCOUNT_SETUP_IN_PROGRESS"}'
 
     http_error = HTTPError(response=response)
 
@@ -1393,4 +1393,4 @@ def test_handle_pay_http_error_known_pay_api_code(app):
 
     assert exc_info.value.code == Error.CFS_ACCOUNT_SETUP_IN_PROGRESS.name
     assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
-    assert exc_info.value.detail == "Please wait a few minutes."
+    assert exc_info.value.detail == Error.CFS_ACCOUNT_SETUP_IN_PROGRESS.message

--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.10.56",
+  "version": "2.10.57",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.10.56",
+      "version": "2.10.57",
       "hasInstallScript": true,
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",

--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.10.57",
+  "version": "2.10.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.10.57",
+      "version": "2.10.56",
       "hasInstallScript": true,
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",

--- a/auth-web/package-lock.json
+++ b/auth-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth-web",
-  "version": "2.10.57",
+  "version": "2.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auth-web",
-      "version": "2.10.57",
+      "version": "2.11.0",
       "hasInstallScript": true,
       "dependencies": {
         "@bcrs-shared-components/base-address": "2.0.39",

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.10.57",
+  "version": "2.10.56",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.10.56",
+  "version": "2.10.57",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-web",
-  "version": "2.10.57",
+  "version": "2.11.0",
   "appName": "Auth Web",
   "sbcName": "SBC Common Components",
   "private": true,

--- a/auth-web/src/components/auth/account-settings/payment/AccountPaymentMethods.vue
+++ b/auth-web/src/components/auth/account-settings/payment/AccountPaymentMethods.vue
@@ -468,11 +468,11 @@ export default defineComponent({
             case 409:
             case 400:
               state.errorText = `${formatText(normalized.code)}<br>` +
-                  `${formatText(normalized.message?.detail) || formatText(normalized.detail) || ''}`.trim()
+                  `${formatText(normalized.message?.detail) || formatText(normalized.message) || ''}`.trim()
 
               state.errorTitle = formatText(normalized.message?.title) ||
                   formatText(normalized.message?.detail) ||
-                  formatText(normalized.detail) ||
+                  formatText(normalized.message) ||
                   'Error'
               break
             default:

--- a/auth-web/tests/unit/components/AccountPaymentMethods.spec.ts
+++ b/auth-web/tests/unit/components/AccountPaymentMethods.spec.ts
@@ -122,15 +122,15 @@ describe('AccountPaymentMethods.vue', () => {
     expect(wrapper.vm.errorText).toBe('BCOL API Error<br>Invalid User ID or Password')
   })
 
-  it('sets errorText and errorTitle correctly for a 400 pay-api error response', async () => {
-    const payApiDetail = 'Payment account setup is still in progress. Please wait a few minutes and try updating your bank details again.'
+  it('sets errorText and errorTitle correctly for a 400 account setup error', async () => {
+    const authApiMessage = 'Payment account setup is still in progress. Please wait a few minutes and try updating your bank details again.'
     await saveWithMockError({
       code: 'CFS_ACCOUNT_SETUP_IN_PROGRESS',
-      message: 'CFS_ACCOUNT_SETUP_IN_PROGRESS',
-      detail: payApiDetail
+      message: authApiMessage,
+      detail: authApiMessage
     })
 
-    expect(wrapper.vm.errorTitle).toBe(payApiDetail)
-    expect(wrapper.vm.errorText).toBe(`Cfs Account Setup In Progress<br>${payApiDetail}`)
+    expect(wrapper.vm.errorTitle).toBe(authApiMessage)
+    expect(wrapper.vm.errorText).toBe(`Cfs Account Setup In Progress<br>${authApiMessage}`)
   })
 })

--- a/auth-web/tests/unit/components/AccountPaymentMethods.spec.ts
+++ b/auth-web/tests/unit/components/AccountPaymentMethods.spec.ts
@@ -122,15 +122,14 @@ describe('AccountPaymentMethods.vue', () => {
     expect(wrapper.vm.errorText).toBe('BCOL API Error<br>Invalid User ID or Password')
   })
 
-  it('sets errorText and errorTitle correctly for a 400 pay-api error response', async () => {
-    const payApiDetail = 'Payment account setup is still in progress. Please wait a few minutes and try updating your bank details again.'
+  it('sets errorText and errorTitle correctly for a 400 CFS account setup error', async () => {
+    const authApiMessage = 'Payment account setup is still in progress. Please wait a few minutes and try updating your bank details again.'
     await saveWithMockError({
       code: 'CFS_ACCOUNT_SETUP_IN_PROGRESS',
-      message: 'CFS_ACCOUNT_SETUP_IN_PROGRESS',
-      detail: payApiDetail
+      message: authApiMessage
     })
 
-    expect(wrapper.vm.errorTitle).toBe(payApiDetail)
-    expect(wrapper.vm.errorText).toBe(`Cfs Account Setup In Progress<br>${payApiDetail}`)
+    expect(wrapper.vm.errorTitle).toBe(authApiMessage)
+    expect(wrapper.vm.errorText).toBe(`Cfs Account Setup In Progress<br>${authApiMessage}`)
   })
 })

--- a/auth-web/tests/unit/components/AccountPaymentMethods.spec.ts
+++ b/auth-web/tests/unit/components/AccountPaymentMethods.spec.ts
@@ -122,15 +122,15 @@ describe('AccountPaymentMethods.vue', () => {
     expect(wrapper.vm.errorText).toBe('BCOL API Error<br>Invalid User ID or Password')
   })
 
-  it('sets errorText and errorTitle correctly for a 400 account setup error', async () => {
-    const authApiMessage = 'Payment account setup is still in progress. Please wait a few minutes and try updating your bank details again.'
+  it('sets errorText and errorTitle correctly for a 400 pay-api error response', async () => {
+    const payApiDetail = 'Payment account setup is still in progress. Please wait a few minutes and try updating your bank details again.'
     await saveWithMockError({
       code: 'CFS_ACCOUNT_SETUP_IN_PROGRESS',
-      message: authApiMessage,
-      detail: authApiMessage
+      message: 'CFS_ACCOUNT_SETUP_IN_PROGRESS',
+      detail: payApiDetail
     })
 
-    expect(wrapper.vm.errorTitle).toBe(authApiMessage)
-    expect(wrapper.vm.errorText).toBe(`Cfs Account Setup In Progress<br>${authApiMessage}`)
+    expect(wrapper.vm.errorTitle).toBe(payApiDetail)
+    expect(wrapper.vm.errorText).toBe(`Cfs Account Setup In Progress<br>${payApiDetail}`)
   })
 })


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33382

*Description of changes:*

when the error is only surfaced through auth-api → auth-web (e.g. account deactivate: OUTSTANDING_CREDIT). Pay-api should return type only; auth maps the code, sets HTTP status, and supplies user-facing text.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
