### PR TITLE
33929 - Unaffiliated invitation bypass for business details

### DIFF
--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -58,7 +58,7 @@ from auth_api.utils.enums import (
     QueueMessageType,
     Status,
 )
-from auth_api.utils.roles import ADMIN, CLIENT_AUTH_ROLES, COORDINATOR, Role, STAFF, USER
+from auth_api.utils.roles import ADMIN, CLIENT_AUTH_ROLES, COORDINATOR, STAFF, USER, Role
 from auth_api.utils.user_context import UserContext, user_context
 from auth_api.utils.util import escape_wam_friendly_url
 

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -56,10 +56,9 @@ from auth_api.utils.enums import (
     InvitationStatus,
     LoginSource,
     QueueMessageType,
-    Role,
     Status,
 )
-from auth_api.utils.roles import ADMIN, CLIENT_AUTH_ROLES, COORDINATOR, STAFF, USER
+from auth_api.utils.roles import ADMIN, CLIENT_AUTH_ROLES, COORDINATOR, Role, STAFF, USER
 from auth_api.utils.user_context import UserContext, user_context
 from auth_api.utils.util import escape_wam_friendly_url
 

--- a/auth-api/src/auth_api/services/affiliation_invitation.py
+++ b/auth-api/src/auth_api/services/affiliation_invitation.py
@@ -56,6 +56,7 @@ from auth_api.utils.enums import (
     InvitationStatus,
     LoginSource,
     QueueMessageType,
+    Role,
     Status,
 )
 from auth_api.utils.roles import ADMIN, CLIENT_AUTH_ROLES, COORDINATOR, STAFF, USER
@@ -875,12 +876,14 @@ class AffiliationInvitation:
                 raise BusinessException(Error.INVALID_AFFILIATION_INVITATION_TYPE, None)
 
     @staticmethod
-    def send_unaffiliated_email_invitation(entity: EntityService):
+    @user_context
+    def send_unaffiliated_email_invitation(entity: EntityService, **kwargs):
         """Send an UNAFFILIATED_EMAIL affiliation invitation to entity contact. SYSTEM access only.
 
         If a pending invitation already exists for the same email, update it and resend.
         If the email has changed, create a new invitation row.
         """
+        user_from_context: UserContext = kwargs["user_context"]
         if AffiliationModel.find_affiliations_by_entity_id(entity.identifier):
             raise BusinessException(Error.AFFILIATION_ALREADY_EXISTS, None)
 
@@ -918,16 +921,18 @@ class AffiliationInvitation:
         affiliation_invitation.login_source = LoginSource.BCSC.value
         affiliation_invitation.save()
 
-        token = RestService.get_service_account_token(
-            config_id="ENTITY_SVC_CLIENT_ID",
-            config_secret="ENTITY_SVC_CLIENT_SECRET",  # noqa: S106
-        )
-        business = AffiliationInvitation._get_business_details(entity.business_identifier, token)
-        business_name = business["business"]["legalName"]
-        if business["business"]["legalType"] in ["SP", "GP"]:
-            business_name = AffiliationInvitation.get_business_name_from_alternative_name(
-                business, business_name, entity.business_identifier
+        business_name = entity.name
+        if not user_from_context.has_role(Role.SKIP_UNAFFILIATED_BUSINESS_CHECK.value):
+            token = RestService.get_service_account_token(
+                config_id="ENTITY_SVC_CLIENT_ID",
+                config_secret="ENTITY_SVC_CLIENT_SECRET",  # noqa: S106
             )
+            business = AffiliationInvitation._get_business_details(entity.business_identifier, token)
+            business_name = business["business"]["legalName"]
+            if business["business"]["legalType"] in ["SP", "GP"]:
+                business_name = AffiliationInvitation.get_business_name_from_alternative_name(
+                    business, business_name, entity.business_identifier
+                )
 
         registry_home_url = current_app.config.get("REGISTRY_HOME_URL")
         context_url = f"{registry_home_url}?preset=bcscUser&token={confirmation_token}"

--- a/auth-api/src/auth_api/utils/roles.py
+++ b/auth-api/src/auth_api/utils/roles.py
@@ -45,6 +45,9 @@ class Role(Enum):
     # Used by Business-AR / Contact Centre Staff / Maximus Staff to create affiliations (and bypass passcode check)
     SKIP_AFFILIATION_AUTH = "skip_affiliation_auth"
 
+    # Used by entities data migration client. Bypasses business detail calls.
+    SKIP_UNAFFILIATED_BUSINESS_CHECK = "skip_unaffiliated_business_check"
+
     STAFF_TASK_SEARCH = "staff_task_search"
     VIEW_TASK_DETAILS = "view_task_details"
     VIEW_ACCOUNT_PENDING_INVITATIONS = "view_account_pending_invitations"

--- a/auth-api/tests/unit/api/test_affiliation_invitation.py
+++ b/auth-api/tests/unit/api/test_affiliation_invitation.py
@@ -19,6 +19,7 @@ Test-Suite to ensure that the /affiliationsInvitations endpoint is working as ex
 
 import json
 from http import HTTPStatus
+from unittest.mock import patch
 
 import pytest
 
@@ -1125,6 +1126,30 @@ def test_send_unaffiliated_email_invitation(
         content_type="application/json",
     )
     assert rv.status_code == HTTPStatus.CREATED
+
+
+def test_send_unaffiliated_email_invitation_skips_business_check_with_role(client, jwt, session, keycloak_mock):
+    """Assert that business details service calls are skipped when SKIP_UNAFFILIATED_BUSINESS_CHECK role is present."""
+    business_identifier = setup_entity_with_contact(client, jwt)
+    claims = {
+        **TestJwtClaims.system_role,
+        "realm_access": {"roles": ["system", "skip_unaffiliated_business_check"]},
+    }
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    with (
+        patch("auth_api.services.affiliation_invitation.RestService.get_service_account_token") as mock_token,
+        patch("auth_api.services.affiliation_invitation.AffiliationInvitation._get_business_details") as mock_business,
+    ):
+        rv = client.post(
+            f"/api/v1/affiliationInvitations/unaffiliated/{business_identifier}",
+            headers=headers,
+            content_type="application/json",
+        )
+
+    assert rv.status_code == HTTPStatus.CREATED
+    mock_token.assert_not_called()
+    mock_business.assert_not_called()
 
 
 def test_send_unaffiliated_email_invitation_idempotent(


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33929

*Description of changes:*
- add in support for skipping business details by role for migration processes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
