### PR TITLE
chore: upgrade packageManager to pnpm@11.9.0

### DIFF
--- a/auth-web/package.json
+++ b/auth-web/package.json
@@ -97,5 +97,6 @@
     "vue-template-compiler": "2.6.14",
     "vue-test-utils-helpers": "git+https://github.com/AmpleOrganics/vue-test-utils-helpers.git",
     "vuelidate-property-decorators": "^1.0.28"
-  }
+  },
+  "packageManager": "pnpm@11.9.0"
 }


### PR DESCRIPTION
Sets `packageManager` to `pnpm@11.9.0` in `auth-web/package.json` as part of the pnpm v11 upgrade (ticket #33875).

The Cloud Build CI trigger has already been updated to use `pnpm@11.9.0`.