### PR TITLE
33789 - account link notifications

### DIFF
--- a/auth-api/poetry.lock
+++ b/auth-api/poetry.lock
@@ -3305,8 +3305,8 @@ jaeger-client = "*"
 [package.source]
 type = "git"
 url = "https://github.com/bcgov/sbc-common-components.git"
-reference = "ae0f031d40d51d86a7ac9e500be0b97fc10f19a7"
-resolved_reference = "ae0f031d40d51d86a7ac9e500be0b97fc10f19a7"
+reference = "d6e4ff25af28a1d46666550683349fdeb3907c67"
+resolved_reference = "d6e4ff25af28a1d46666550683349fdeb3907c67"
 subdirectory = "python"
 
 [[package]]
@@ -3896,4 +3896,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "00c23176b017c7bcb1b50f7f8072b3e45daec4a6eff54d3843ef602fd2646855"
+content-hash = "79793506e8203e549c3698223f0d0126aa997a18f157e445322246fdd42d24e2"

--- a/auth-api/pyproject.toml
+++ b/auth-api/pyproject.toml
@@ -52,7 +52,7 @@ Werkzeug = "^3.1.5"
 # VCS dependencies
 sql-versioning = { git = "https://github.com/bcgov/sbc-connect-common.git", subdirectory = "python/sql-versioning", branch = "add_column_exclusion" }
 flask-jwt-oidc = {git = "https://github.com/seeker25/flask-jwt-oidc.git", branch = "main" }
-sbc-common-components = { git = "https://github.com/bcgov/sbc-common-components.git", rev = "ae0f031d40d51d86a7ac9e500be0b97fc10f19a7", subdirectory = "python" }
+sbc-common-components = { git = "https://github.com/bcgov/sbc-common-components.git", rev = "d6e4ff25af28a1d46666550683349fdeb3907c67", subdirectory = "python" }
 cloud-sql-connector = { git = "https://github.com/bcgov/sbc-connect-common.git", subdirectory = "python/cloud-sql-connector", branch = "main" }
 gcp-queue = { git = "https://github.com/bcgov/sbc-connect-common.git", subdirectory = "python/gcp-queue", branch = "main" }
 structured-logging = { git = "https://github.com/bcgov/sbc-connect-common.git", subdirectory = "python/structured-logging", branch = "main" }

--- a/auth-api/src/auth_api/services/account_linking_key.py
+++ b/auth-api/src/auth_api/services/account_linking_key.py
@@ -19,11 +19,14 @@ import secrets
 from datetime import UTC, datetime, timedelta
 
 from flask import current_app
+from sbc_common_components.utils.enums import QueueMessageTypes
 
 from auth_api.models.account_linking_key import AccountLinkingKey as AccountLinkingKeyModel
 from auth_api.models.dataclass import Activity
 from auth_api.models.db import db
 from auth_api.services.activity_log_publisher import ActivityLogPublisher
+from auth_api.utils.account_mailer import publish_to_mailer
+from auth_api.utils.date import pacific_today_isoformat
 from auth_api.utils.enums import ActivityAction, LinkingKeyStatus
 
 
@@ -56,6 +59,9 @@ class AccountLinkingKey:
         record.save()
 
         AccountLinkingKey._publish(ActivityAction.LINKING_KEY_GENERATED.value, record)
+        if record.status == LinkingKeyStatus.ACTIVE.value:
+            data = {"linkDate": pacific_today_isoformat()}
+            AccountLinkingKey._publish_mailer_notification(QueueMessageTypes.ACCOUNT_LINK_CREATED.value, record, data)
         return record
 
     @staticmethod
@@ -69,9 +75,13 @@ class AccountLinkingKey:
         record = AccountLinkingKeyModel.find_by_id(key_id, account_id)
         if not record:
             return False
+        was_active = record.status == LinkingKeyStatus.ACTIVE.value
         record.status = LinkingKeyStatus.REVOKED.value
         record.save()
         AccountLinkingKey._publish(ActivityAction.LINKING_KEY_REVOKED.value, record)
+        if was_active:
+            data = {"linkRemovalDate": pacific_today_isoformat()}
+            AccountLinkingKey._publish_mailer_notification(QueueMessageTypes.ACCOUNT_LINK_REMOVED.value, record, data)
         return True
 
     @staticmethod
@@ -113,6 +123,8 @@ class AccountLinkingKey:
         record.save()
 
         AccountLinkingKey._publish(ActivityAction.LINKING_KEY_BOUND.value, record)
+        data = {"linkDate": pacific_today_isoformat()}
+        AccountLinkingKey._publish_mailer_notification(QueueMessageTypes.ACCOUNT_LINK_CREATED.value, record, data)
         return record
 
     # -- private helpers --
@@ -143,3 +155,19 @@ class AccountLinkingKey:
                 value=AccountLinkingKey._vendor_label(record),
             )
         )
+
+    @staticmethod
+    def _publish_mailer_notification(
+        notification_type: str, record: AccountLinkingKeyModel, additional_data: dict[str, str]
+    ) -> None:
+        """Publish an account-link email notification to the account mailer."""
+        data = {
+            "accountId": record.account_id,
+            "serviceProviderName": record.vendor_account.name,
+            **additional_data,
+        }
+        try:
+            publish_to_mailer(notification_type, data=data)
+        except Exception as e:  # noqa: B901
+            current_app.logger.warning(f"AccountLinkingKey._publish_mailer_notification failed: {e}")
+

--- a/auth-api/src/auth_api/utils/date.py
+++ b/auth-api/src/auth_api/utils/date.py
@@ -18,6 +18,11 @@ import datetime as dt
 import pytz
 
 
+def pacific_today_isoformat() -> str:
+    """Return today's date in Canada/Pacific time, as an ISO date string."""
+    return dt.datetime.now(pytz.timezone("Canada/Pacific")).date().isoformat()
+
+
 def str_to_utc_dt(date: str, add_time: bool):
     """Convert ISO formatted dates into dateTime objects in UTC."""
     time_zone = pytz.timezone("Canada/Pacific")

--- a/auth-api/tests/unit/api/test_org_linking_keys.py
+++ b/auth-api/tests/unit/api/test_org_linking_keys.py
@@ -17,6 +17,7 @@ import copy
 import json
 from http import HTTPStatus
 
+from auth_api.utils.enums import LinkingKeyStatus
 from tests.utilities.factory_scenarios import TestJwtClaims, TestUserInfo
 from tests.utilities.factory_utils import (
     factory_auth_header,
@@ -216,8 +217,24 @@ def test_revoke_linking_key_by_id(client, jwt, session):  # pylint:disable=unuse
     """Assert that DELETE revokes a specific linking key by ID."""
     user = factory_user_model(TestUserInfo.user1)
     org = factory_org_model()
+    vendor = factory_org_model()
     factory_membership_model(user.id, org.id)
-    record = factory_linking_key_model(account_id=org.id)
+    record = factory_linking_key_model(account_id=org.id, vendor_account_id=vendor.id)
+
+    headers = _account_holder_headers(jwt, user)
+    rv = client.delete(f"/api/v1/orgs/{org.id}/linking-keys/{record.id}", headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+
+    rv_list = client.get(f"/api/v1/orgs/{org.id}/linking-keys", headers=headers)
+    assert rv_list.json.get("linkingKeys") == []
+
+
+def test_revoke_pending_linking_key_by_id(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert that DELETE revokes a PENDING (unbound) linking key by ID."""
+    user = factory_user_model(TestUserInfo.user1)
+    org = factory_org_model()
+    factory_membership_model(user.id, org.id)
+    record = factory_linking_key_model(account_id=org.id, status=LinkingKeyStatus.PENDING.value)
 
     headers = _account_holder_headers(jwt, user)
     rv = client.delete(f"/api/v1/orgs/{org.id}/linking-keys/{record.id}", headers=headers)

--- a/auth-api/tests/unit/services/test_account_linking_key.py
+++ b/auth-api/tests/unit/services/test_account_linking_key.py
@@ -14,6 +14,10 @@
 """Tests for the AccountLinkingKey service."""
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from freezegun import freeze_time
+from sbc_common_components.utils.enums import QueueMessageTypes
 
 from auth_api.models.account_linking_key import AccountLinkingKey as AccountLinkingKeyModel
 from auth_api.services.account_linking_key import AccountLinkingKey as AccountLinkingKeyService
@@ -98,7 +102,8 @@ def test_get_all_returns_active_keys(session):  # pylint:disable=unused-argument
 def test_revoke_sets_status_to_revoked(session):  # pylint:disable=unused-argument
     """Assert that revoke changes the key status to REVOKED."""
     org = factory_org_model()
-    record = factory_linking_key_model(account_id=org.id)
+    vendor = factory_org_model()
+    record = factory_linking_key_model(account_id=org.id, vendor_account_id=vendor.id)
 
     found = AccountLinkingKeyService.revoke(record.id, org.id)
 
@@ -190,3 +195,81 @@ def test_validate_updates_last_used(session):  # pylint:disable=unused-argument
 
     updated = AccountLinkingKeyModel.query.get(record.id)
     assert updated.last_used is not None
+
+
+@freeze_time("2026-07-01 12:00:00+00:00")
+def test_generate_with_vendor_publishes_link_created(session):  # pylint:disable=unused-argument
+    """Assert that generating an immediately-active key publishes an ACCOUNT_LINK_CREATED notification."""
+    lawfirm = factory_org_model()
+    vendor = factory_org_model()
+
+    with patch("auth_api.services.account_linking_key.publish_to_mailer") as mock_publish:
+        record = AccountLinkingKeyService.generate(lawfirm.id, vendor_account_id=vendor.id)
+
+    mock_publish.assert_called_once()
+    notification_type, kwargs = mock_publish.call_args.args[0], mock_publish.call_args.kwargs
+    assert notification_type == QueueMessageTypes.ACCOUNT_LINK_CREATED.value
+    assert kwargs["data"]["accountId"] == lawfirm.id
+    assert kwargs["data"]["serviceProviderName"] == vendor.name
+    assert kwargs["data"]["linkDate"] == "2026-07-01"
+    assert record.status == LinkingKeyStatus.ACTIVE.value
+
+
+def test_generate_without_vendor_does_not_publish(session):  # pylint:disable=unused-argument
+    """Assert that generating a PENDING key does not publish a mailer notification."""
+    lawfirm = factory_org_model()
+
+    with patch("auth_api.services.account_linking_key.publish_to_mailer") as mock_publish:
+        AccountLinkingKeyService.generate(lawfirm.id)
+
+    mock_publish.assert_not_called()
+
+
+@freeze_time("2026-07-01 12:00:00+00:00")
+def test_bind_publishes_link_created(session):  # pylint:disable=unused-argument
+    """Assert that binding a PENDING key publishes an ACCOUNT_LINK_CREATED notification."""
+    lawfirm = factory_org_model()
+    vendor = factory_org_model()
+    pending_key = factory_linking_key_model(account_id=lawfirm.id, status=LinkingKeyStatus.PENDING.value)
+
+    with patch("auth_api.services.account_linking_key.publish_to_mailer") as mock_publish:
+        record = AccountLinkingKeyService.bind(pending_key.linking_key, vendor.id)
+
+    mock_publish.assert_called_once()
+    notification_type, kwargs = mock_publish.call_args.args[0], mock_publish.call_args.kwargs
+    assert notification_type == QueueMessageTypes.ACCOUNT_LINK_CREATED.value
+    assert kwargs["data"]["accountId"] == lawfirm.id
+    assert kwargs["data"]["serviceProviderName"] == vendor.name
+    assert kwargs["data"]["linkDate"] == "2026-07-01"
+    assert record.status == LinkingKeyStatus.ACTIVE.value
+
+
+@freeze_time("2026-07-01 12:00:00+00:00")
+def test_revoke_active_key_publishes_link_removed(session):  # pylint:disable=unused-argument
+    """Assert that revoking an ACTIVE key publishes an ACCOUNT_LINK_REMOVED notification."""
+    lawfirm = factory_org_model()
+    vendor = factory_org_model()
+    record = factory_linking_key_model(account_id=lawfirm.id, vendor_account_id=vendor.id)
+
+    with patch("auth_api.services.account_linking_key.publish_to_mailer") as mock_publish:
+        found = AccountLinkingKeyService.revoke(record.id, lawfirm.id)
+
+    assert found is True
+    mock_publish.assert_called_once()
+    notification_type, kwargs = mock_publish.call_args.args[0], mock_publish.call_args.kwargs
+    assert notification_type == QueueMessageTypes.ACCOUNT_LINK_REMOVED.value
+    assert kwargs["data"]["accountId"] == lawfirm.id
+    assert kwargs["data"]["serviceProviderName"] == vendor.name
+    assert kwargs["data"]["linkRemovalDate"] == "2026-07-01"
+
+
+def test_revoke_pending_key_does_not_publish(session):  # pylint:disable=unused-argument
+    """Assert that revoking a PENDING key (never active) does not publish a mailer notification."""
+    lawfirm = factory_org_model()
+    record = factory_linking_key_model(account_id=lawfirm.id, status=LinkingKeyStatus.PENDING.value)
+
+    with patch("auth_api.services.account_linking_key.publish_to_mailer") as mock_publish:
+        found = AccountLinkingKeyService.revoke(record.id, lawfirm.id)
+
+    assert found is True
+    mock_publish.assert_not_called()

--- a/queue_services/account-mailer/src/account_mailer/auth_utils.py
+++ b/queue_services/account-mailer/src/account_mailer/auth_utils.py
@@ -40,6 +40,12 @@ def get_transaction_url(org_id: str) -> str:
     transaction_url = f"{web_app_url}/account/{org_id}/settings/transactions"
     return transaction_url
 
+def get_vendor_connections_url(org_id: str) -> str:
+    """Get vendor connections url."""
+    web_app_url = current_app.config.get("WEB_APP_URL")
+    connections_url = f"{web_app_url}/account/{org_id}/settings/vendor-connections"
+    return connections_url
+
 
 def get_dashboard_url():
     """Get application dashboard url."""

--- a/queue_services/account-mailer/src/account_mailer/email_processors/common_mailer.py
+++ b/queue_services/account-mailer/src/account_mailer/email_processors/common_mailer.py
@@ -17,7 +17,13 @@
 from flask import current_app
 from jinja2 import Template
 
-from account_mailer.auth_utils import get_brd_url, get_dashboard_url, get_login_url, get_payment_statements_url
+from account_mailer.auth_utils import (
+    get_brd_url,
+    get_dashboard_url,
+    get_login_url,
+    get_payment_statements_url,
+    get_vendor_connections_url,
+)
 from account_mailer.email_processors import generate_template
 from account_mailer.email_processors.utils import get_account_info
 
@@ -40,6 +46,7 @@ def process(org_id, recipients, template_name, subject, logo_url, **kwargs) -> d
         "logo_url": logo_url,
         "dashboard_url": get_dashboard_url(),
         "payment_statement_url": get_payment_statements_url(org_id),
+        "vendor_connections_url": get_vendor_connections_url(org_id),
         "brd_url": get_brd_url(),
         **kwargs,
     }

--- a/queue_services/account-mailer/src/account_mailer/email_templates/account_link_created_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/account_link_created_email.html
@@ -1,0 +1,20 @@
+# New Third-Party Service Provider Connected
+
+**Service Provider Name:** {{ service_provider_name }}
+**Date Added:** {{ link_date }}
+**Account Number:** {{ account_number }}
+**Account Name:** {{ account_name_with_branch }}
+
+You are receiving this email because you are listed as the account administrator or coordinator for this account.
+
+**What this change means for you:**
+* This connection lets you view and manage records in the service provider's application.
+* For security purposes, third-party connections are valid for one year. Your connection with {{ service_provider_name }} will expire on {{ expiry_date }}.
+* To view connection details or manage service provider access, visit your account settings page and [manage third-party connections]({{ context_url }}).
+
+If you did not authorize this action, please secure your account and manage the connection immediately.
+
+---
+
+**BC Registries and Digital Services**
+Email: [BCRegistries@gov.bc.ca](BCRegistries@gov.bc.ca)

--- a/queue_services/account-mailer/src/account_mailer/email_templates/account_link_expiry_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/account_link_expiry_email.html
@@ -1,0 +1,28 @@
+{% if is_reminder %}
+    {% set title = 'Action Required: Upcoming Expiry of Third-Party Service Provider Connection'%}
+    {% set expiry_information = 'For security purposes, third-party connections are valid for one year. Your connection with ' ~ service_provider_name ~ ' will expire in 30 days.'%}
+{% else %}
+    {% set title = 'Expired Third-Party Service Provider Connection'%}
+    {% set expiry_information = 'Your connection with ' ~ service_provider_name ~ ' is expired.'%}
+{% endif %}
+
+**Service Provider Name:** {{ service_provider_name }}
+**Date Added:** {{ link_date }}
+**Expiration Date:** {{ expiry_date }}
+**Account Number:** {{ account_number }}
+**Account Name:** {{ account_name_with_branch }}
+
+You are receiving this email because you are listed as the account administrator or coordinator for this account.
+
+
+**What this change means for you:**
+* {{ expiry_information }}
+* To prevent a disruption in service, please log in to renew this connection.
+* To view connection details or manage service provider access, visit your account settings page and [manage third-party connections]({{ context_url }}).
+
+If you did not authorize this action, please secure your account and manage the connection immediately.
+
+---
+
+**BC Registries and Digital Services**
+Email: [BCRegistries@gov.bc.ca](BCRegistries@gov.bc.ca)

--- a/queue_services/account-mailer/src/account_mailer/email_templates/account_link_removed_email.html
+++ b/queue_services/account-mailer/src/account_mailer/email_templates/account_link_removed_email.html
@@ -1,0 +1,19 @@
+# New Third-Party Service Provider Removed
+
+**Service Provider Name:** {{ service_provider_name }}
+**Date Removed:** {{ link_removal_date }}
+**Account Number:** {{ account_number }}
+**Account Name:** {{ account_name_with_branch }}
+
+You are receiving this email because you are listed as the account administrator or coordinator for this account.
+
+**What this change means for you:**
+* You no longer have access to view or manage records in the service provider's application.
+* To view connection details or manage service provider access, visit your account settings page and [manage third-party connections]({{ context_url }}).
+
+If you did not authorize this action, please secure your account and manage the connection immediately.
+
+---
+
+**BC Registries and Digital Services**
+Email: [BCRegistries@gov.bc.ca](BCRegistries@gov.bc.ca)

--- a/queue_services/account-mailer/src/account_mailer/enums.py
+++ b/queue_services/account-mailer/src/account_mailer/enums.py
@@ -94,6 +94,10 @@ class SubjectType(Enum):
         "[BC Registries and Online Services] Manage Your Business on BC Registries"
     )
     AFFILIATION_CONFIRMATION_EMAIL = "[BC Registries and Online Services] You’re Ready to Manage Your Business in the BC Business Registry"
+    ACCOUNT_LINK_CREATED = "New Third-Party Service Provider Connected"
+    ACCOUNT_LINK_REMOVED = "Third-Party Service Provider Removed"
+    ACCOUNT_LINK_EXPIRY_REMINDER = "Action Required: Upcoming Expiry of Third-Party Service Provider Connection"
+    ACCOUNT_LINK_EXPIRED = "Expired Third-Party Service Provider Connection"
 
 
 class TitleType(Enum):
@@ -174,6 +178,9 @@ class TemplateType(Enum):
     EFT_AVAILABLE_NOTIFICATION_TEMPLATE_NAME = "eft_available_notification"
     AFFILIATION_INVITATION_UNAFFILIATED_EMAIL_TEMPLATE_NAME = "affiliation_invitation_unaffiliated_email"
     AFFILIATION_CONFIRMATION_EMAIL_TEMPLATE_NAME = "affiliation_confirmation_email"
+    ACCOUNT_LINK_CREATED_TEMPLATE_NAME = "account_link_created_email"
+    ACCOUNT_LINK_REMOVED_TEMPLATE_NAME = "account_link_removed_email"
+    ACCOUNT_LINK_EXPIRY_TEMPLATE_NAME = "account_link_expiry_email"
 
 
 class Constants(Enum):

--- a/queue_services/account-mailer/src/account_mailer/resources/worker.py
+++ b/queue_services/account-mailer/src/account_mailer/resources/worker.py
@@ -27,7 +27,13 @@ from auth_api.utils.roles import ADMIN, COORDINATOR
 from flask import Blueprint, current_app, request
 from sbc_common_components.utils.enums import QueueMessageTypes
 
-from account_mailer.auth_utils import get_dashboard_url, get_login_url, get_member_emails, get_transaction_url
+from account_mailer.auth_utils import (
+    get_dashboard_url,
+    get_login_url,
+    get_member_emails,
+    get_transaction_url,
+    get_vendor_connections_url,
+)
 from account_mailer.email_processors import (
     account_unlock,
     common_mailer,
@@ -77,6 +83,7 @@ def worker():
         handle_product_actions(message_type, email_msg)
         handle_statement_notification(message_type, email_msg)
         handle_payment_reminder_or_due(message_type, email_msg)
+        handle_account_link_notification(message_type, email_msg)
 
         # Note if you're extending above, make sure to include the new type in handle_other_messages below.
         handle_other_messages(message_type, email_msg)
@@ -533,6 +540,44 @@ def handle_payment_reminder_or_due(message_type, email_msg):
     )
     process_email(email_dict)
 
+def handle_account_link_notification(message_type, email_msg):
+    """Handle account link notification message."""
+    is_reminder = email_msg.get("isReminder", False)
+    match message_type:
+        case QueueMessageTypes.ACCOUNT_LINK_CREATED.value:
+            template_name = TemplateType.ACCOUNT_LINK_CREATED_TEMPLATE_NAME.value
+            subject = SubjectType.ACCOUNT_LINK_CREATED.value
+        case QueueMessageTypes.ACCOUNT_LINK_REMOVED.value:
+            template_name = TemplateType.ACCOUNT_LINK_REMOVED_TEMPLATE_NAME.value
+            subject = SubjectType.ACCOUNT_LINK_REMOVED.value
+        case QueueMessageTypes.ACCOUNT_LINK_EXPIRY.value:
+            template_name = TemplateType.ACCOUNT_LINK_EXPIRY_TEMPLATE_NAME.value
+            subject = SubjectType.ACCOUNT_LINK_EXPIRY_REMINDER.value if is_reminder \
+                else SubjectType.ACCOUNT_LINK_EXPIRED.value
+        case _:
+            return
+
+    org_id = email_msg.get("accountId")
+    recipients = get_member_emails(org_id, (ADMIN,COORDINATOR))
+
+    context_url = get_vendor_connections_url(org_id)
+    logo_url = email_msg.get("logo_url")
+    args = {"is_reminder": is_reminder,
+            "service_provider_name": email_msg.get("serviceProviderName", None),
+            "link_date": email_msg.get("linkDate", None),
+            "link_removal_date": email_msg.get("linkRemovalDate", None)
+            }
+    email_dict = common_mailer.process(
+        org_id,
+        recipients,
+        template_name,
+        subject,
+        logo_url=logo_url,
+        context_url=context_url,
+        **args
+    )
+    process_email(email_dict)
+
 
 def handle_other_messages(message_type, email_msg):
     """Handle the other messages not in the list."""
@@ -562,6 +607,9 @@ def handle_other_messages(message_type, email_msg):
         QueueMessageTypes.STATEMENT_NOTIFICATION.value,
         QueueMessageTypes.PAYMENT_REMINDER_NOTIFICATION.value,
         QueueMessageTypes.PAYMENT_DUE_NOTIFICATION.value,
+        QueueMessageTypes.ACCOUNT_LINK_CREATED.value,
+        QueueMessageTypes.ACCOUNT_LINK_REMOVED.value,
+        QueueMessageTypes.ACCOUNT_LINK_EXPIRY.value,
         AFFILIATION_INVITATION_UNAFFILIATED_EMAIL,
         AFFILIATION_CONFIRMATION_EMAIL
     ]:

--- a/queue_services/account-mailer/tests/unit/test_worker_queue.py
+++ b/queue_services/account-mailer/tests/unit/test_worker_queue.py
@@ -748,6 +748,153 @@ def test_affiliation_confirmation_email(app, session, client):
         assert "April 16, 2026" in email_body
 
 
+def test_account_link_created_email(app, session, client):
+    """Assert that the account link created event sends the correct email content."""
+    user = factory_user_model_with_contact()
+    org = factory_org_model()
+    factory_membership_model(user.id, org.id)
+    id = org.id
+
+    with patch.object(notification_service, "send_email", return_value=None) as mock_send:
+        mail_details = {
+            "accountId": id,
+            "serviceProviderName": "Test Provider",
+            "linkDate": "2026-04-16",
+        }
+        helper_add_event_to_queue(
+            client,
+            message_type=QueueMessageTypes.ACCOUNT_LINK_CREATED.value,
+            mail_details=mail_details,
+        )
+
+        mock_send.assert_called()
+        assert mock_send.call_args.args[0].get("recipients") == "foo@bar.com"
+        assert mock_send.call_args.args[0].get("content").get("subject") == SubjectType.ACCOUNT_LINK_CREATED.value
+        assert mock_send.call_args.args[0].get("attachments") is None
+        email_body = mock_send.call_args.args[0].get("content").get("body")
+        assert email_body is not None
+        assert "Test Provider" in email_body
+        assert "2026-04-16" in email_body
+        assert f"/account/{org.id}/settings/vendor-connections" in email_body
+
+
+def test_account_link_removed_email(app, session, client):
+    """Assert that the account link removed event sends the correct email content."""
+    user = factory_user_model_with_contact()
+    org = factory_org_model()
+    factory_membership_model(user.id, org.id)
+    id = org.id
+
+    with patch.object(notification_service, "send_email", return_value=None) as mock_send:
+        mail_details = {
+            "accountId": id,
+            "serviceProviderName": "Test Provider",
+            "linkRemovalDate": "2026-04-16",
+        }
+        helper_add_event_to_queue(
+            client,
+            message_type=QueueMessageTypes.ACCOUNT_LINK_REMOVED.value,
+            mail_details=mail_details,
+        )
+
+        mock_send.assert_called()
+        assert mock_send.call_args.args[0].get("recipients") == "foo@bar.com"
+        assert mock_send.call_args.args[0].get("content").get("subject") == SubjectType.ACCOUNT_LINK_REMOVED.value
+        assert mock_send.call_args.args[0].get("attachments") is None
+        email_body = mock_send.call_args.args[0].get("content").get("body")
+        assert email_body is not None
+        assert "Test Provider" in email_body
+        assert "2026-04-16" in email_body
+        assert f"/account/{org.id}/settings/vendor-connections" in email_body
+
+
+def test_account_link_expiry_reminder_email(app, session, client):
+    """Assert that the account link expiry event sends a reminder email when isReminder is True."""
+    user = factory_user_model_with_contact()
+    org = factory_org_model()
+    factory_membership_model(user.id, org.id)
+    id = org.id
+
+    with patch.object(notification_service, "send_email", return_value=None) as mock_send:
+        mail_details = {
+            "accountId": id,
+            "serviceProviderName": "Test Provider",
+            "linkDate": "2025-04-16",
+            "isReminder": True,
+        }
+        helper_add_event_to_queue(
+            client,
+            message_type=QueueMessageTypes.ACCOUNT_LINK_EXPIRY.value,
+            mail_details=mail_details,
+        )
+
+        mock_send.assert_called()
+        assert mock_send.call_args.args[0].get("recipients") == "foo@bar.com"
+        assert (
+            mock_send.call_args.args[0].get("content").get("subject")
+            == SubjectType.ACCOUNT_LINK_EXPIRY_REMINDER.value
+        )
+        email_body = mock_send.call_args.args[0].get("content").get("body")
+        assert email_body is not None
+        assert "Test Provider" in email_body
+        assert "will expire in 30 days" in email_body
+        assert "is expired" not in email_body
+        assert SubjectType.ACCOUNT_LINK_EXPIRED.value not in email_body
+
+
+def test_account_link_expiry_expired_email(app, session, client):
+    """Assert that the account link expiry event sends an expired email when isReminder is False."""
+    user = factory_user_model_with_contact()
+    org = factory_org_model()
+    factory_membership_model(user.id, org.id)
+    id = org.id
+
+    with patch.object(notification_service, "send_email", return_value=None) as mock_send:
+        mail_details = {
+            "accountId": id,
+            "serviceProviderName": "Test Provider",
+            "linkDate": "2025-04-16",
+            "isReminder": False,
+        }
+        helper_add_event_to_queue(
+            client,
+            message_type=QueueMessageTypes.ACCOUNT_LINK_EXPIRY.value,
+            mail_details=mail_details,
+        )
+
+        mock_send.assert_called()
+        assert mock_send.call_args.args[0].get("recipients") == "foo@bar.com"
+        assert mock_send.call_args.args[0].get("content").get("subject") == SubjectType.ACCOUNT_LINK_EXPIRED.value
+        email_body = mock_send.call_args.args[0].get("content").get("body")
+        assert email_body is not None
+        assert "Test Provider" in email_body
+        assert "is expired" in email_body
+        assert "will expire in 30 days" not in email_body
+        assert SubjectType.ACCOUNT_LINK_EXPIRY_REMINDER.value not in email_body
+
+
+def test_account_link_expiry_email_default_is_reminder_false(app, session, client):
+    """Assert that isReminder defaults to False when omitted from the message."""
+    user = factory_user_model_with_contact()
+    org = factory_org_model()
+    factory_membership_model(user.id, org.id)
+    id = org.id
+
+    with patch.object(notification_service, "send_email", return_value=None) as mock_send:
+        mail_details = {
+            "accountId": id,
+            "serviceProviderName": "Test Provider",
+        }
+        helper_add_event_to_queue(
+            client,
+            message_type=QueueMessageTypes.ACCOUNT_LINK_EXPIRY.value,
+            mail_details=mail_details,
+        )
+
+        mock_send.assert_called()
+        assert mock_send.call_args.args[0].get("content").get("subject") == SubjectType.ACCOUNT_LINK_EXPIRED.value
+
+
 def test_get_admin_emails_null_firstname(app, session):
     """Assert that a user with a null firstname does not raise TypeError."""
     factory_user_model_for_email_test(


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/33789

*Description of changes:*
- account mailer account linking notification templates (create, remove, expiry)
- auth api updates to publish create and removal

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
