### PR TITLE
AUTH-WEB - Vendor connections hidden: LD getFlag can't return false

### DIFF
--- a/auth-web/src/util/flag-util.ts
+++ b/auth-web/src/util/flag-util.ts
@@ -1,0 +1,18 @@
+import ConfigHelper from '@/util/config-helper'
+import { SessionStorageKeys } from '@/util/constants'
+
+/**
+ * Read a LaunchDarkly flag in a way that supports `false` values.
+ *
+ * sbc-common-components' LaunchDarklyService.getFlag() uses `||` chaining, so a
+ * flag whose value is `false` always falls through to the default value. This
+ * helper reads the flag set the LD service stores in session storage on init
+ * and checks key existence instead, so `false` is returned correctly.
+ */
+export function getLdFlag (flagName: string, defaultValue: any = null): any {
+  const ldFlags = JSON.parse(ConfigHelper.getFromSession(SessionStorageKeys.LaunchDarklyFlags) || '{}')
+  if (flagName in ldFlags) {
+    return ldFlags[flagName]
+  }
+  return defaultValue
+}

--- a/auth-web/src/util/vendor-connection-util.ts
+++ b/auth-web/src/util/vendor-connection-util.ts
@@ -1,14 +1,14 @@
 
 import { AccountLinkingKey, VendorConnection, VendorConnectionStatuses } from '@/models/vendorConnection'
 import { LDFlags, Role } from '@/util/constants'
-import LaunchDarklyService from 'sbc-common-components/src/services/launchdarkly.services'
 import { MembershipType } from '@/models/Organization'
+import { getLdFlag } from '@/util/flag-util'
 import moment from 'moment'
 
 export const VENDOR_CONNECTION_EXPIRY_WARNING_DAYS = 30
 
 function isAccountLinkingDisabled (): boolean {
-  return LaunchDarklyService.getFlag(LDFlags.DisableAccountLinking, true)
+  return getLdFlag(LDFlags.DisableAccountLinking, true)
 }
 
 function hasLinkingKeysJwtRole (userRoles: string[] = []): boolean {

--- a/auth-web/tests/unit/components/VendorConnections.spec.ts
+++ b/auth-web/tests/unit/components/VendorConnections.spec.ts
@@ -1,9 +1,8 @@
 
+import { LDFlags, Role, SessionStorageKeys } from '@/util/constants'
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
-import LaunchDarklyService from 'sbc-common-components/src/services/launchdarkly.services'
 import { MembershipType } from '@/models/Organization'
-import { Role } from '@/util/constants'
 import VendorConnections from '@/components/auth/account-settings/advance-settings/VendorConnections.vue'
 import VendorConnectionsTable from '@/components/auth/account-settings/advance-settings/VendorConnectionsTable.vue'
 import VueRouter from 'vue-router'
@@ -22,7 +21,9 @@ describe('VendorConnections.vue', () => {
 
   beforeEach(() => {
     setActivePinia(createPinia())
-    vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(false)
+    sessionStorage.setItem(SessionStorageKeys.LaunchDarklyFlags, JSON.stringify({
+      [LDFlags.DisableAccountLinking]: false
+    }))
 
     const orgStore = useOrgStore()
     orgStore.$patch({
@@ -60,6 +61,7 @@ describe('VendorConnections.vue', () => {
     vi.resetModules()
     vi.clearAllMocks()
     vi.restoreAllMocks()
+    sessionStorage.removeItem(SessionStorageKeys.LaunchDarklyFlags)
     wrapper.destroy()
   })
 

--- a/auth-web/tests/unit/util/flag-util.spec.ts
+++ b/auth-web/tests/unit/util/flag-util.spec.ts
@@ -1,0 +1,17 @@
+import { SessionStorageKeys } from '@/util/constants'
+import { getLdFlag } from '@/util/flag-util'
+
+describe('getLdFlag', () => {
+  afterEach(() => {
+    sessionStorage.removeItem(SessionStorageKeys.LaunchDarklyFlags)
+  })
+
+  it('returns a false flag value instead of the default', () => {
+    sessionStorage.setItem(SessionStorageKeys.LaunchDarklyFlags, JSON.stringify({ 'disable-account-linking': false }))
+    expect(getLdFlag('disable-account-linking', true)).toBe(false)
+  })
+
+  it('returns the default when the flag is missing', () => {
+    expect(getLdFlag('disable-account-linking', true)).toBe(true)
+  })
+})

--- a/auth-web/tests/unit/util/vendor-connection-util.spec.ts
+++ b/auth-web/tests/unit/util/vendor-connection-util.spec.ts
@@ -1,4 +1,4 @@
-import { LDFlags, Role } from '@/util/constants'
+import { LDFlags, Role, SessionStorageKeys } from '@/util/constants'
 import {
   canManageVendorConnections,
   canViewVendorConnections,
@@ -6,33 +6,41 @@ import {
   mapLinkingKeyToVendorConnection,
   showsStandaloneRemoveAction
 } from '@/util/vendor-connection-util'
-import LaunchDarklyService from 'sbc-common-components/src/services/launchdarkly.services'
 import { MembershipType } from '@/models/Organization'
 import { VendorConnectionStatuses } from '@/models/vendorConnection'
 import moment from 'moment'
 
+function setDisableAccountLinkingFlag (value: boolean) {
+  sessionStorage.setItem(SessionStorageKeys.LaunchDarklyFlags, JSON.stringify({
+    [LDFlags.DisableAccountLinking]: value
+  }))
+}
+
 describe('vendor-connection-util', () => {
   afterEach(() => {
-    vi.restoreAllMocks()
+    sessionStorage.removeItem(SessionStorageKeys.LaunchDarklyFlags)
   })
 
   describe('canViewVendorConnections', () => {
     it('returns false when disable-account-linking flag is on', () => {
-      vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(true)
+      setDisableAccountLinkingFlag(true)
 
       expect(canViewVendorConnections(MembershipType.Admin, [Role.AccountHolder])).toBe(false)
-      expect(LaunchDarklyService.getFlag).toHaveBeenCalledWith(LDFlags.DisableAccountLinking, true)
+    })
+
+    it('returns false when the flag is missing (safe default)', () => {
+      expect(canViewVendorConnections(MembershipType.Admin, [Role.AccountHolder])).toBe(false)
     })
 
     it('returns false without account_holder or manage_accounts JWT role', () => {
-      vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(false)
+      setDisableAccountLinkingFlag(false)
 
       expect(canViewVendorConnections(MembershipType.Admin, [])).toBe(false)
       expect(canViewVendorConnections(MembershipType.Admin, [Role.Staff])).toBe(false)
     })
 
     it('returns true for Admin with account_holder role', () => {
-      vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(false)
+      setDisableAccountLinkingFlag(false)
 
       expect(canViewVendorConnections(
         MembershipType.Admin,
@@ -41,7 +49,7 @@ describe('vendor-connection-util', () => {
     })
 
     it('returns true for Coordinator with account_holder role', () => {
-      vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(false)
+      setDisableAccountLinkingFlag(false)
 
       expect(canViewVendorConnections(
         MembershipType.Coordinator,
@@ -50,7 +58,7 @@ describe('vendor-connection-util', () => {
     })
 
     it('returns true for regular User with account_holder role', () => {
-      vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(false)
+      setDisableAccountLinkingFlag(false)
 
       expect(canViewVendorConnections(
         MembershipType.User,
@@ -59,7 +67,7 @@ describe('vendor-connection-util', () => {
     })
 
     it('returns true for staff with manage_accounts role', () => {
-      vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(false)
+      setDisableAccountLinkingFlag(false)
 
       expect(canViewVendorConnections(
         undefined,
@@ -68,7 +76,7 @@ describe('vendor-connection-util', () => {
     })
 
     it('returns true for external staff with manage_accounts role', () => {
-      vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(false)
+      setDisableAccountLinkingFlag(false)
 
       expect(canViewVendorConnections(
         undefined,
@@ -79,7 +87,7 @@ describe('vendor-connection-util', () => {
 
   describe('canManageVendorConnections', () => {
     beforeEach(() => {
-      vi.spyOn(LaunchDarklyService, 'getFlag').mockReturnValue(false)
+      setDisableAccountLinkingFlag(false)
     })
 
     it('returns true for Admin with account_holder role', () => {


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/<Put the github issue number here>

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
