### PR TITLE
Replace gsutil with gcloud storage

### DIFF
--- a/.github/workflows/auth-db-mask-rules-upload.yml
+++ b/.github/workflows/auth-db-mask-rules-upload.yml
@@ -17,5 +17,5 @@ jobs:
         PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       with:
-        args: cp -r "jobs/gcp-db-data-masking/sql/*" "gs://auth-db-dump-prod/"
-        cli: gsutil
+        args: storage cp -r "jobs/gcp-db-data-masking/sql/*" "gs://auth-db-dump-prod/"
+        cli: gcloud

--- a/auth-api/devops/gcs-bucket-cors/apply-cors.sh
+++ b/auth-api/devops/gcs-bucket-cors/apply-cors.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 
 # dev
-gsutil cors set gcs-auth-accounts-dev-cors.json gs://auth-accounts-dev
-gsutil cors get gs://auth-accounts-dev
+gcloud storage buckets update gs://auth-accounts-dev --cors-file=gcs-auth-accounts-dev-cors.json
+gcloud storage buckets describe gs://auth-accounts-dev --format="default(cors_config)"
 
-gsutil cors set gcs-auth-static-resources-dev-cors.json gs://auth-static-resources-dev
-gsutil cors get gs://auth-static-resources-dev
+gcloud storage buckets update gs://auth-static-resources-dev --cors-file=gcs-auth-static-resources-dev-cors.json
+gcloud storage buckets describe gs://auth-static-resources-dev --format="default(cors_config)"
 
 # test
-gsutil cors set gcs-auth-accounts-test-cors.json gs://auth-accounts-test
-gsutil cors get gs://auth-accounts-test
+gcloud storage buckets update gs://auth-accounts-test --cors-file=gcs-auth-accounts-test-cors.json
+gcloud storage buckets describe gs://auth-accounts-test --format="default(cors_config)"
 
-gsutil cors set gcs-auth-static-resources-test-cors.json gs://auth-static-resources-test
-gsutil cors get gs://auth-static-resources-test
+gcloud storage buckets update gs://auth-static-resources-test --cors-file=gcs-auth-static-resources-test-cors.json
+gcloud storage buckets describe gs://auth-static-resources-test --format="default(cors_config)"
 
 # prod
-gsutil cors set gcs-auth-accounts-prod-cors.json gs://auth-accounts-prod
-gsutil cors get gs://auth-accounts-prod
+gcloud storage buckets update gs://auth-accounts-prod --cors-file=gcs-auth-accounts-prod-cors.json
+gcloud storage buckets describe gs://auth-accounts-prod --format="default(cors_config)"
 
-gsutil cors set gcs-auth-static-resources-prod-cors.json gs://auth-static-resources-prod
-gsutil cors get gs://auth-static-resources-prod
+gcloud storage buckets update gs://auth-static-resources-prod --cors-file=gcs-auth-static-resources-prod-cors.json
+gcloud storage buckets describe gs://auth-static-resources-prod --format="default(cors_config)"
 
 # sandbox
-gsutil cors set gcs-auth-accounts-sandbox-cors.json gs://auth-accounts-sandbox
-gsutil cors get gs://auth-accounts-sandbox
+gcloud storage buckets update gs://auth-accounts-sandbox --cors-file=gcs-auth-accounts-sandbox-cors.json
+gcloud storage buckets describe gs://auth-accounts-sandbox --format="default(cors_config)"

--- a/jobs/gcp-db-data-masking/run.sh
+++ b/jobs/gcp-db-data-masking/run.sh
@@ -25,6 +25,6 @@ echo "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO auth;"
 echo "GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO auth;" >> readonly.sql
 
 echo "applying readonly user changes ..."
-gsutil cp readonly.sql "gs://${DB_NAME}-dump-${ENV}/"
+gcloud storage cp readonly.sql "gs://${DB_NAME}-dump-${ENV}/"
 gcloud --quiet sql import sql "${DB_NAME}-sandbox" "gs://${DB_NAME}-dump-${ENV}/readonly.sql" --database=$DB_NAME --user=$DB_USER
 gcloud --quiet sql import sql "${DB_NAME}-sandbox" "gs://${DB_NAME}-dump-${ENV}/mask.sql" --database=$DB_NAME --user=$DB_USER


### PR DESCRIPTION
## Summary
GCP is removing `gsutil` from the default `gcloud` CLI bundle starting March 2027 (see [announcement](https://cloud.google.com/storage/docs/gsutil-transition-to-gcloud)). This migrates this repo's scripts/CI off `gsutil` onto the recommended `gcloud storage` equivalents.

Part of bcgov/entity#34311.

## Test plan
- [ ] Verify `gcloud storage` commands run successfully in this repo's actual CI/job environment (has `gcloud` CLI, correct auth/permissions)
- [ ] Confirm bucket/object operations produce the same result as the old `gsutil` calls