### PR TITLE
34465 Auth API - colin affiliation tweaks

### DIFF
--- a/auth-api/pyproject.toml
+++ b/auth-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auth-api"
-version = "3.0.11"
+version = "3.0.12"
 description = ""
 authors = [{ name = "BC Registries and Online Services" }]
 readme = "README.md"

--- a/auth-api/src/auth_api/resources/v1/entity.py
+++ b/auth-api/src/auth_api/resources/v1/entity.py
@@ -144,14 +144,14 @@ def get_entity_authentication(business_identifier):
     """Get passcode or password for the Entity identified by the provided business identifier."""
     # This route allows public users to see if businesses have a form of authentication.
     # It's used by the business dashboard for magic link.
-    if (entity := EntityService.find_by_business_identifier(business_identifier, skip_auth=True)) and (
-        contact := entity.get_contact()
-    ):
+    if entity := EntityService.find_by_business_identifier(business_identifier, skip_auth=True):
+        # COLIN businesses synced into auth may have no contact email on file
+        contact = entity.get_contact()
         has_valid_pass_code = (
             entity.pass_code_claimed is False and entity.pass_code is not None
         ) or entity.corp_type in ["SP", "GP"]
         return {
-            "contactEmail": mask_email(contact.email),
+            "contactEmail": mask_email(contact.email) if contact else "",
             "hasValidPassCode": has_valid_pass_code,
         }, HTTPStatus.OK
     return (

--- a/auth-api/src/auth_api/services/affiliation.py
+++ b/auth-api/src/auth_api/services/affiliation.py
@@ -222,6 +222,9 @@ class Affiliation:
     @staticmethod
     def send_affiliation_confirmation_email(entity: Entity, affiliation: AffiliationModel, recipients):
         """Send confirmation email to the user."""
+        # businesses still managed in COLIN are not sent affiliation confirmation emails
+        if not entity.is_loaded_lear:
+            return
         bc_registry_home_url = current_app.config.get("BC_REGISTRY_HOME_URL")
         context_url = f"{bc_registry_home_url}login"
         mailer_data = ConfirmationEmailData(

--- a/auth-api/src/auth_api/services/entity_mapping.py
+++ b/auth-api/src/auth_api/services/entity_mapping.py
@@ -343,14 +343,13 @@ class EntityMappingService:
     @staticmethod
     def populate_entity_mapping_for_identifier(identifier: str):
         """Populate the entity mapping for the identifier."""
-        if entity_mapping := EntityMappingService.fetch_entity_mapping_details(identifier):
-            EntityMappingService.from_entity_details(entity_mapping[0], skip_auth=True)
-            return
-        # COLIN businesses aren't in LEAR, so there are no mappings to fetch. They are always
-        # a standalone business row - no NR and no bootstrap - so map them directly.
         entity = Entity.find_by_business_identifier(identifier)
         if entity and not entity.is_loaded_lear:
+            # COLIN businesses aren't in LEAR, so there are no extra mappings details to fetch.
             EntityMappingService.from_entity_details({"identifier": identifier}, skip_auth=True)
+            return
+        if entity_mapping := EntityMappingService.fetch_entity_mapping_details(identifier):
+            EntityMappingService.from_entity_details(entity_mapping[0], skip_auth=True)
 
     @staticmethod
     def fetch_entity_mapping_details(identifier: str):

--- a/auth-api/tests/unit/api/test_entity.py
+++ b/auth-api/tests/unit/api/test_entity.py
@@ -780,6 +780,26 @@ def test_sync_entity_from_colin(client, jwt, session):  # pylint:disable=unused-
     assert json.loads(rv.data)["hasValidPassCode"] is True
 
 
+def test_sync_entity_from_colin_without_email_still_offers_passcode(client, jwt, session):  # pylint:disable=unused-argument
+    """Assert a COLIN business with no registered office email still exposes its passcode option."""
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.public_user_role)
+
+    with patch.object(ColinService, "fetch_auth_info", return_value=dict(COLIN_SYNC_AUTH_INFO, email=None)):
+        rv = client.post(f"/api/v1/entities/{COLIN_SYNC_IDENTIFIER}/synchronizations/colin", headers=headers)
+    assert rv.status_code == HTTPStatus.NO_CONTENT
+
+    # no contact was created, so the email option stays hidden in the modal
+    rv = client.get(f"/api/v1/entities/{COLIN_SYNC_IDENTIFIER}/contacts", headers=headers)
+    assert rv.status_code == HTTPStatus.NOT_FOUND
+
+    # but the passcode option is still offered
+    rv = client.get(f"/api/v1/entities/{COLIN_SYNC_IDENTIFIER}/authentication", headers=headers)
+    assert rv.status_code == HTTPStatus.OK
+    data = json.loads(rv.data)
+    assert data["hasValidPassCode"] is True
+    assert data["contactEmail"] == ""
+
+
 def test_sync_entity_from_colin_lear_business_untouched(client, jwt, session):  # pylint:disable=unused-argument
     """Assert a LEAR loaded business succeeds as a no-op without calling COLIN."""
     factory_entity_model(

--- a/auth-api/tests/unit/services/test_colin_affiliation.py
+++ b/auth-api/tests/unit/services/test_colin_affiliation.py
@@ -158,6 +158,49 @@ def test_sync_from_colin_handles_missing_business(session, monkeypatch):  # pyli
     assert EntityModel.find_by_business_identifier(COLIN_IDENTIFIER) is None
 
 
+def test_sync_from_colin_without_email_creates_no_contact(session, monkeypatch):  # pylint:disable=unused-argument
+    """Assert a COLIN business with no registered office email still syncs, just without a contact."""
+    monkeypatch.setattr(ColinService, "fetch_auth_info", staticmethod(lambda _: _colin_info(email=None)))
+
+    entity = EntityService.sync_from_colin(COLIN_IDENTIFIER)
+
+    assert entity is not None
+    assert entity.get_contact() is None
+    assert entity.pass_code is not None
+
+
+def test_affiliation_confirmation_email_suppressed_for_colin_entity(session, monkeypatch):  # pylint:disable=unused-argument
+    """Assert no affiliation confirmation email goes out for a business still managed in COLIN."""
+    monkeypatch.setattr(ColinService, "fetch_auth_info", staticmethod(lambda _: _colin_info()))
+    entity = EntityService.sync_from_colin(COLIN_IDENTIFIER)
+
+    with patch("auth_api.services.affiliation.publish_to_mailer") as mock_mailer:
+        AffiliationService.send_affiliation_confirmation_email(entity, None, "user@test.com")
+
+    mock_mailer.assert_not_called()
+
+
+def test_affiliation_confirmation_email_still_sent_for_lear_entity(session):  # pylint:disable=unused-argument
+    """Assert the COLIN suppression does not stop confirmation emails for LEAR businesses."""
+    entity_model = EntityModel.create_from_dict(
+        {
+            "businessIdentifier": "BC5555555",
+            "name": "LEAR COMPANY LTD.",
+            "corpTypeCode": "BC",
+            "passCode": None,
+        }
+    )
+    org = factory_org_model()
+    affiliation = factory_affiliation_model(entity_model.id, org.id)
+
+    with patch("auth_api.services.affiliation.publish_to_mailer") as mock_mailer:
+        AffiliationService.send_affiliation_confirmation_email(
+            EntityService(entity_model), affiliation, "user@test.com"
+        )
+
+    mock_mailer.assert_called_once()
+
+
 def test_sync_from_colin_keeps_passcode_when_colin_has_none(session, monkeypatch):  # pylint:disable=unused-argument
     """Assert an empty COLIN passcode does not silently clear the stored credential."""
     monkeypatch.setattr(ColinService, "fetch_auth_info", staticmethod(lambda _: _colin_info()))

--- a/auth-api/tests/unit/services/test_entity_mapping.py
+++ b/auth-api/tests/unit/services/test_entity_mapping.py
@@ -248,6 +248,30 @@ def test_populate_entity_mapping_for_identifier_no_data(session):
         assert mapping is None
 
 
+def test_colin_entity_reaches_paginate_from_affiliations(session):
+    """Test a synced COLIN business shows on the paginated dashboard end to end.
+
+    The paginated search is driven off entity_mappings, so a COLIN business only shows
+    if populate_entity_mapping_for_identifier created its mapping row.
+    """
+    org_id, _ = _setup_orgs()
+    entity = Entity(business_identifier="BC0870226", corp_type_code="BC", is_loaded_lear=False).save()
+    AffiliationModel(org_id=org_id, entity_id=entity.id).save()
+
+    # LEAR is never asked about a business it does not have - a LEAR outage raises, which
+    # would otherwise leave the business with no mapping row and invisible on the dashboard
+    with patch.object(EntityMappingService, "fetch_entity_mapping_details") as mock_fetch:
+        EntityMappingService.populate_entity_mapping_for_identifier("BC0870226")
+    mock_fetch.assert_not_called()
+
+    assert session.query(EntityMapping).filter(EntityMapping.business_identifier == "BC0870226").one_or_none()
+
+    search_details = AffiliationSearchDetails(page=1, limit=1000)
+    results, _ = EntityMappingService.paginate_from_affiliations(org_id, search_details)
+
+    assert [result[0] for result in results] == [["BC0870226"]]
+
+
 def test_get_filtered_affiliations_identifier_matches_not_loaded_lear(session):
     """Test that affiliations are returned when is_loaded_lear is False.
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/34465

*Description of changes:*
- skip successful affiliation email (info does not make sense for colin affiliation flow - design approved skipping it)
- entity mapping tweak required so that they show up in the BRD table
- handle cases where there is no admin email in colin (password only)
- secured with tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
