### PR TITLE
34061 - revoke access update / expiry handling update

### DIFF
--- a/auth-api/src/auth_api/resources/v1/org_linking_keys.py
+++ b/auth-api/src/auth_api/resources/v1/org_linking_keys.py
@@ -34,7 +34,6 @@ from auth_api.utils.user_context import UserContext, user_context
 bp = Blueprint("LINKING_KEYS", __name__, url_prefix=EndpointEnum.API_V1.value)
 
 _OWNER_ROLES = (COORDINATOR, ADMIN)
-_REVOKE_ROLES = (ADMIN,)
 
 
 @bp.before_request
@@ -80,8 +79,8 @@ def post_linking_key(org_id):
 @cross_origin(origins="*")
 @_jwt.has_one_of_roles([Role.ACCOUNT_HOLDER.value])
 def delete_linking_key(org_id, key_id):
-    """Revoke a specific linking key by ID (soft delete). Admin only."""
-    org = OrgService.find_by_org_id(org_id, allowed_roles=_REVOKE_ROLES)
+    """Revoke a specific linking key by ID (soft delete). Admin/Coordinator only."""
+    org = OrgService.find_by_org_id(org_id, allowed_roles=_OWNER_ROLES)
     if org is None:
         return {"message": "The requested organization could not be found."}, HTTPStatus.NOT_FOUND
     found = AccountLinkingKeyService.revoke(key_id, org_id)

--- a/auth-api/src/auth_api/services/account_linking_key.py
+++ b/auth-api/src/auth_api/services/account_linking_key.py
@@ -106,8 +106,13 @@ class AccountLinkingKey:
         if record.status != LinkingKeyStatus.ACTIVE.value:
             raise BusinessException(Error.INVALID_LINKING_KEY_STATE, None)
         window_days = current_app.config.get("ACCOUNT_LINK_EXPIRY_REMINDER_DAYS", 30)
-        if record.expires_on > datetime.now(UTC) + timedelta(days=window_days):
+        now = datetime.now(UTC)
+        if record.expires_on > now + timedelta(days=window_days):
             raise BusinessException(Error.LINKING_KEY_NOT_NEAR_EXPIRY, None)
+        # If the status is still ACTIVE (auth-job will toggle to EXPIRED), the expiry notification
+        # has not gone out so we allow for a 1-day buffer period for extending
+        if now > record.expires_on + timedelta(days=1):
+            raise BusinessException(Error.INVALID_LINKING_KEY_STATE, None)
 
         record.expires_on = record.expires_on + relativedelta(years=1)
         record.save()

--- a/auth-api/tests/unit/api/test_org_linking_keys.py
+++ b/auth-api/tests/unit/api/test_org_linking_keys.py
@@ -18,6 +18,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 
+import pytest
 from dateutil.relativedelta import relativedelta
 
 from auth_api.utils.enums import LinkingKeyStatus
@@ -274,28 +275,16 @@ def test_get_linking_keys_hides_key_value(client, jwt, session):  # pylint:disab
     assert "linkingKey" not in keys[0], "Raw key must not be exposed on GET"
 
 
-def test_revoke_linking_key_by_id(client, jwt, session):  # pylint:disable=unused-argument
-    """Assert that DELETE revokes a specific linking key by ID."""
+@pytest.mark.parametrize("key_status", [LinkingKeyStatus.ACTIVE.value, LinkingKeyStatus.PENDING.value])
+def test_revoke_linking_key_by_id(client, jwt, session, key_status):  # pylint:disable=unused-argument
+    """Assert that DELETE revokes a specific linking key by ID, for both ACTIVE and PENDING keys."""
     user = factory_user_model(TestUserInfo.user1)
     org = factory_org_model()
     vendor = factory_org_model()
     factory_membership_model(user.id, org.id)
-    record = factory_linking_key_model(account_id=org.id, vendor_account_id=vendor.id)
-
-    headers = _account_holder_headers(jwt, user)
-    rv = client.delete(f"/api/v1/orgs/{org.id}/linking-keys/{record.id}", headers=headers)
-    assert rv.status_code == HTTPStatus.OK
-
-    rv_list = client.get(f"/api/v1/orgs/{org.id}/linking-keys", headers=headers)
-    assert rv_list.json.get("linkingKeys") == []
-
-
-def test_revoke_pending_linking_key_by_id(client, jwt, session):  # pylint:disable=unused-argument
-    """Assert that DELETE revokes a PENDING (unbound) linking key by ID."""
-    user = factory_user_model(TestUserInfo.user1)
-    org = factory_org_model()
-    factory_membership_model(user.id, org.id)
-    record = factory_linking_key_model(account_id=org.id, status=LinkingKeyStatus.PENDING.value)
+    # a PENDING key is one no vendor has bound yet
+    vendor_account_id = vendor.id if key_status == LinkingKeyStatus.ACTIVE.value else None
+    record = factory_linking_key_model(account_id=org.id, vendor_account_id=vendor_account_id, status=key_status)
 
     headers = _account_holder_headers(jwt, user)
     rv = client.delete(f"/api/v1/orgs/{org.id}/linking-keys/{record.id}", headers=headers)
@@ -319,21 +308,30 @@ def test_revoke_wrong_org_returns_404(client, jwt, session):  # pylint:disable=u
     assert rv.status_code == HTTPStatus.NOT_FOUND
 
 
-def test_revoke_forbidden_for_coordinator(client, jwt, session):  # pylint:disable=unused-argument
-    """Assert that a COORDINATOR cannot revoke a linking key (revoke is ADMIN only)."""
+@pytest.mark.parametrize(
+    "member_type, expected_status",
+    [
+        ("ADMIN", HTTPStatus.OK),
+        ("COORDINATOR", HTTPStatus.OK),
+        ("USER", HTTPStatus.FORBIDDEN),
+    ],
+)
+def test_revoke_by_membership_type(client, jwt, session, member_type, expected_status):  # pylint:disable=unused-argument
+    """Assert that only ADMIN and COORDINATOR members can revoke a linking key."""
     user = factory_user_model(TestUserInfo.user1)
     org = factory_org_model()
-    factory_membership_model(user.id, org.id, member_type="COORDINATOR")
-    record = factory_linking_key_model(account_id=org.id)
+    vendor = factory_org_model()
+    factory_membership_model(user.id, org.id, member_type=member_type)
+    record = factory_linking_key_model(account_id=org.id, vendor_account_id=vendor.id)
 
     headers = _account_holder_headers(jwt, user)
     rv = client.delete(f"/api/v1/orgs/{org.id}/linking-keys/{record.id}", headers=headers)
 
-    assert rv.status_code == HTTPStatus.FORBIDDEN
+    assert rv.status_code == expected_status
 
 
 def test_revoke_forbidden_for_staff_manage_accounts(client, jwt, session):  # pylint:disable=unused-argument
-    """Assert that staff with manage_accounts cannot revoke a linking key (revoke is ADMIN only)."""
+    """Assert that staff with manage_accounts cannot revoke a linking key (revoke is ADMIN/COORDINATOR)."""
     user = factory_user_model(TestUserInfo.user1)
     org = factory_org_model()
     factory_membership_model(user.id, org.id)

--- a/auth-api/tests/unit/services/test_account_linking_key.py
+++ b/auth-api/tests/unit/services/test_account_linking_key.py
@@ -469,17 +469,31 @@ def test_extend_rejected_outside_the_window(session):  # pylint:disable=unused-a
     assert exc_info.value.code == Error.LINKING_KEY_NOT_NEAR_EXPIRY.name
 
 
-def test_extend_allowed_when_past_expiry_but_not_yet_swept(session):  # pylint:disable=unused-argument
-    """Assert that a key past its expiry is still extendable while auth-jobs has not run yet."""
+def test_extend_allowed_within_the_buffer_past_expiry(session):  # pylint:disable=unused-argument
+    """Assert that a key can be extended within the last day with a buffer."""
     lawfirm = factory_org_model()
     vendor = factory_org_model()
-    original_expiry = datetime.now(UTC) - timedelta(days=2)
+    original_expiry = datetime.now(UTC) - timedelta(hours=12)
     record = factory_linking_key_model(account_id=lawfirm.id, vendor_account_id=vendor.id, expires_on=original_expiry)
 
     updated = AccountLinkingKeyService.extend(record.id, lawfirm.id)
 
     assert updated is not None
     assert updated.expires_on == original_expiry + relativedelta(years=1)
+
+
+def test_extend_rejected_past_the_buffer(session):  # pylint:disable=unused-argument
+    """Assert that a key more than a day past its expiry can no longer be extended."""
+    lawfirm = factory_org_model()
+    vendor = factory_org_model()
+    record = factory_linking_key_model(
+        account_id=lawfirm.id, vendor_account_id=vendor.id, expires_on=datetime.now(UTC) - timedelta(days=2)
+    )
+
+    with pytest.raises(BusinessException) as exc_info:
+        AccountLinkingKeyService.extend(record.id, lawfirm.id)
+
+    assert exc_info.value.code == Error.INVALID_LINKING_KEY_STATE.name
 
 
 def test_extend_rejects_pending_key(session):  # pylint:disable=unused-argument

--- a/auth-web/src/components/auth/account-settings/advance-settings/VendorConnectionsTable.vue
+++ b/auth-web/src/components/auth/account-settings/advance-settings/VendorConnectionsTable.vue
@@ -50,27 +50,15 @@
           v-if="canManageConnections"
           class="action-buttons d-flex justify-end"
         >
-          <v-btn
-            v-if="showsStandaloneRemoveAction(getConnectionStatus(item)) && canRevokeConnections"
-            color="primary"
-            depressed
-            class="vendor-connection-action-btn vendor-connection-action-btn--standalone"
-            :aria-label="$t('vendorConnectionsRemoveAria')"
-            :title="$t('vendorConnectionsRemoveAria')"
-            :data-test="getIndexedTag('remove-button', item.id)"
-            @click="openRemoveModal(item)"
-          >
-            {{ $t('vendorConnectionsRemove') }}
-          </v-btn>
-
-          <span
-            v-else-if="!showsStandaloneRemoveAction(getConnectionStatus(item))"
-            class="vendor-connection-split-actions d-inline-flex align-center"
-          >
+          <span class="vendor-connection-split-actions d-inline-flex align-center">
             <v-btn
+              v-if="getLinkActions(item).showExtend"
               color="primary"
               depressed
-              class="vendor-connection-action-btn vendor-connection-action-btn--split-main"
+              class="vendor-connection-action-btn"
+              :class="getLinkActions(item).showRemove
+                ? 'vendor-connection-action-btn--split-main'
+                : 'vendor-connection-action-btn--standalone'"
               :aria-label="$t('vendorConnectionsExtendAria')"
               :title="$t('vendorConnectionsExtendAria')"
               :data-test="getIndexedTag('extend-button', item.id)"
@@ -78,8 +66,9 @@
             >
               {{ $t('vendorConnectionsExtend') }}
             </v-btn>
+
             <v-menu
-              v-if="canRevokeConnections"
+              v-if="getLinkActions(item).showExtend && getLinkActions(item).showRemove"
               v-model="actionMenuOpen[item.id]"
               offset-y
               left
@@ -107,6 +96,19 @@
                 </v-list-item>
               </v-list>
             </v-menu>
+
+            <v-btn
+              v-else-if="getLinkActions(item).showRemove"
+              color="primary"
+              depressed
+              class="vendor-connection-action-btn vendor-connection-action-btn--standalone"
+              :aria-label="$t('vendorConnectionsRemoveAria')"
+              :title="$t('vendorConnectionsRemoveAria')"
+              :data-test="getIndexedTag('remove-button', item.id)"
+              @click="openRemoveModal(item)"
+            >
+              {{ $t('vendorConnectionsRemove') }}
+            </v-btn>
           </span>
         </div>
       </template>
@@ -188,14 +190,14 @@
 
 <script lang="ts">
 import { Ref, computed, defineComponent, onBeforeUnmount, onMounted, reactive, ref } from '@vue/composition-api'
-import { VendorConnection, VendorConnectionStatuses } from '@/models/vendorConnection'
+import { VendorConnection, VendorConnectionActions, VendorConnectionStatuses } from '@/models/vendorConnection'
 import {
   canManageVendorConnections,
   canRevokeVendorConnection,
   getDaysUntilExpiry,
+  getVendorConnectionActions,
   getVendorConnectionStatus,
-  mapLinkingKeyToVendorConnection,
-  showsStandaloneRemoveAction
+  mapLinkingKeyToVendorConnection
 } from '@/util/vendor-connection-util'
 import { BaseTableHeaderI } from '@/components/datatable/interfaces'
 import { BaseVDataTable } from '@/components'
@@ -308,6 +310,15 @@ export default defineComponent({
 
     const getConnectionStatus = (connection: VendorConnection) => {
       return getVendorConnectionStatus(connection.expiryDate, connection.status)
+    }
+
+    const getLinkActions = (connection: VendorConnection): VendorConnectionActions => {
+      const actions = getVendorConnectionActions(getConnectionStatus(connection))
+
+      return {
+        showExtend: actions.showExtend,
+        showRemove: actions.showRemove && canRevokeConnections.value
+      }
     }
 
     const getServiceProviderDisplayName = (connection: VendorConnection) => {
@@ -438,6 +449,7 @@ export default defineComponent({
       getConnectionStatus,
       getDaysUntilExpiry,
       getIndexedTag,
+      getLinkActions,
       getServiceProviderDisplayName,
       isLoading,
       loadConnections,
@@ -445,7 +457,6 @@ export default defineComponent({
       openExtendModal,
       openRemoveModal,
       removeDialog,
-      showsStandaloneRemoveAction,
       tableHeaders: TABLE_HEADERS,
       VendorConnectionStatuses
     }

--- a/auth-web/src/models/vendorConnection.ts
+++ b/auth-web/src/models/vendorConnection.ts
@@ -49,3 +49,8 @@ export const VendorConnectionStatuses = {
 } as const
 
 export type VendorConnectionStatus = typeof VendorConnectionStatuses[keyof typeof VendorConnectionStatuses]
+
+export interface VendorConnectionActions {
+  showExtend: boolean
+  showRemove: boolean
+}

--- a/auth-web/src/util/vendor-connection-util.ts
+++ b/auth-web/src/util/vendor-connection-util.ts
@@ -1,5 +1,10 @@
 
-import { AccountLinkingKey, VendorConnection, VendorConnectionStatuses } from '@/models/vendorConnection'
+import {
+  AccountLinkingKey,
+  VendorConnection,
+  VendorConnectionActions,
+  VendorConnectionStatuses
+} from '@/models/vendorConnection'
 import { LDFlags, Role } from '@/util/constants'
 import { MembershipType } from '@/models/Organization'
 import { getLdFlag } from '@/util/flag-util'
@@ -26,6 +31,13 @@ function isOrgMember (membershipTypeCode: MembershipType | undefined): boolean {
     MembershipType.Admin,
     MembershipType.Coordinator,
     MembershipType.User
+  ].includes(membershipTypeCode)
+}
+
+function isAdminOrCoordinator (membershipTypeCode: MembershipType | undefined): boolean {
+  return [
+    MembershipType.Admin,
+    MembershipType.Coordinator
   ].includes(membershipTypeCode)
 }
 
@@ -72,7 +84,7 @@ export function canManageVendorConnections (
     return true
   }
 
-  return [MembershipType.Admin, MembershipType.Coordinator].includes(membershipTypeCode)
+  return isAdminOrCoordinator(membershipTypeCode)
 }
 
 export function canRevokeVendorConnection (
@@ -83,7 +95,7 @@ export function canRevokeVendorConnection (
     return false
   }
 
-  return membershipTypeCode === MembershipType.Admin
+  return isAdminOrCoordinator(membershipTypeCode)
 }
 
 export function mapLinkingKeyToVendorConnection (linkingKey: AccountLinkingKey): VendorConnection {
@@ -119,9 +131,14 @@ export function getVendorConnectionStatus (expiryDate: string, keyStatus?: strin
   return normalizedStatus
 }
 
-export function showsStandaloneRemoveAction (connectionStatus?: string): boolean {
-  return connectionStatus === VendorConnectionStatuses.Active ||
-    connectionStatus === VendorConnectionStatuses.Pending
+export function getVendorConnectionActions (connectionStatus?: string): VendorConnectionActions {
+  return {
+    showExtend: connectionStatus === VendorConnectionStatuses.Expiring ||
+      connectionStatus === VendorConnectionStatuses.Expired,
+    showRemove: connectionStatus === VendorConnectionStatuses.Active ||
+      connectionStatus === VendorConnectionStatuses.Pending ||
+      connectionStatus === VendorConnectionStatuses.Expiring
+  }
 }
 
 export function getDaysUntilExpiry (expiryDate: string): number {

--- a/auth-web/tests/unit/components/VendorConnectionsTable.spec.ts
+++ b/auth-web/tests/unit/components/VendorConnectionsTable.spec.ts
@@ -145,7 +145,7 @@ describe('VendorConnectionsTable.vue', () => {
     expect(wrapper.vm.canManageConnections).toBe(false)
   })
 
-  it('hides remove actions for Coordinator membership but keeps extend', async () => {
+  it('allows remove and extend actions for Coordinator membership', async () => {
     const orgStore = useOrgStore()
     orgStore.$patch({
       currentMembership: {
@@ -155,7 +155,7 @@ describe('VendorConnectionsTable.vue', () => {
     await wrapper.vm.$nextTick()
 
     expect(wrapper.vm.canManageConnections).toBe(true)
-    expect(wrapper.vm.canRevokeConnections).toBe(false)
+    expect(wrapper.vm.canRevokeConnections).toBe(true)
   })
 
   it('shows remove button for active connections when user can manage', () => {
@@ -163,7 +163,15 @@ describe('VendorConnectionsTable.vue', () => {
       connection => wrapper.vm.getConnectionStatus(connection) === VendorConnectionStatuses.Active
     )
     expect(activeConnection).toBeTruthy()
-    expect(wrapper.vm.showsStandaloneRemoveAction(wrapper.vm.getConnectionStatus(activeConnection))).toBe(true)
+    expect(wrapper.vm.getLinkActions(activeConnection)).toEqual({ showExtend: false, showRemove: true })
+  })
+
+  it('hides remove for an expired connection but still offers extend', () => {
+    const expiredConnection = wrapper.vm.connectionsList.find(
+      connection => wrapper.vm.getConnectionStatus(connection) === VendorConnectionStatuses.Expired
+    )
+    expect(expiredConnection).toBeTruthy()
+    expect(wrapper.vm.getLinkActions(expiredConnection)).toEqual({ showExtend: true, showRemove: false })
   })
 
   it('shows pending badge and remove-only action for pending connection', async () => {
@@ -186,7 +194,7 @@ describe('VendorConnectionsTable.vue', () => {
 
     expect(wrapper.vm.getConnectionStatus(pendingConnection)).toBe(VendorConnectionStatuses.Pending)
     expect(wrapper.vm.getServiceProviderDisplayName(pendingConnection)).toBe('Pending vendor connection')
-    expect(wrapper.vm.showsStandaloneRemoveAction(wrapper.vm.getConnectionStatus(pendingConnection))).toBe(true)
+    expect(wrapper.vm.getLinkActions(pendingConnection)).toEqual({ showExtend: false, showRemove: true })
   })
 
   it('confirmRemove removes connection after API call', async () => {

--- a/auth-web/tests/unit/util/vendor-connection-util.spec.ts
+++ b/auth-web/tests/unit/util/vendor-connection-util.spec.ts
@@ -4,9 +4,9 @@ import {
   canManageVendorConnections,
   canRevokeVendorConnection,
   canViewVendorConnections,
+  getVendorConnectionActions,
   getVendorConnectionStatus,
-  mapLinkingKeyToVendorConnection,
-  showsStandaloneRemoveAction
+  mapLinkingKeyToVendorConnection
 } from '@/util/vendor-connection-util'
 import { MembershipType } from '@/models/Organization'
 import { VendorConnectionStatuses } from '@/models/vendorConnection'
@@ -140,11 +140,11 @@ describe('vendor-connection-util', () => {
       )).toBe(true)
     })
 
-    it('returns false for Coordinator even with account_holder role', () => {
+    it('returns true for Coordinator with account_holder role', () => {
       expect(canRevokeVendorConnection(
         MembershipType.Coordinator,
         [Role.AccountHolder]
-      )).toBe(false)
+      )).toBe(true)
     })
 
     it('returns false for regular User', () => {
@@ -218,15 +218,27 @@ describe('vendor-connection-util', () => {
     })
   })
 
-  describe('showsStandaloneRemoveAction', () => {
-    it('returns true for active and pending connections', () => {
-      expect(showsStandaloneRemoveAction(VendorConnectionStatuses.Active)).toBe(true)
-      expect(showsStandaloneRemoveAction(VendorConnectionStatuses.Pending)).toBe(true)
+  describe('getVendorConnectionActions', () => {
+    it('remove but not extend for active and pending connections', () => {
+      expect(getVendorConnectionActions(VendorConnectionStatuses.Active))
+        .toEqual({ showExtend: false, showRemove: true })
+      expect(getVendorConnectionActions(VendorConnectionStatuses.Pending))
+        .toEqual({ showExtend: false, showRemove: true })
     })
 
-    it('returns false for expiring and expired connections', () => {
-      expect(showsStandaloneRemoveAction(VendorConnectionStatuses.Expiring)).toBe(false)
-      expect(showsStandaloneRemoveAction(VendorConnectionStatuses.Expired)).toBe(false)
+    it('both actions for expiring connections', () => {
+      expect(getVendorConnectionActions(VendorConnectionStatuses.Expiring))
+        .toEqual({ showExtend: true, showRemove: true })
+    })
+
+    it('extend but not remove for expired connections', () => {
+      expect(getVendorConnectionActions(VendorConnectionStatuses.Expired))
+        .toEqual({ showExtend: true, showRemove: false })
+    })
+
+    it('no actions for an unknown status', () => {
+      expect(getVendorConnectionActions(undefined))
+        .toEqual({ showExtend: false, showRemove: false })
     })
   })
 


### PR DESCRIPTION
*Issue #:*
https://github.com/bcgov/entity/issues/34816
https://github.com/bcgov/entity/issues/34756

*Description of changes:*
- Allow coordinator to revoke key
- Key extension buffer
- UI restructure for button states

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the sbc-auth license (Apache 2.0).
